### PR TITLE
Add fallback Boost library check via AC_CHECK_LIB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,12 +84,16 @@ AX_BOOST_BASE([1.53.0],
 AX_BOOST_SYSTEM
 AS_IF([ test "x$BOOST_SYSTEM_LIB" != "x" ],
       [ LIBS="$BOOST_SYSTEM_LIB $LIBS" ],
-      [AC_MSG_ERROR([You need the Boost::System library to run Aleph One.])])
+      [ AC_CHECK_LIB([boost_system], [main],
+                     [ LIBS="-lboost_system $LIBS" ],
+                     [ AC_MSG_ERROR([You need the Boost::System library to run Aleph One.]) ])])
 AX_BOOST_FILESYSTEM
 AS_IF([ test "x$BOOST_FILESYSTEM_LIB" != "x" ],
       [ LIBS="$BOOST_FILESYSTEM_LIB $LIBS" ],
-      [AC_MSG_ERROR([You need the Boost::Filesystem library to run Aleph One.])])
-      
+      [ AC_CHECK_LIB([boost_filesystem], [main],
+                     [ LIBS="-lboost_filesystem $LIBS" ],
+                     [ AC_MSG_ERROR([You need the Boost::Filesystem library to run Aleph One.]) ])])
+
 AC_DEFUN([AX_CHECK_BOOST_HEADER],
          [ AC_LANG_PUSH(C++)
            AC_CHECK_HEADER([$1], , [AC_MSG_ERROR([You need $1 from the Boost library to build Aleph One.])])

--- a/m4/ax_boost_filesystem.m4
+++ b/m4/ax_boost_filesystem.m4
@@ -103,12 +103,12 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
-            fi
-			if test "x$link_filesystem" != "xyes"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
-			fi
+            #if test "x$ax_lib" = "x"; then
+            #    AC_MSG_ERROR(Could not find a version of the library!)
+            #fi
+            #if test "x$link_filesystem" != "xyes"; then
+            #	AC_MSG_ERROR(Could not link against $ax_lib !)
+            #fi
 		fi
 
 		CPPFLAGS="$CPPFLAGS_SAVED"

--- a/m4/ax_boost_system.m4
+++ b/m4/ax_boost_system.m4
@@ -106,12 +106,12 @@ AC_DEFUN([AX_BOOST_SYSTEM],
                   done
 
             fi
-            if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
-            fi
-			if test "x$link_system" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
-			fi
+            #if test "x$ax_lib" = "x"; then
+            #    AC_MSG_ERROR(Could not find a version of the library!)
+            #fi
+            #if test "x$link_system" = "xno"; then
+            #	AC_MSG_ERROR(Could not link against $ax_lib !)
+            #fi
 		fi
 
 		CPPFLAGS="$CPPFLAGS_SAVED"


### PR DESCRIPTION
Otherwise Boost::Filesystem and Boost::System detection fails for me in a
32 bit Ubuntu 14.04 chroot environment.