### PR TITLE
Add Header Test developer tool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -310,6 +310,7 @@ Source_Files/Sound/Makefile
 Source_Files/TCPMess/Makefile
 Source_Files/XML/Makefile
 tools/Makefile
+tools/headertest/GNUmakefile
 data/Makefile
 data/default_theme/Makefile
 data/icons/Makefile

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,5 +1,7 @@
 ## Process this file with automake to produce Makefile.in 
 
+EXTRA_DIST = headertest/README
+
 # these are currently broken
 # noinst_PROGRAMS = single2forks forks2single dumprsrcmap dumpwad
 #dumprsrcmap_SOURCES = dumprsrcmap.cpp

--- a/tools/headertest/GNUmakefile.in
+++ b/tools/headertest/GNUmakefile.in
@@ -1,0 +1,80 @@
+# Requires GNU Make 3.81+ (preferably 4.0+ for option -O support)
+
+# Default to "keep going" mode, parallel execution, and grouping output by target
+MAKEFLAGS = -k -j -O
+
+# Build-config variables
+CPPFLAGS = @CPPFLAGS@
+CXX = @CXX@
+CXXFLAGS = @CXXFLAGS@
+DEFS = @DEFS@
+srcdir = @srcdir@
+top_srcdir = @top_srcdir@
+abs_builddir = @abs_builddir@
+top_builddir = @top_builddir@
+abs_top_builddir = @abs_top_builddir@
+
+SFDir := $(top_srcdir)/Source_Files
+DepsDir := cache/.deps
+
+
+# --------------
+# Scope Settings
+# --------------
+
+# Parent directories of all headers in the Source_Files tree we want to cover
+# - currently this is just the entire Source_Files tree except Expat
+HeaderDirs := $(strip $(shell find $(SFDir) -type d ! -path $(SFDir)/Expat -print -o -prune))
+
+# Customized header lists for specific directories (overrides the default '*.h' selection)
+# - format: <dir>-Headers := <non-empty header list>
+$(SFDir)/Lua-Headers := $(wildcard $(SFDir)/Lua/lua_*.h)
+
+Headers := $(foreach dir,$(HeaderDirs),$(or $($(dir)-Headers),$(wildcard $(dir)/*.h)))
+
+# Header targets: paths to headers in the Source_Files tree, relative to Source_Files
+HeaderTargets := $(Headers:$(SFDir)/%=%)
+
+
+# --------------------
+# Compilation Settings
+# --------------------
+
+# [User-specified variable] Extra options to be appended to the compile command; defaults to empty
+# - this variable is intentionally not tracked as a dependency
+z =
+
+# Include dirs normally specified in AM_CPPFLAGS in .am files and implicitly by Automake
+# - skip conditionally including Expat; only LibNAT/upnp.c #includes expat.h
+AMIncludeDirs := $(top_builddir) $(HeaderDirs)
+
+TestOptions := -x c++ -fsyntax-only -fdiagnostics-color
+BasicCxxCmd := $(CXX) $(DEFS) $(AMIncludeDirs:%=-I%) $(CPPFLAGS) $(CXXFLAGS) $(TestOptions) $(z)
+
+
+# -------
+# Targets
+# -------
+
+.PHONY: all $(HeaderTargets) clean
+
+all: $(HeaderTargets) ;
+
+$(HeaderTargets): %: cache/%.test ;
+
+clean:
+	rm -rf cache
+
+# Test completion file for header target %
+cache/%.test: GNUmakefile
+	@mkdir -p $(@D) $(DepsDir)/$(*D) && \
+	$(BasicCxxCmd) -MD -MP -MT $@ -MF $(DepsDir)/$*.d.tmp $(SFDir)/$* && \
+	mv -f $(DepsDir)/$*.d.tmp $(DepsDir)/$*.d && \
+	touch $@
+
+GNUmakefile: $(srcdir)/GNUmakefile.in $(top_builddir)/config.status
+	@cd $(top_builddir) && ./config.status $(abs_builddir:$(abs_top_builddir)/%=%)/GNUmakefile
+
+
+# Include any existing dep files
+-include $(HeaderTargets:%=$(DepsDir)/%.d)

--- a/tools/headertest/README
+++ b/tools/headertest/README
@@ -1,0 +1,30 @@
+# Header Test Developer Tool #
+
+Requires GNU Make 3.81+
+
+This makefile compiles Aleph One headers individually in order to catch 
+missing #include dependencies for the current build configuration.
+
+Usage: run configure to generate the build configuration-specific makefile in 
+<build root>/tools/headertest/, then run make from that directory.
+
+Targets:
+  all      - (default) compiles all headers in scope
+  <header> - compiles <header>, relative to Source_Files (e.g. Misc/vbl.h)
+  clean    - deletes cache/
+
+Headers in scope (recalculated on every invocation):
+  - all .h files in the Source_Files tree, outside of Expat and Lua
+  - Source_Files/Lua/lua_*.h
+
+Headers are compiled as C++ using the current build configuration. Successful 
+compilation results are stored in cache/ to speed up later invocations.
+
+Additional compiler options can be given by passing 'z=<extra options>' as a 
+single argument to make (quote if necessary). To accommodate rapid 
+adjustments to options that control diagnostic formatting, these extra 
+options are not tracked as a dependency (no recompiles if 'z=...' changes).
+
+The makefile uses options '-k -j -O' ("keep going" mode, parallel execution, 
+and grouping output by target) by default; this can be overridden by passing 
+'MAKEFLAGS=' as an argument. -O has an effect only with GNU Make 4.0+.


### PR DESCRIPTION
This is a makefile that compiles headers to catch missing #includes. An initial run tests 232 headers, which takes about 14 s on my machine (in a VirtualBox environment).