### PR TITLE
Append -fno-strict-aliasing if we're using GNU compatible compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,14 @@ AS_CASE([$target],
 AM_CONDITIONAL([MAKE_WINDOWS], [test "x$make_windows" = "xtrue"])
 AM_CONDITIONAL([INSTALL_MIME], [test "x$install_mime" = "xtrue"])
 
+dnl Append -fno-strict-aliasing to buildflags if we're using GNU compatible compilers
+AS_CASE([$CC],
+        [gcc|*-gcc|clang|clang-*],
+        [ CFLAGS="${CFLAGS} -fno-strict-aliasing" ])
+AS_CASE([$CXX],
+        [g++|*-g++|clang++|clang++-*],
+        [ CXXFLAGS="${CXXFLAGS} -fno-strict-aliasing" ])
+
 dnl Set target system name.
 AC_DEFINE_UNQUOTED([TARGET_PLATFORM], ["$target_os $target_cpu"], [Target platform name])
 
@@ -346,5 +354,14 @@ AX_PRINT_SUMMARY([alsa])
 AX_PRINT_SUMMARY([curl])
 AX_PRINT_SUMMARY([zzip])
 AX_PRINT_SUMMARY([png])
+AS_ECHO([""])
+AS_ECHO(["         CC: ${CC}"])
+AS_ECHO(["        CXX: ${CXX}"])
+AS_ECHO(["        CPP: ${CPP}"])
+AS_ECHO(["     CFLAGS: ${CFLAGS}"])
+AS_ECHO(["   CXXFLAGS: ${CXXFLAGS}"])
+AS_ECHO(["   CPPFLAGS: ${CPPFLAGS}"])
+AS_ECHO(["    LDFLAGS: ${LDFLAGS}"])
+AS_ECHO(["       LIBS: ${LIBS}"])
 AS_ECHO([""])
 AS_ECHO(["Configuration done. Now type \"make\"."])


### PR DESCRIPTION
Disables the following `-Wstrict-aliasing` warnings:
```
monsters.cpp: In function ‘bool attempt_evasive_manouvers(short int)’:
monsters.cpp:2916:64: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  world_point2d destination= *((world_point2d*)&object->location);
                                                                ^
monsters.cpp:2916:64: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
monsters.cpp: In function ‘void advance_monster_path(short int)’:
monsters.cpp:2994:106: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    path_goal= *(world_point2d *)&get_object_data(get_monster_data(monster->target_index)->object_index)->location;
                                                                                                          ^
monsters.cpp:2994:13: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    path_goal= *(world_point2d *)&get_object_data(get_monster_data(monster->target_index)->object_index)->location;
             ^
player.cpp: In function ‘void update_player_teleport(short int)’:
player.cpp:1304:37: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
      *((world_point2d *)&destination)= destination_polygon->center;
                                     ^
player.cpp:1304:38: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
      *((world_point2d *)&destination)= destination_polygon->center;
                                      ^
network_messages.cpp: In member function ‘virtual bool ServerWarningMessage::reallyInflateFrom(AIStream&)’:
network_messages.cpp:279:28: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   inputStream >> (uint16&) mReason;
                            ^
motion_sensor.cpp:461:54: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     entity->previous_points[0]= *(point2d *)&object->location;
                                                      ^
motion_sensor.cpp:461:31: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     entity->previous_points[0]= *(point2d *)&object->location;
                               ^
```

It will also print a summary of the used tools and buildflags:
```
         CC: gcc
        CXX: g++
        CPP: gcc -E
     CFLAGS: -g -O2 -fno-strict-aliasing
   CXXFLAGS: -g -O2 -fno-strict-aliasing
   CPPFLAGS: -I/usr/include/libpng12    -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -DSDL
    LDFLAGS: 
       LIBS: -lpng12   -lasound -lz -lSDL_net -lSDL_ttf -lboost_filesystem -lboost_system  -L/usr/lib/x86_64-linux-gnu -lSDL -lGL -lpthread -lGLU
```