### PR TITLE
Make Lua overlays + printed messages scale with HUD size

### DIFF
--- a/Source_Files/Lua/lua_player.cpp
+++ b/Source_Files/Lua/lua_player.cpp
@@ -416,23 +416,19 @@ typedef PlayerSubtable<Lua_Overlay_Name> Lua_Overlay;
 
 int Lua_Overlay_Clear(lua_State *L)
 {
+        int player = Lua_Overlay::PlayerIndex(L, 1);
 	int index = Lua_Overlay::Index(L, 1);
-	if (Lua_Overlay::PlayerIndex(L, 1) == local_player_index)
-	{
-		SetScriptHUDIcon(index, 0, 0);
-		SetScriptHUDText(index, 0);
-	}
+	SetScriptHUDIcon(player, index, 0, 0);
+	SetScriptHUDText(player, index, 0);
 
 	return 0;
 }
 
 int Lua_Overlay_Fill_Icon(lua_State *L)
 {
-	if (Lua_Overlay::PlayerIndex(L, 1) == local_player_index)
-	{
-		int color = Lua_OverlayColor::ToIndex(L, 2);
-		SetScriptHUDSquare(Lua_Overlay::Index(L, 1), color);
-	}
+        int player = Lua_Overlay::PlayerIndex(L, 1);
+	int color = Lua_OverlayColor::ToIndex(L, 2);
+	SetScriptHUDSquare(player, Lua_Overlay::Index(L, 1), color);
 
 	return 0;
 }
@@ -445,16 +441,14 @@ const luaL_Reg Lua_Overlay_Get[] = {
 
 static int Lua_Overlay_Set_Icon(lua_State *L)
 {
-	if (Lua_Overlay::PlayerIndex(L, 1) == local_player_index)
+        int player = Lua_Overlay::PlayerIndex(L, 1);
+	if (lua_isstring(L, 2))
 	{
-		if (lua_isstring(L, 2))
-		{
-			SetScriptHUDIcon(Lua_Overlay::Index(L, 1), lua_tostring(L, 2), lua_rawlen(L, 2));
-		}
-		else
-		{
-			SetScriptHUDIcon(Lua_Overlay::Index(L, 1), 0, 0);
-		}
+		SetScriptHUDIcon(player, Lua_Overlay::Index(L, 1), lua_tostring(L, 2), lua_rawlen(L, 2));
+	}
+	else
+	{
+		SetScriptHUDIcon(player, Lua_Overlay::Index(L, 1), 0, 0);
 	}
 
 	return 0;
@@ -462,25 +456,21 @@ static int Lua_Overlay_Set_Icon(lua_State *L)
 
 static int Lua_Overlay_Set_Text(lua_State *L)
 {
-	if (Lua_Overlay::PlayerIndex(L, 1) == local_player_index)
-	{
-		const char *text = 0;
-		if (lua_isstring(L, 2)) 
-			text = lua_tostring(L, 2);
-		
-		SetScriptHUDText(Lua_Overlay::Index(L, 1), text);
-	}
+        int player = Lua_Overlay::PlayerIndex(L, 1);
+	const char *text = 0;
+	if (lua_isstring(L, 2)) 
+		text = lua_tostring(L, 2);
+	
+	SetScriptHUDText(player, Lua_Overlay::Index(L, 1), text);
 
 	return 0;
 }
 
 static int Lua_Overlay_Set_Text_Color(lua_State *L)
 {
-	if (Lua_Overlay::PlayerIndex(L, 1) == local_player_index)
-	{
-		int color = Lua_OverlayColor::ToIndex(L, 2);
-		SetScriptHUDColor(Lua_Overlay::Index(L, 1), color);
-	}
+        int player = Lua_Overlay::PlayerIndex(L, 1);
+	int color = Lua_OverlayColor::ToIndex(L, 2);
+	SetScriptHUDColor(player, Lua_Overlay::Index(L, 1), color);
 
 	return 0;
 }

--- a/Source_Files/Lua/lua_script.cpp
+++ b/Source_Files/Lua/lua_script.cpp
@@ -763,6 +763,18 @@ bool L_Get_Proper_Item_Accounting(lua_State* L)
 	return value;
 }
 
+static char L_NONLOCAL_OVERLAYS_KEY[] = "nonlocal_overlays";
+
+void L_Set_Nonlocal_Overlays(lua_State* L, bool value)
+{
+  SetScriptHUDNonlocal(value);
+}
+
+bool L_Get_Nonlocal_Overlays(lua_State* L)
+{
+  return IsScriptHUDNonlocal();
+}
+
 static int L_Enable_Player(lua_State*);
 static int L_Disable_Player(lua_State*);
 static int L_Kill_Script(lua_State*);

--- a/Source_Files/Lua/lua_templates.h
+++ b/Source_Files/Lua/lua_templates.h
@@ -56,6 +56,9 @@ extern std::string L_Get_Search_Path(lua_State* L);
 extern bool L_Get_Proper_Item_Accounting(lua_State* L);
 extern void L_Set_Proper_Item_Accounting(lua_State* L, bool value);
 
+extern bool L_Get_Nonlocal_Overlays(lua_State* L);
+extern void L_Set_Nonlocal_Overlays(lua_State* L, bool value);
+
 // pushes a function that returns the parameterized function
 template<lua_CFunction f>
 int L_TableFunction(lua_State *L)

--- a/Source_Files/RenderOther/screen.h
+++ b/Source_Files/RenderOther/screen.h
@@ -237,9 +237,6 @@ void ShowMessage(char *Text);
 
 /* SB: Custom Blizzard-style overlays */
 #define MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS 6
-/* This is rather high for people who play at 320x240. Yes, I DO exist!
-However, since text in general doesn't work too well for us... :'( */
-#define SCRIPT_HUD_ELEMENT_SPACING (640/MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS)
 /* color is a terminal color */
 void SetScriptHUDColor(int idx, int color);
 /* text == NULL or "" removes that HUD element

--- a/Source_Files/RenderOther/screen.h
+++ b/Source_Files/RenderOther/screen.h
@@ -238,15 +238,15 @@ void ShowMessage(char *Text);
 /* SB: Custom Blizzard-style overlays */
 #define MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS 6
 /* color is a terminal color */
-void SetScriptHUDColor(int idx, int color);
+void SetScriptHUDColor(int player, int idx, int color);
 /* text == NULL or "" removes that HUD element
    to turn HUD elements off, set all elements NULL or "" */
-void SetScriptHUDText(int idx, const char* text);
+void SetScriptHUDText(int player, int idx, const char* text);
 /* icon == NULL turns the icon off
    someday I'll document the format */
-bool SetScriptHUDIcon(int idx, const char* icon, size_t length);
+bool SetScriptHUDIcon(int player, int idx, const char* icon, size_t length);
 /* sets the icon for that HUD to a colored square (same colors as SetScriptHUDColor) */
-void SetScriptHUDSquare(int idx, int color);
+void SetScriptHUDSquare(int player, int idx, int color);
 
 bool MainScreenVisible();
 int MainScreenWidth();

--- a/Source_Files/RenderOther/screen.h
+++ b/Source_Files/RenderOther/screen.h
@@ -237,6 +237,8 @@ void ShowMessage(char *Text);
 
 /* SB: Custom Blizzard-style overlays */
 #define MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS 6
+bool IsScriptHUDNonlocal();
+void SetScriptHUDNonlocal(bool nonlocal = true);
 /* color is a terminal color */
 void SetScriptHUDColor(int player, int idx, int color);
 /* text == NULL or "" removes that HUD element

--- a/Source_Files/RenderOther/screen_shared.h
+++ b/Source_Files/RenderOther/screen_shared.h
@@ -598,20 +598,55 @@ static void DisplayMessages(SDL_Surface *s)
 	/* SB */
 	for(int i = 0; i < MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; ++i) {
 		if(ScriptHUDElements[i].text[0]) {
-			short x2 = X, sk, ysk = 0;
+			short x2 = X, sk = Font.TextWidth("AAAAAAAAAAAAAA"),
+				icon_skip, icon_drop;
+			switch(get_screen_mode()->hud_scale_level) {
+			case 0:
+				icon_drop = 2;
+				break;
+			case 1:
+				if(MainScreenHeight() >= 960)
+					icon_drop = 4;
+				else
+					icon_drop = 2;
+				break;
+			case 2:
+				if(MainScreenHeight() >= 480)
+					icon_drop = MainScreenHeight() * 2 / 480;
+				else
+					icon_drop = 2;
+				break;
+			}
+			bool had_icon;
 			/* Yes, I KNOW this is the same i as above. I know what I'm doing. */
 			for(i = 0; i < MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; ++i) {
 				if(!ScriptHUDElements[i].text[0]) continue;
-				sk = SCRIPT_HUD_ELEMENT_SPACING;
 				if(ScriptHUDElements[i].isicon) {
-					ysk = 2;
+					had_icon = true;
 
 					SDL_Rect rect;
 					rect.x = x2;
-					rect.y = Y - 11;
-					rect.w = rect.h = 16;					
+					rect.y = Y - Font.Ascent + Font.Leading;
+					rect.w = rect.h = 16;
+                                        icon_skip = 20;
+					switch(get_screen_mode()->hud_scale_level) {
+					case 1:
+						if(MainScreenHeight() >= 960) {
+							rect.w *= 2;
+							rect.h *= 2;
+							icon_skip *= 2;
+						}
+						break;
+					case 2:
+						if(MainScreenHeight() > 480) {
+							rect.w = rect.w * MainScreenHeight() / 480;
+							rect.h = rect.h * MainScreenHeight() / 480;
+							icon_skip = icon_skip * MainScreenHeight() / 480;
+						}
+						break;
+					}
 #ifdef HAVE_OPENGL
-					if(OGL_IsActive()) {						
+					if(OGL_IsActive()) {
 						ScriptHUDElements[i].ogl_blitter.Draw(rect);
 					}
 					else 
@@ -619,15 +654,18 @@ static void DisplayMessages(SDL_Surface *s)
 					{
 						ScriptHUDElements[i].sdl_blitter.Draw(s, rect);
 					}
-					x2 += 20;
-					sk -= 20;
+					x2 += icon_skip;
 				}
 				SDL_Color color;
 				_get_interface_color(ScriptHUDElements[i].color+_computer_interface_text_color, &color);
-				DisplayText(x2,Y + (ScriptHUDElements[i].isicon ? 2 : 0),ScriptHUDElements[i].text, color.r, color.g, color.b);
+				DisplayText(x2,Y + (ScriptHUDElements[i].isicon ? icon_drop : 0),ScriptHUDElements[i].text, color.r, color.g, color.b);
 				x2 += sk;
+				if(ScriptHUDElements[i].isicon)
+					x2 -= icon_skip;
 			}
-			Y += LineSpacing + ysk;
+			Y += LineSpacing;
+			if(had_icon)
+				Y += icon_drop;
 			break;
 		}
 	}

--- a/Source_Files/RenderOther/screen_shared.h
+++ b/Source_Files/RenderOther/screen_shared.h
@@ -120,7 +120,7 @@ static ScreenMessage Messages[NumScreenMessages];
 static struct ScriptHUDElement {
 	/* I don't like this convention, but I'll follow it. */
 	enum {
-		Len = 256
+		Len = 32
 	};
 	/* this needs optimized (sorry, making fun of my grandmother...) */
 	/* it's char[4] instead of int32 to make the OpenGL support simpler to implement */
@@ -132,7 +132,7 @@ static struct ScriptHUDElement {
 #ifdef HAVE_OPENGL	
 	OGL_Blitter ogl_blitter;
 #endif	
-} ScriptHUDElements[MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS];
+} ScriptHUDElements[MAXIMUM_NUMBER_OF_NETWORK_PLAYERS][MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS];
 /* /SB */
 
 /* ---------- private prototypes */
@@ -224,10 +224,10 @@ namespace icon {
     return true;
   }
 	
-  void seticon(int idx, unsigned char palette[1024], unsigned char graphic[256]) {
+  void seticon(int player, int idx, unsigned char palette[1024], unsigned char graphic[256]) {
     unsigned char* p1, *p2, px;
     int n;
-    p1 = ScriptHUDElements[idx].icon;
+    p1 = ScriptHUDElements[player][idx].icon;
     p2 = graphic;
     for(n = 0; n < 256; ++n) {
       px = *(p2++);
@@ -236,54 +236,58 @@ namespace icon {
       *(p1++) = palette[px * 4 + 1];
       *(p1++) = palette[px * 4 + 2];
     }
-    ScriptHUDElements[idx].isicon = true;
+    ScriptHUDElements[player][idx].isicon = true;
 	SDL_Surface *srf;
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
-	srf = SDL_CreateRGBSurfaceFrom(ScriptHUDElements[idx].icon, 16, 16, 32, 64, 0xFF<<8, 0xFF<<16, 0xFF<<24, 0xFF);
+	srf = SDL_CreateRGBSurfaceFrom(ScriptHUDElements[player][idx].icon, 16, 16, 32, 64, 0xFF<<8, 0xFF<<16, 0xFF<<24, 0xFF);
 #else
-	srf = SDL_CreateRGBSurfaceFrom(ScriptHUDElements[idx].icon, 16, 16, 32, 64, 0xFF<<16, 0xFF<<8, 0xFF, 0xFF<<24);
+	srf = SDL_CreateRGBSurfaceFrom(ScriptHUDElements[player][idx].icon, 16, 16, 32, 64, 0xFF<<16, 0xFF<<8, 0xFF, 0xFF<<24);
 #endif
 #ifdef HAVE_OPENGL	
 	if (OGL_IsActive()) {
-		ScriptHUDElements[idx].ogl_blitter.Load(*srf);
+		ScriptHUDElements[player][idx].ogl_blitter.Load(*srf);
 	} else
 #endif	  
 	{	  
-		ScriptHUDElements[idx].sdl_blitter.Load(*srf);
+		ScriptHUDElements[player][idx].sdl_blitter.Load(*srf);
 	}
 	SDL_FreeSurface(srf);
   }
 	
 }
 
-void SetScriptHUDColor(int idx, int color) {
+void SetScriptHUDColor(int player, int idx, int color) {
+  player %= MAXIMUM_NUMBER_OF_NETWORK_PLAYERS;
   idx %= MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; /* o_o */
-  ScriptHUDElements[idx].color = color % 8; /* O_O */
+  ScriptHUDElements[player][idx].color = color % 8; /* O_O */
 }
 
-void SetScriptHUDText(int idx, const char* text) {
+void SetScriptHUDText(int player, int idx, const char* text) {
+  player %= MAXIMUM_NUMBER_OF_NETWORK_PLAYERS;
   idx %= MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS;
   if(!text) text = "";
-  strncpy(ScriptHUDElements[idx].text, text, 255);
-  ScriptHUDElements[idx].text[255] = 0;
+  strncpy(ScriptHUDElements[player][idx].text, text, ScriptHUDElement::Len);
+  ScriptHUDElements[player][idx].text[ScriptHUDElement::Len-1] = 0;
 }
 
-bool SetScriptHUDIcon(int idx, const char* text, size_t rem) {
+bool SetScriptHUDIcon(int player, int idx, const char* text, size_t rem) {
   unsigned char palette[1024], graphic[256];
   int numcolors;
+  player %= MAXIMUM_NUMBER_OF_NETWORK_PLAYERS;
   idx %= MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS;
   if(text) {
     if(!icon::parseicon(text, rem, palette, numcolors, graphic)) return false;
-    icon::seticon(idx, palette, graphic);
-  } else ScriptHUDElements[idx].isicon = false;
+    icon::seticon(player, idx, palette, graphic);
+  } else ScriptHUDElements[player][idx].isicon = false;
   return true;
 }
 
-void SetScriptHUDSquare(int idx, int _color) {
+void SetScriptHUDSquare(int player, int idx, int _color) {
   unsigned char palette[4]; /* short, I KNOW. */
   unsigned char graphic[256];
+  player %= MAXIMUM_NUMBER_OF_NETWORK_PLAYERS;
   idx %= MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS;
-  ScriptHUDElements[idx].color = _color % 8;
+  ScriptHUDElements[player][idx].color = _color % 8;
   memset(graphic, 0, 256);
   SDL_Color color;
   _get_interface_color(_color+_computer_interface_text_color, &color);
@@ -291,7 +295,7 @@ void SetScriptHUDSquare(int idx, int _color) {
   palette[1] = color.g;
   palette[2] = color.b;
   palette[3] = 0xff;
-  icon::seticon(idx, palette, graphic);
+  icon::seticon(player, idx, palette, graphic);
 }
 /* /SB */
 
@@ -301,10 +305,12 @@ void reset_messages()
 	for(int i = 0; i < NumScreenMessages; i++)
 		Messages[i].TimeRemaining = 0;
 	/* SB: reset HUD elements */
-	for(int i = 0; i < MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; i++) {
-		ScriptHUDElements[i].color = 1;
-		ScriptHUDElements[i].text[0] = 0;
-		ScriptHUDElements[i].isicon = false;
+	for(int p = 0; p < MAXIMUM_NUMBER_OF_NETWORK_PLAYERS; p++) {
+		for(int i = 0; i < MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; i++) {
+			ScriptHUDElements[p][i].color = 1;
+			ScriptHUDElements[p][i].text[0] = 0;
+			ScriptHUDElements[p][i].isicon = false;
+		}
 	}
 }
 
@@ -596,8 +602,9 @@ static void DisplayMessages(SDL_Surface *s)
 	short Y = Y0 + LineSpacing;
 	if (ShowPosition) Y += 6*LineSpacing;	// Make room for the position data
 	/* SB */
+	short view = current_player_index;
 	for(int i = 0; i < MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; ++i) {
-		if(ScriptHUDElements[i].text[0]) {
+		if(ScriptHUDElements[view][i].text[0]) {
 			short x2 = X, sk = Font.TextWidth("AAAAAAAAAAAAAA"),
 				icon_skip, icon_drop;
 			switch(get_screen_mode()->hud_scale_level) {
@@ -620,8 +627,8 @@ static void DisplayMessages(SDL_Surface *s)
 			bool had_icon;
 			/* Yes, I KNOW this is the same i as above. I know what I'm doing. */
 			for(i = 0; i < MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; ++i) {
-				if(!ScriptHUDElements[i].text[0]) continue;
-				if(ScriptHUDElements[i].isicon) {
+				if(!ScriptHUDElements[view][i].text[0]) continue;
+				if(ScriptHUDElements[view][i].isicon) {
 					had_icon = true;
 
 					SDL_Rect rect;
@@ -647,20 +654,20 @@ static void DisplayMessages(SDL_Surface *s)
 					}
 #ifdef HAVE_OPENGL
 					if(OGL_IsActive()) {
-						ScriptHUDElements[i].ogl_blitter.Draw(rect);
+						ScriptHUDElements[view][i].ogl_blitter.Draw(rect);
 					}
 					else 
 #endif 
 					{
-						ScriptHUDElements[i].sdl_blitter.Draw(s, rect);
+						ScriptHUDElements[view][i].sdl_blitter.Draw(s, rect);
 					}
 					x2 += icon_skip;
 				}
 				SDL_Color color;
-				_get_interface_color(ScriptHUDElements[i].color+_computer_interface_text_color, &color);
-				DisplayText(x2,Y + (ScriptHUDElements[i].isicon ? icon_drop : 0),ScriptHUDElements[i].text, color.r, color.g, color.b);
+				_get_interface_color(ScriptHUDElements[view][i].color+_computer_interface_text_color, &color);
+				DisplayText(x2,Y + (ScriptHUDElements[view][i].isicon ? icon_drop : 0),ScriptHUDElements[view][i].text, color.r, color.g, color.b);
 				x2 += sk;
-				if(ScriptHUDElements[i].isicon)
+				if(ScriptHUDElements[view][i].isicon)
 					x2 -= icon_skip;
 			}
 			Y += LineSpacing;

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -542,6 +542,10 @@ Calling Triggers = {} at the beginning of the script removes the compatibility t
 </dt>
 <dd><p class="description">When true, the current item counts on the map are updated properly when Lua deletes map items and changes player inventories. This defaults to false to preserve film playback with older scripts. New scripts that manipulate items should always set this to true.</p></dd>
 <dt>
+    .nonlocal_overlays <span class="version">Git</span>
+</dt>
+<dd><p class="description">When false, only the local player's overlays are used, and only prints to the local player will be displayed. When true, the overlays and prints of whatever player is currently being viewed will apply. This defaults to false for compatibility with scripts that depend on the old behavior.</p></dd>
+<dt>
     .time_remaining<span class="access"> (read-only)</span>
 </dt>
 <dd><p class="description">the number of ticks until the game ends, or nil if there is no time limit</p></dd>
@@ -590,6 +594,20 @@ Calling Triggers = {} at the beginning of the script removes the compatibility t
 <dd>
 <p class="description">the date version of the local player's engine</p>
 <p class="note">for example, "20071103" </p>
+</dd>
+<dt>
+    .local_player<span class="access"> (read-only)</span> <span class="version">Git</span>
+</dt>
+<dd>
+<p class="description">The local player.</p>
+<p class="note">normally, you shouldn't need this--you'll just make the game go out of sync </p>
+</dd>
+<dt>
+    .view_player <span class="version">Git</span>
+</dt>
+<dd>
+<p class="description">The player currently being viewed by the local computer.</p>
+<p class="note">Be very careful when using this not to make any decisions that affect the game world (including non-local random numbers), or you will cause a desync </p>
 </dd>
 </dl></dd>
 </dl>
@@ -1539,7 +1557,10 @@ Calling Triggers = {} at the beginning of the script removes the compatibility t
 </dd>
       <dt>:view_player(player) <span class="version">20080707</span>
 </dt>
-<dd><p class="description">switch to another player's view</p></dd>
+<dd>
+<p class="description">switch to another player's view</p>
+<p class="note">You may also write to Game.view_player, if you are only interested in changing the local player's view </p>
+</dd>
       <dt>.weapons</dt>
 <dd><dl>
 <dt>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -470,6 +470,10 @@ Calling Triggers = {} at the beginning of the script removes the compatibility t
 	<description>When true, the current item counts on the map are updated properly when Lua deletes map items and changes player inventories. This defaults to false to preserve film playback with older scripts. New scripts that manipulate items should always set this to true.</description>
 	<type>boolean</type>
       </variable>
+      <variable name="nonlocal_overlays" version="Git">
+	<description>When false, only the local player's overlays are used, and only prints to the local player will be displayed. When true, the overlays and prints of whatever player is currently being viewed will apply. This defaults to false for compatibility with scripts that depend on the old behavior.</description>
+	<type>boolean</type>
+      </variable>
       <variable name="time_remaining" access="read-only">
 	<description>the number of ticks until the game ends, or nil if there is no time limit</description>
 	<type>number</type>
@@ -518,6 +522,16 @@ Calling Triggers = {} at the beginning of the script removes the compatibility t
       <variable name="version" access="read-only">
 	<description>the date version of the local player's engine</description>
 	<note>for example, "20071103"</note>
+      </variable>
+      <variable name="local_player" version="Git" access="read-only">
+	<description>The local player.</description>
+	<type>Player</type>
+	<note>normally, you shouldn't need this--you'll just make the game go out of sync</note>
+      </variable>
+      <variable name="view_player" version="Git">
+        <description>The player currently being viewed by the local computer.</description>
+        <type>Player</type>
+        <note>Be very careful when using this not to make any decisions that affect the game world (including non-local random numbers), or you will cause a desync</note>
       </variable>
     </table>
     <table name="goal">
@@ -1378,6 +1392,7 @@ Calling Triggers = {} at the beginning of the script removes the compatibility t
       <function name="view_player" version="20080707">
 	<description>switch to another player's view</description>
 	<argument name="player"><type>player</type></argument>
+        <note>You may also write to Game.view_player, if you are only interested in changing the local player's view</note>
       </function>
       <subtable name="weapons">
 	<variable name="current" access="read-only">


### PR DESCRIPTION
Back when I first added Lua overlays, there were no HUD scaling options. When they were added, Lua overlays and "prints" were left in the past. When playing in 1080p, potentially critical script-related information became very easy to miss. This PR makes the "on-screen font" text size scale under the same circumstances as the HUD, thus making all script-driven information channels more or less equally visible at different resolutions. (People who are attached to tiny text are invited to change the on-screen font to a smaller one via MML.)

As a side note, overlays now adapt to different on-screen font settings in a sane way. Previously, many aspects of their positioning were hard-coded...

Finally, because I was an idiot when I originally wrote the code, the Lua overlays only ever displayed overlays for the local player, even when viewing another player. This PR also makes it so that overlays are actually tracked for all players, and displays whichever set of overlays is applicable for the currently-viewed player. (This is important in co-op, team games, and film playback.)

This PR should not affect film playback, saved games, or network games, and has no known unintended side effects.
