### PR TITLE
Add missing dependencies for headers

### DIFF
--- a/Source_Files/CSeries/csalerts.h
+++ b/Source_Files/CSeries/csalerts.h
@@ -23,6 +23,8 @@
 #ifndef _CSERIES_ALERTS_
 #define _CSERIES_ALERTS_
 
+#include "cseries.h"  // need OSErr
+
 #if defined(__GNUC__)
 #define NORETURN __attribute__((noreturn))
 #else

--- a/Source_Files/CSeries/cscluts.h
+++ b/Source_Files/CSeries/cscluts.h
@@ -25,6 +25,7 @@
 #include "cstypes.h"
 
 class LoadedResource;
+struct RGBColor;
 
 typedef struct rgb_color {
 	uint16 red;

--- a/Source_Files/CSeries/csmisc.h
+++ b/Source_Files/CSeries/csmisc.h
@@ -21,6 +21,8 @@
 #ifndef _CSERIES_MISC_
 #define _CSERIES_MISC_
 
+#include "cstypes.h"
+
 #define MACHINE_TICKS_PER_SECOND 1000
 
 extern uint32 machine_tick_count(void);

--- a/Source_Files/CSeries/mytm.h
+++ b/Source_Files/CSeries/mytm.h
@@ -26,6 +26,8 @@
 #ifndef MYTM_H_
 #define MYTM_H_
 
+#include "cstypes.h"
+
 typedef struct myTMTask myTMTask,*myTMTaskPtr;
 
 extern myTMTaskPtr myTMSetup(

--- a/Source_Files/Expat/xmltok.h
+++ b/Source_Files/Expat/xmltok.h
@@ -5,6 +5,9 @@
 #ifndef XmlTok_INCLUDED
 #define XmlTok_INCLUDED 1
 
+#include "expat_external.h"
+#include "internal.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Source_Files/Files/Packing.h
+++ b/Source_Files/Files/Packing.h
@@ -55,7 +55,7 @@ Aug 27, 2002 (Alexander Strange):
 	Moved functions to Packing.cpp to get around inlining issues.
 */
 
-//#include <string.h>
+#include "cstypes.h"
 
 // Default: packed-data is big-endian.
 // May be overridden by some previous definition,

--- a/Source_Files/Files/crc.h
+++ b/Source_Files/Files/crc.h
@@ -29,6 +29,8 @@ Aug 15, 2000 (Loren Petrich):
 	Using object-oriented file handler
 */
 
+#include "cstypes.h"
+
 class FileSpecifier;
 class OpenedFile;
 

--- a/Source_Files/Files/extensions.h
+++ b/Source_Files/Files/extensions.h
@@ -27,6 +27,8 @@ Aug 12, 2000 (Loren Petrich):
 	Using object-oriented file handler
 */
 
+#include "cstypes.h"
+
 class FileSpecifier;
 
 #define BUNGIE_PHYSICS_DATA_VERSION 0

--- a/Source_Files/Files/game_wad.h
+++ b/Source_Files/Files/game_wad.h
@@ -33,6 +33,9 @@ Aug 12, 2000 (Loren Petrich):
 	Using object-oriented file handler
 */
 
+#include "cstypes.h"
+#include <string>
+
 class FileSpecifier;
 
 bool save_game_file(FileSpecifier& File, const std::string& metadata, const std::string& imagedata);

--- a/Source_Files/Files/resource_manager.h
+++ b/Source_Files/Files/resource_manager.h
@@ -28,6 +28,7 @@
 #ifndef RESOURCE_MANAGER_H
 #define RESOURCE_MANAGER_H
 
+#include "cstypes.h"
 #include <stdio.h>
 #include <vector>
 #include <SDL.h>

--- a/Source_Files/Files/wad_prefs.h
+++ b/Source_Files/Files/wad_prefs.h
@@ -28,6 +28,7 @@ Aug 21, 2000 (Loren Petrich):
 */
 
 #include "FileHandler.h"
+#include "wad.h"
 
 /* Open the file, and allocate whatever internal structures are necessary in the */
 /*  preferences pointer.. */

--- a/Source_Files/GameWorld/dynamic_limits.h
+++ b/Source_Files/GameWorld/dynamic_limits.h
@@ -31,6 +31,8 @@ May 4, 2000
 #ifndef MARATHON_DYNAMIC_ENTITY_LIMITS
 #define MARATHON_DYNAMIC_ENTITY_LIMITS
 
+#include "cstypes.h"
+
 
 // Limit types:
 enum {

--- a/Source_Files/GameWorld/effect_definitions.h
+++ b/Source_Files/GameWorld/effect_definitions.h
@@ -28,6 +28,10 @@ Feb 3, 2000 (Loren Petrich):
 	Added VacBob effects
 */
 
+#include "effects.h"
+#include "map.h"
+#include "SoundManagerEnums.h"
+
 /* ---------- constants */
 
 enum /* flags */

--- a/Source_Files/GameWorld/effects.h
+++ b/Source_Files/GameWorld/effects.h
@@ -43,6 +43,9 @@ Aug 30, 2000 (Loren Petrich):
 // LP addition:
 #include "dynamic_limits.h"
 
+#include "world.h"
+#include <vector>
+
 /* ---------- effect structure */
 
 enum /* effect types */
@@ -149,7 +152,7 @@ const int SIZEOF_effect_definition = 14;
 
 // Turned the list of active effects into a variable array
 
-extern vector<effect_data> EffectList;
+extern std::vector<effect_data> EffectList;
 #define effects (&EffectList[0])
 
 // extern struct effect_data *effects;

--- a/Source_Files/GameWorld/flood_map.h
+++ b/Source_Files/GameWorld/flood_map.h
@@ -24,6 +24,8 @@ FLOOD_MAP.H
 Saturday, June 18, 1994 8:07:35 PM
 */
 
+#include "world.h"
+
 /* ---------- constants */
 
 enum /* flood modes */

--- a/Source_Files/GameWorld/item_definitions.h
+++ b/Source_Files/GameWorld/item_definitions.h
@@ -28,6 +28,9 @@ Feb 4, 2000 (Loren Petrich):
 
 */
 
+#include "items.h"
+#include "map.h"
+
 /* ---------- structures */
 
 struct item_definition

--- a/Source_Files/GameWorld/lightsource.h
+++ b/Source_Files/GameWorld/lightsource.h
@@ -30,6 +30,7 @@ Aug 29, 2000 (Loren Petrich):
 	Added packing routines for the light data; also moved old light stuff (M1) here
 */
 
+#include "cstypes.h"
 #include <vector>
 
 /* ---------- constants */
@@ -170,7 +171,7 @@ const int SIZEOF_old_light_data = 32;
 // Turned the list of lights into a variable array;
 // took over their maximum number as how many of them
 
-extern vector<light_data> LightList;
+extern std::vector<light_data> LightList;
 #define lights (&LightList[0])
 #define MAXIMUM_LIGHTS_PER_MAP (LightList.size())
 

--- a/Source_Files/GameWorld/media_definitions.h
+++ b/Source_Files/GameWorld/media_definitions.h
@@ -30,6 +30,11 @@ May 17, 2000 (Loren Petrich):
 	Jjaro media type has its own fade effect
 */
 
+#include "effects.h"
+#include "fades.h"
+#include "media.h"
+#include "SoundManagerEnums.h"
+
 /* ---------- structures */
 
 struct media_definition

--- a/Source_Files/GameWorld/monster_definitions.h
+++ b/Source_Files/GameWorld/monster_definitions.h
@@ -33,9 +33,12 @@ Oct 26, 2000 (Mark Levin)
 	Added some includes that this file depends on
 */
 
-//New includes
 #include "effects.h"
+#include "items.h"
+#include "map.h"
+#include "monsters.h"
 #include "projectiles.h"
+#include "SoundManagerEnums.h"
 
 
 /* ---------- macros */

--- a/Source_Files/GameWorld/monsters.h
+++ b/Source_Files/GameWorld/monsters.h
@@ -50,6 +50,8 @@ Oct 24, 2000 (Mark Levin)
 #include <vector>
 using namespace std;
 
+#include "world.h"
+
 /* ---------- constants */
 
 #define FLAMING_DEAD_SHAPE BUILD_DESCRIPTOR(_collection_rocket, 7)

--- a/Source_Files/GameWorld/physics_models.h
+++ b/Source_Files/GameWorld/physics_models.h
@@ -24,6 +24,8 @@ PHYSICS_MODELS.H
 Tuesday, May 31, 1994 5:18:35 PM
 */
 
+#include "world.h"
+
 /* ---------- constants */
 
 enum /* models */

--- a/Source_Files/GameWorld/platform_definitions.h
+++ b/Source_Files/GameWorld/platform_definitions.h
@@ -24,6 +24,9 @@ PLATFORM_DEFINITIONS.H
 Monday, June 26, 1995 9:43:22 AM  (Jason)
 */
 
+#include "platforms.h"
+#include "SoundManagerEnums.h"
+
 /* ---------- constants */
 
 enum /* sound codes for play_platform_sound() */

--- a/Source_Files/GameWorld/platforms.h
+++ b/Source_Files/GameWorld/platforms.h
@@ -30,6 +30,8 @@ May 18, 2000 (Loren Petrich):
 	Added XML-parser support
 */
 
+#include "map.h"
+
 /* ---------- constants */
 
 // #define MAXIMUM_PLATFORMS_PER_MAP 64

--- a/Source_Files/GameWorld/projectile_definitions.h
+++ b/Source_Files/GameWorld/projectile_definitions.h
@@ -27,6 +27,12 @@ Feb 4, 2000 (Loren Petrich):
 	Added SMG bullet and its ability to enter/exit liquids
 */
 
+#include "effects.h"
+#include "map.h"
+#include "media.h"
+#include "projectiles.h"
+#include "SoundManagerEnums.h"
+
 /* ---------- constants */
 
 enum /* projectile flags */

--- a/Source_Files/GameWorld/projectiles.h
+++ b/Source_Files/GameWorld/projectiles.h
@@ -45,6 +45,8 @@ Jan 6, 2001 (Loren Petrich):
 #include "dynamic_limits.h"
 #include "world.h" // for angle
 
+#include <vector>
+
 // LP change: made this settable from the resource fork
 #define MAXIMUM_PROJECTILES_PER_MAP (get_dynamic_limit(_dynamic_limit_projectiles))
 
@@ -152,7 +154,7 @@ enum /* translate_projectile() flags */
 
 // Turned the list of active projectiles into a variable array
 
-extern vector<projectile_data> ProjectileList;
+extern std::vector<projectile_data> ProjectileList;
 #define projectiles (&ProjectileList[0])
 
 // extern struct projectile_data *projectiles;

--- a/Source_Files/GameWorld/scenery.h
+++ b/Source_Files/GameWorld/scenery.h
@@ -27,6 +27,8 @@ May 18, 2000 (Loren Petrich):
 	Added XML-parser support
 */
 
+#include "world.h"
+
 /* ---------- prototypes/SCENERY.C */
 
 void initialize_scenery(void);

--- a/Source_Files/GameWorld/scenery_definitions.h
+++ b/Source_Files/GameWorld/scenery_definitions.h
@@ -29,6 +29,10 @@ Feb 4, 2000 (Loren Petrich):
 	That could be done by making (effect = NONE) in effects.c make the breaking-glass sound
 */
 
+#include "effects.h"
+#include "shape_descriptors.h"
+#include "world.h"
+
 /* ---------- constants */
 
 enum

--- a/Source_Files/GameWorld/weapon_definitions.h
+++ b/Source_Files/GameWorld/weapon_definitions.h
@@ -29,6 +29,12 @@
 	Added SMG stuff
 */
 
+#include "items.h"
+#include "map.h"
+#include "projectiles.h"
+#include "SoundManagerEnums.h"
+#include "weapons.h"
+
 /* TEMPORARY!!! */
 enum {
 	_projectile_ball_dropped= 1000

--- a/Source_Files/GameWorld/weapons.h
+++ b/Source_Files/GameWorld/weapons.h
@@ -36,6 +36,8 @@ Aug 31, 2000 (Loren Petrich):
 	Added stuff for unpacking and packing
 */
 
+#include "cstypes.h"
+
 /* enums for player.c */
 enum { /* Weapons */
 	_weapon_fist,

--- a/Source_Files/GameWorld/world.h
+++ b/Source_Files/GameWorld/world.h
@@ -40,6 +40,8 @@ Jul 1, 2000 (Loren Petrich):
 #ifndef _WORLD_H
 #define _WORLD_H
 
+#include "cstypes.h"
+
 /* ---------- constants */
 
 #define TRIG_SHIFT 10

--- a/Source_Files/Input/joystick.h
+++ b/Source_Files/Input/joystick.h
@@ -26,6 +26,8 @@ May 18, 2009 (Eric Peterson):
 #ifndef JOYSTICK_H
 #define JOYSTICK_H
 
+#include "cstypes.h"
+
 // this is where we start stuffing button presses into the big keymap array,
 // since 65 is where uppercase letters start + room for 8 mouse presses
 #define SDLK_BASE_JOYSTICK_BUTTON 73

--- a/Source_Files/Input/mouse.h
+++ b/Source_Files/Input/mouse.h
@@ -27,6 +27,8 @@ Tuesday, January 17, 1995 2:53:17 PM  (Jason')
         semi-hacky scheme in SDL to let mouse buttons simulate keypresses
 */
 
+#include "cstypes.h"
+
 void enter_mouse(short type);
 void test_mouse(short type, uint32 *action_flags, _fixed *delta_yaw, _fixed *delta_pitch, _fixed *delta_velocity);
 void exit_mouse(short type);

--- a/Source_Files/Lua/lua_mnemonics.h
+++ b/Source_Files/Lua/lua_mnemonics.h
@@ -20,6 +20,8 @@ LUA_MNEMONICS.H
 	Implements the Lua string mnemonics
 */
 
+#include "lua_script.h"
+
 struct lang_def
 {
 	const char *name;

--- a/Source_Files/Lua/lua_templates.h
+++ b/Source_Files/Lua/lua_templates.h
@@ -958,11 +958,11 @@ public:
 	}
 	static boost::function<bool (index_t)> Valid;
 	
-	static map<index_t, object_t> _objects;
+	static std::map<index_t, object_t> _objects;
 };
 
 template<char *name, typename object_t, typename index_t>
-map<index_t, object_t> L_ObjectClass<name, object_t, index_t>::_objects;
+std::map<index_t, object_t> L_ObjectClass<name, object_t, index_t>::_objects;
 
 template<char *name, typename object_t, typename index_t>
 struct object_valid

--- a/Source_Files/Misc/CircularQueue.h
+++ b/Source_Files/Misc/CircularQueue.h
@@ -36,6 +36,8 @@
 #ifndef CIRCULAR_QUEUE_H
 #define CIRCULAR_QUEUE_H
 
+#include "csalerts.h"  // need assert
+
 template<typename T>
 class CircularQueue {
 public:

--- a/Source_Files/Misc/Random.h
+++ b/Source_Files/Misc/Random.h
@@ -27,6 +27,8 @@
 	http://www.gnu.org/licenses/gpl.html
 */
 
+#include "cstypes.h"
+
 
 struct GM_Random
 {

--- a/Source_Files/Misc/WindowedNthElementFinder.h
+++ b/Source_Files/Misc/WindowedNthElementFinder.h
@@ -27,6 +27,7 @@
 #define WINDOWEDNTHELEMENTFINDER_H
 
 #include "CircularQueue.h"
+#include <set>
 
 template <typename tElementType>
 class WindowedNthElementFinder {

--- a/Source_Files/Misc/key_definitions.h
+++ b/Source_Files/Misc/key_definitions.h
@@ -28,6 +28,9 @@
  *
  */
 
+#include "interface.h"
+#include "player.h"
+
 
 /* Constants */
 enum /* special flag types */

--- a/Source_Files/Misc/progress.h
+++ b/Source_Files/Misc/progress.h
@@ -25,6 +25,8 @@
 
 */
 
+#include <stddef.h>
+
 enum {
 	strPROGRESS_MESSAGES= 143,
 	_distribute_map_single= 0,

--- a/Source_Files/Misc/sdl_dialogs.h
+++ b/Source_Files/Misc/sdl_dialogs.h
@@ -28,16 +28,17 @@
 #ifndef SDL_DIALOGS_H
 #define SDL_DIALOGS_H
 
+#include "cstypes.h"
 #include <vector>
 #include <memory>
 #include <boost/function.hpp>
+#include <SDL.h>
 
 #ifndef NO_STD_NAMESPACE
 using std::vector;
 #endif
 
 class widget;
-struct SDL_Surface;
 class font_info;
 class FileSpecifier;
 

--- a/Source_Files/Misc/vbl_definitions.h
+++ b/Source_Files/Misc/vbl_definitions.h
@@ -29,6 +29,8 @@ Aug 12, 2000 (Loren Petrich):
 	Using object-oriented file handler; removing refnum from here
 */
 
+#include "player.h"
+
 #define MAXIMUM_QUEUE_SIZE           512
 
 typedef struct action_queue /* 8 bytes */

--- a/Source_Files/ModelView/ModelRenderer.h
+++ b/Source_Files/ModelView/ModelRenderer.h
@@ -26,6 +26,7 @@
 	Created by Loren Petrich, July 18, 2001
 */
 
+#include "csmacros.h"  // need obj_clear
 #include "Model3D.h"
 
 struct ModelRenderShader

--- a/Source_Files/Network/network_games.h
+++ b/Source_Files/Network/network_games.h
@@ -25,6 +25,8 @@
 
 */
 
+#include "player.h"
+
 struct player_ranking_data {
 	short player_index;
 	long ranking;

--- a/Source_Files/Network/network_lookup_sdl.h
+++ b/Source_Files/Network/network_lookup_sdl.h
@@ -28,6 +28,7 @@
 #ifndef NETWORK_LOOKUP_SDL_H
 #define NETWORK_LOOKUP_SDL_H
 
+#include "cseries.h"  // need OSErr
 #include	"SSLP_API.h"
 
 /* ---------- prototypes/NETWORK_NAMES.C */

--- a/Source_Files/Network/network_microphone_shared.h
+++ b/Source_Files/Network/network_microphone_shared.h
@@ -34,6 +34,8 @@
 #ifndef NETWORK_MICROPHONE_SHARED_H
 #define NETWORK_MICROPHONE_SHARED_H
 
+#include "cstypes.h"
+
 // Netmic code should call this once the format is known (and any time the capture format changes).
 // copy_and_send_() uses the values specified by the most recent call to this routine.
 // It is an error to call copy_and_send() without calling this first.

--- a/Source_Files/RenderMain/Crosshairs.h
+++ b/Source_Files/RenderMain/Crosshairs.h
@@ -33,6 +33,10 @@ Jun 26, 2002 (Loren Petrich):
 #ifndef _CROSSHAIRS
 #define _CROSSHAIRS
 
+#include "cseries.h"  // need RGBColor
+
+struct SDL_Surface;
+
 enum {
 	CHShape_RealCrosshairs,
 	CHShape_Circle

--- a/Source_Files/RenderMain/OGL_Faders.h
+++ b/Source_Files/RenderMain/OGL_Faders.h
@@ -25,6 +25,8 @@
 	This contains code for doing fader stuff.	
 */
 
+#include "cstypes.h"
+
 
 // Indicates whether OpenGL-rendering faders will be used
 bool OGL_FaderActive();

--- a/Source_Files/RenderMain/OGL_Textures.h
+++ b/Source_Files/RenderMain/OGL_Textures.h
@@ -34,6 +34,10 @@ May 3, 2003 (Br'fin (Jeremy Parsons))
 #ifndef _OGL_TEXTURES
 #define _OGL_TEXTURES
 
+#include "OGL_Headers.h"
+#include "OGL_Subst_Texture_Def.h"
+#include "scottish_textures.h"
+
 // Initialize the texture accounting
 void OGL_StartTextures();
 

--- a/Source_Files/RenderMain/RenderVisTree.h
+++ b/Source_Files/RenderMain/RenderVisTree.h
@@ -39,7 +39,7 @@ Oct 13, 2000
 
 #include <deque>
 #include <vector>
-#include "world.h"
+#include "map.h"
 #include "render.h"
 
 

--- a/Source_Files/RenderMain/collection_definition.h
+++ b/Source_Files/RenderMain/collection_definition.h
@@ -36,6 +36,9 @@ Saturday, July 9, 1994 3:36:05 PM
 	added NUMBER_OF_PRIVATE_COLORS constant.
 */
 
+#include "cstypes.h"
+#include <vector>
+
 /* ---------- collection definition structure */
 
 /* 2 added pixels_to_world to collection_definition structure */

--- a/Source_Files/RenderMain/render.h
+++ b/Source_Files/RenderMain/render.h
@@ -199,6 +199,10 @@ void render_computer_interface(struct view_data *view);
 
 #include "scottish_textures.h"
 
+// Forward declarations in case we get first included by scottish_textures.h:
+struct rectangle_definition;
+struct polygon_definition;
+
 // LP: definitions moved up here because they are referred to
 // outside of render.c, where they are defined.
 

--- a/Source_Files/RenderMain/scottish_textures.h
+++ b/Source_Files/RenderMain/scottish_textures.h
@@ -42,6 +42,7 @@ May 3, 2003 (Br'fin (Jeremy Parsons))
 	instead of abusing/overflowing shape_descriptors
 */
 
+#include "render.h"
 #include "shape_descriptors.h"
 
 /* ---------- constants */

--- a/Source_Files/RenderMain/shape_definitions.h
+++ b/Source_Files/RenderMain/shape_definitions.h
@@ -28,6 +28,10 @@ Aug 14, 2000 (Loren Petrich):
 	and because these are variable-format objects.
 */
 
+#include "shape_descriptors.h"
+
+struct collection_definition;
+
 /* ---------- structures */
 
 struct collection_header /* 32 bytes on disk */

--- a/Source_Files/RenderMain/shape_descriptors.h
+++ b/Source_Files/RenderMain/shape_descriptors.h
@@ -32,6 +32,8 @@ Feb 3, 2000 (Loren Petrich):
 	Annotated some of the _collection's better
 */
 
+#include "cstypes.h"
+
 /* ---------- types */
 
 typedef uint16 shape_descriptor; /* [clut.3] [collection.5] [shape.8] */

--- a/Source_Files/RenderMain/vec3.h
+++ b/Source_Files/RenderMain/vec3.h
@@ -9,6 +9,7 @@
 #ifndef _VEC3__H
 #define _VEC3__H
 
+#include "OGL_Headers.h"
 #include <cfloat>
 #include <cmath>
 

--- a/Source_Files/RenderOther/IMG_savepng.h
+++ b/Source_Files/RenderOther/IMG_savepng.h
@@ -24,7 +24,7 @@
 #ifndef __IMG_SAVETOPNG_H__
 #define __IMG_SAVETOPNG_H__
 
-/* #include <SDL/begin_code.h> */
+#include <SDL.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/Source_Files/RenderOther/TextStrings.h
+++ b/Source_Files/RenderOther/TextStrings.h
@@ -30,6 +30,8 @@
 	and an index inside that string set, which starts from 0.
 */
 
+#include <stddef.h>
+
 // Set up a string in the repository; a repeated call will replace an old string
 void TS_PutCString(short ID, short Index, const char *String);
 

--- a/Source_Files/RenderOther/computer_interface.h
+++ b/Source_Files/RenderOther/computer_interface.h
@@ -76,6 +76,8 @@
 		char text;
 */
 
+#include "cstypes.h"
+
 /* ------------ structures */
 struct static_preprocessed_terminal_data {
 	int16 total_length;

--- a/Source_Files/RenderOther/game_window.h
+++ b/Source_Files/RenderOther/game_window.h
@@ -27,6 +27,8 @@ Apr 30, 2000 (Loren Petrich): Added XML parser object for all the interface stuf
 
 */
 
+struct Rect;
+
 void initialize_game_window(void);
 
 void draw_interface(void);

--- a/Source_Files/RenderOther/motion_sensor.h
+++ b/Source_Files/RenderOther/motion_sensor.h
@@ -29,6 +29,8 @@ Jan 30, 2000 (Loren Petrich)
 May 1, 2000 (Loren Petrich): Added XML parser object for the stuff here.
 */
 
+#include "shape_descriptors.h"
+
 enum {
 	MType_Friend,	// What you, friendly players, and the Bobs are
 	MType_Alien,	// What the other critters are

--- a/Source_Files/RenderOther/overhead_map.h
+++ b/Source_Files/RenderOther/overhead_map.h
@@ -26,6 +26,8 @@
 May 1, 2000 (Loren Petrich): Added XML parser object for the stuff here.
 */
 
+#include "world.h"
+
 #define OVERHEAD_MAP_MINIMUM_SCALE 1
 #define OVERHEAD_MAP_MAXIMUM_SCALE 4
 #define DEFAULT_OVERHEAD_MAP_SCALE 3

--- a/Source_Files/RenderOther/screen.h
+++ b/Source_Files/RenderOther/screen.h
@@ -61,6 +61,9 @@ Jan 25, 2002 (Br'fin (Jeremy Parsons)):
 
 #include <utility>
 #include <vector>
+#include <SDL.h>
+
+struct Rect;
 
 struct screen_mode_data;
 namespace alephone

--- a/Source_Files/RenderOther/screen_drawing.h
+++ b/Source_Files/RenderOther/screen_drawing.h
@@ -33,6 +33,8 @@ Jul 2, 2000 (Loren Petrich):
 #include	"shape_descriptors.h"
 #include "sdl_fonts.h"
 
+struct rgb_color;
+
 /* Rectangles for the interface, etc.. */
 /* rectangle id's */
 enum {

--- a/Source_Files/RenderOther/screen_shared.h
+++ b/Source_Files/RenderOther/screen_shared.h
@@ -34,7 +34,15 @@ Jan 25, 2002 (Br'fin (Jeremy Parsons)):
 	Minor tweaks to screen_printf() mechanism (safer; resets when screen_reset called)
 */
 
+#include "computer_interface.h"
+#include "fades.h"
+#include "network.h"
+#include "OGL_Render.h"
+#include "overhead_map.h"
+#include "screen.h"
 #include <stdarg.h>
+
+extern SDL_Surface *world_pixels;
 
 #define DESIRED_SCREEN_WIDTH 640
 #define DESIRED_SCREEN_HEIGHT 480

--- a/Source_Files/RenderOther/sdl_fonts.h
+++ b/Source_Files/RenderOther/sdl_fonts.h
@@ -28,6 +28,7 @@
 #ifndef SDL_FONTS_H
 #define SDL_FONTS_H
 
+#include "csfonts.h"
 #include "FileHandler.h"
 #include <SDL_ttf.h>
 #include <boost/tuple/tuple.hpp>

--- a/Source_Files/Sound/SoundManagerEnums.h
+++ b/Source_Files/Sound/SoundManagerEnums.h
@@ -24,6 +24,8 @@
 
 // ghs: moved these here because SoundManager's header file is enormous already
 
+#include "cstypes.h"
+
 /* ---------- sound codes */
 
 enum /* ambient sound codes */

--- a/Source_Files/Sound/song_definitions.h
+++ b/Source_Files/Sound/song_definitions.h
@@ -25,6 +25,8 @@
 
 */
 
+#include "csmisc.h"
+
 #define RANDOM_COUNT(x) (-(x))
 
 enum {

--- a/Source_Files/Sound/sound_definitions.h
+++ b/Source_Files/Sound/sound_definitions.h
@@ -39,6 +39,9 @@ Aug 17, 2000 (Loren Petrich):
 	Turned handle for loaded sound into a pointer; added length of that sound object.
 */
 
+#include "SoundManagerEnums.h"
+#include "world.h"
+
 /* ---------- constants */
 
 enum

--- a/Source_Files/XML/XML_ParseTreeRoot.h
+++ b/Source_Files/XML/XML_ParseTreeRoot.h
@@ -28,6 +28,8 @@
 	including that root element, of course.
 */
 
+#include <stddef.h>
+
 extern void ResetAllMMLValues(); // reset everything that's been changed to hard-coded defaults
 
 class FileSpecifier;

--- a/Source_Files/shell.h
+++ b/Source_Files/shell.h
@@ -39,7 +39,12 @@ Dec 29, 2000 (Loren Petrich):
 	Added function for showing text messages on the screen
 */
 
+#include "cstypes.h"
+
 class FileSpecifier;
+struct RGBColor;
+struct SDL_Color;
+struct SDL_Surface;
 
 /* ---------- constants */
 


### PR DESCRIPTION
Adds #includes, std:: qualifications, and forward declarations to headers such that they each compile cleanly when included in an otherwise empty source file. This was tested with the help of a script. All Aleph One headers other than "tabulation" headers and RenderMain/low_level_textures.h now pass this test. No changes impact the include set of any source file.

The driving motivation is to allow IDE symbol tracking and highlighting features to fully work when viewing headers. Secondary benefits include making most headers order-independent and making header inclusion less of a hassle in any future refactoring efforts.

RenderMain/low_level_textures.h was left unaddressed because it is interdependent with scottish_textures.cpp. Any cleanup work there would be better handled separately.