### PR TITLE
Overhaul DEBUG_FAST_CODE, clean up dependencies, and fix Windows build warning

### DIFF
--- a/Source_Files/CSeries/csalerts.h
+++ b/Source_Files/CSeries/csalerts.h
@@ -91,4 +91,13 @@ void alert_corrupted_map(int error) { alert_user_fatal(128, 23, error); }
 #define vwarn(what,message) ((void) 0)
 #endif
 
+// "fast code" assert: disabled by default, enabled under DEBUG_FAST_CODE
+#ifdef DEBUG_FAST_CODE
+#define fc_assert(what) assert(what)
+#define fc_vassert(what,message) vassert(what,message)
+#else
+#define fc_assert(what) ((void) 0)
+#define fc_vassert(what,message) ((void) 0)
+#endif
+
 #endif

--- a/Source_Files/CSeries/csalerts.h
+++ b/Source_Files/CSeries/csalerts.h
@@ -23,6 +23,8 @@
 #ifndef _CSERIES_ALERTS_
 #define _CSERIES_ALERTS_
 
+#include "cstypes.h"
+
 #if defined(__GNUC__)
 #define NORETURN __attribute__((noreturn))
 #else

--- a/Source_Files/GameWorld/world.cpp
+++ b/Source_Files/GameWorld/world.cpp
@@ -52,12 +52,6 @@ Jul 1, 2000 (Loren Petrich):
 	Inlined the angle normalization; doing it automatically for all the functions that work with angles
 */
 
-#ifndef DEBUG_FAST_CODE
-#undef DEBUG
-// #undef assert(x)
-#undef assert
-#define assert(x) 
-#endif
 #include "cseries.h"
 #include "world.h"
 #include "FilmProfile.h"
@@ -101,7 +95,7 @@ world_point2d *translate_point2d(
 {
 	// LP change: idiot-proofed this
 	theta = normalize_angle(theta);
-	assert(cosine_table[0]==TRIG_MAGNITUDE);
+	fc_assert(cosine_table[0]==TRIG_MAGNITUDE);
 	
 	point->x+= (distance*cosine_table[theta])>>TRIG_SHIFT;
 	point->y+= (distance*sine_table[theta])>>TRIG_SHIFT;
@@ -139,7 +133,7 @@ world_point2d *rotate_point2d(
 	long_vector2d temp;
 	
 	theta = normalize_angle(theta);
-	assert(cosine_table[0]==TRIG_MAGNITUDE);
+	fc_assert(cosine_table[0]==TRIG_MAGNITUDE);
 	
 	temp.i= int32(point->x)-int32(origin->x);
 	temp.j= int32(point->y)-int32(origin->y);
@@ -161,7 +155,7 @@ world_point2d *transform_point2d(
 	long_vector2d temp;
 	
 	theta = normalize_angle(theta);
-	assert(cosine_table[0]==TRIG_MAGNITUDE);
+	fc_assert(cosine_table[0]==TRIG_MAGNITUDE);
 	
 	temp.i= int32(point->x)-int32(origin->x);
 	temp.j= int32(point->y)-int32(origin->y);
@@ -217,7 +211,7 @@ void build_trig_tables(
 	sine_table= (int16 *) malloc(sizeof(int16)*NUMBER_OF_ANGLES);
 	cosine_table= (int16 *) malloc(sizeof(int16)*NUMBER_OF_ANGLES);
 	tangent_table= (int32 *) malloc(sizeof(int32)*NUMBER_OF_ANGLES);
-	assert(sine_table&&cosine_table&&tangent_table);
+	fc_assert(sine_table&&cosine_table&&tangent_table);
 	
 	for (i=0;i<NUMBER_OF_ANGLES;++i)
 	{
@@ -689,7 +683,7 @@ world_point2d *transform_overflow_point2d(
 	long_vector2d temp, tempr;
 	
 	theta = normalize_angle(theta);
-	assert(cosine_table[0]==TRIG_MAGNITUDE);
+	fc_assert(cosine_table[0]==TRIG_MAGNITUDE);
 	
 	temp.i= int32(point->x)-int32(origin->x);
 	temp.j= int32(point->y)-int32(origin->y);

--- a/Source_Files/LibNAT/os_win.c
+++ b/Source_Files/LibNAT/os_win.c
@@ -228,7 +228,7 @@ static int Initialize_Winsock_Library()
    set during the WSAStartup phase, and detect if we
    are using the winsock 1.1 version of the library or
    newer */
-static Is_Valid_Library(WSADATA * wsaData)
+static int Is_Valid_Library(WSADATA * wsaData)
 {
   float socklib_ver;
   socklib_ver = HIBYTE(wsaData->wVersion)/10.0F;

--- a/Source_Files/ModelView/Model3D.h
+++ b/Source_Files/ModelView/Model3D.h
@@ -25,6 +25,8 @@
 #ifndef MODEL_3D
 #define MODEL_3D
 
+#include "cseries.h"
+
 using namespace std;
 
 #ifdef HAVE_OPENGL

--- a/Source_Files/RenderMain/OGL_FBO.h
+++ b/Source_Files/RenderMain/OGL_FBO.h
@@ -22,6 +22,8 @@
 	Framebuffer Object utilities
 */
 
+#include "cseries.h"
+
 #ifdef HAVE_OPENGL
 
 #include "OGL_Headers.h"

--- a/Source_Files/RenderMain/low_level_textures.h
+++ b/Source_Files/RenderMain/low_level_textures.h
@@ -464,7 +464,7 @@ void tint_vertical_polygon_lines(
 
 	extern SDL_Surface *world_pixels;
 	
-	assert(tint_table_index>=0 && tint_table_index<number_of_shading_tables);
+	fc_assert(tint_table_index>=0 && tint_table_index<number_of_shading_tables);
 
 	while ((line_count-= 1)>=0)
 	{

--- a/Source_Files/RenderMain/low_level_textures.h
+++ b/Source_Files/RenderMain/low_level_textures.h
@@ -30,6 +30,75 @@ Jan 30, 2000 (Loren Petrich):
 	Removed some "static" declarations that conflict with "extern"
 */
 
+#include "cseries.h"
+#include "preferences.h"
+#include "textures.h"
+#include "scottish_textures.h"
+
+/* ---------- global state */
+
+inline uint16 & texture_random_seed()
+{
+	static uint16 seed = 6906;
+	return seed;
+}
+
+/* ---------- texture horizontal polygon */
+
+#define HORIZONTAL_WIDTH_SHIFT 7 /* 128 (8 for 256) */
+#define HORIZONTAL_HEIGHT_SHIFT 7 /* 128 */
+#define HORIZONTAL_FREE_BITS (32-TRIG_SHIFT-WORLD_FRACTIONAL_BITS)
+#define HORIZONTAL_WIDTH_DOWNSHIFT (32-HORIZONTAL_WIDTH_SHIFT)
+#define HORIZONTAL_HEIGHT_DOWNSHIFT (32-HORIZONTAL_HEIGHT_SHIFT)
+
+struct _horizontal_polygon_line_header
+{
+	int32 y_downshift;
+};
+
+struct _horizontal_polygon_line_data
+{
+	uint32 source_x, source_y;
+	uint32 source_dx, source_dy;
+	
+	void *shading_table;
+};
+
+/* ---------- texture vertical polygon */
+
+#define VERTICAL_TEXTURE_WIDTH 128
+#define VERTICAL_TEXTURE_WIDTH_BITS 7
+#define VERTICAL_TEXTURE_WIDTH_FRACTIONAL_BITS (FIXED_FRACTIONAL_BITS-VERTICAL_TEXTURE_WIDTH_BITS)
+#define VERTICAL_TEXTURE_ONE (1<<VERTICAL_TEXTURE_WIDTH_FRACTIONAL_BITS)
+#define VERTICAL_TEXTURE_FREE_BITS FIXED_FRACTIONAL_BITS
+#define VERTICAL_TEXTURE_DOWNSHIFT (32-VERTICAL_TEXTURE_WIDTH_BITS)
+
+struct _vertical_polygon_data
+{
+	int16 downshift;
+	int16 x0;
+	int16 width;
+	
+	int16 pad;
+};
+
+struct _vertical_polygon_line_data
+{
+	void *shading_table;
+	pixel8 *texture;
+	int32 texture_y, texture_dy;
+};
+
+/* ---------- code */
+
+// Find the next lower power of 2, and return the exponent
+inline int NextLowerExponent(int n)
+{
+	int xp = 0;
+	while(n > 1) {n >>= 1; xp++;}
+	return xp;
+}
+
 template <typename T>
 inline T average(T fg, T bg)
 {
@@ -517,7 +586,7 @@ void randomize_vertical_polygon_lines(
 	register short bytes_per_row= screen->bytes_per_row;
 	int line_count= data->width;
 	int x= data->x0;
-	register uint16 seed= texture_random_seed;
+	register uint16 seed= texture_random_seed();
 	register uint16 drop_less_than= transfer_data;
 
 	(void) (view);
@@ -546,5 +615,5 @@ void randomize_vertical_polygon_lines(
 		x+= 1;
 	}
 	
-	texture_random_seed= seed;
+	texture_random_seed() = seed;
 }

--- a/Source_Files/RenderMain/render.h
+++ b/Source_Files/RenderMain/render.h
@@ -41,6 +41,7 @@ Nov 12, 2000 (Loren Petrich):
 
 #include "world.h"	
 #include "textures.h"
+#include "scottish_textures.h"
 // Stuff to control the view
 #include "ViewControl.h"
 
@@ -48,9 +49,6 @@ Nov 12, 2000 (Loren Petrich):
 
 /* the distance behind which we are not required to draw objects */
 #define MINIMUM_OBJECT_DISTANCE ((short)(WORLD_ONE/20))
-
-#define MINIMUM_VERTICES_PER_SCREEN_POLYGON ((short)3)
-#define MAXIMUM_VERTICES_PER_SCREEN_POLYGON ((short)16)
 
 // LP change: suppressed going/leaving states, because of alternative way of
 // adjusting the FOV.
@@ -79,12 +77,6 @@ enum /* shading tables */
 
 
 /* ---------- structures */
-
-struct point2d
-{
-	short x, y;
-};
-typedef struct point2d point2d;
 
 struct definition_header
 {
@@ -196,8 +188,6 @@ void check_m1_exploration(void);
 /* ----------- prototypes/SCREEN.C */
 void render_overhead_map(struct view_data *view);
 void render_computer_interface(struct view_data *view);
-
-#include "scottish_textures.h"
 
 // LP: definitions moved up here because they are referred to
 // outside of render.c, where they are defined.

--- a/Source_Files/RenderMain/scottish_textures.cpp
+++ b/Source_Files/RenderMain/scottish_textures.cpp
@@ -111,19 +111,6 @@ not only that, but texture_horizontal_polygon() is actually faster than texture_
 */
 
 #include "cseries.h"
-#if defined(__GNUC__)
-#ifndef DEBUG_FAST_CODE
-#undef DEBUG
-#undef assert
-#define assert(x)
-#undef vassert
-#define vassert(x...) 
-#undef csprintf
-#define csprintf(x...) 
-#undef vhalt
-#define vhalt(x...)
-#endif
-#endif
 #include "render.h"
 #include "Rasterizer_SW.h"
 
@@ -199,6 +186,12 @@ struct _vertical_polygon_line_data
 };
 
 /* ---------- macros */
+
+#if defined(DEBUG) && defined(DEBUG_FAST_CODE)
+#define VHALT_DEBUG(message) vhalt(message)
+#else
+#define VHALT_DEBUG(message) ((void)0)
+#endif
 
 // i0 + i1 == MAX(i0, i1) + MIN(i0, i1)/2
 //#define calculate_shading_table(result, view, shading_tables, depth, ambient_shade)
@@ -281,7 +274,7 @@ void allocate_texture_tables(
 	scratch_table0= new short[MAXIMUM_SCRATCH_TABLE_ENTRIES];
 	scratch_table1= new short[MAXIMUM_SCRATCH_TABLE_ENTRIES];
 	precalculation_table= (void*)new char[MAXIMUM_PRECALCULATION_TABLE_ENTRY_SIZE*MAXIMUM_SCRATCH_TABLE_ENTRIES];
-	assert(scratch_table0&&scratch_table1&&precalculation_table);
+	fc_assert(scratch_table0&&scratch_table1&&precalculation_table);
 }
 
 void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& textured_polygon)
@@ -290,7 +283,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 	short vertex, highest_vertex, lowest_vertex;
 	point2d *vertices= polygon->vertices;
 
-	assert(polygon->vertex_count>=MINIMUM_VERTICES_PER_SCREEN_POLYGON&&polygon->vertex_count<MAXIMUM_VERTICES_PER_SCREEN_POLYGON);
+	fc_assert(polygon->vertex_count>=MINIMUM_VERTICES_PER_SCREEN_POLYGON&&polygon->vertex_count<MAXIMUM_VERTICES_PER_SCREEN_POLYGON);
 
 	/* if we get static, tinted or landscaped transfer modes punt to the vertical polygon mapper */
 	if (polygon->transfer_mode == _static_transfer) {
@@ -324,7 +317,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 		left_vertex= right_vertex= highest_vertex; /* both sides start at the highest vertex */
 		total_line_count= vertices[lowest_vertex].y-vertices[highest_vertex].y; /* calculate vertical line count */
 
-		assert(total_line_count<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* make sure we have enough scratch space */
+		fc_assert(total_line_count<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* make sure we have enough scratch space */
 		
 		/* precalculate high and low y-coordinates for every x-coordinate */			
 		aggregate_total_line_count= total_line_count;
@@ -365,18 +358,18 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
               //AS: moving delta declaration up to where it's needed. Isn't C++ wonderful?
 			/* advance by the minimum of left_line_count and right_line_count */
 			short delta= MIN(left_line_count, right_line_count);
-			assert(delta);
+			fc_assert(delta);
 //			dprintf("tc=%d lc=%d rc=%d delta=%d", total_line_count, left_line_count, right_line_count, delta);
 			total_line_count-= delta;
 			left_line_count-= delta;
 			right_line_count-= delta;
 			
-			assert(delta||!total_line_count); /* if our delta is zero, weÕd better be out of lines */
+			fc_assert(delta||!total_line_count); /* if our delta is zero, weÕd better be out of lines */
 		}
 		
 		/* make sure every coordinate is accounted for in our tables */
-		assert(aggregate_right_line_count==aggregate_total_line_count);
-		assert(aggregate_left_line_count==aggregate_total_line_count);
+		fc_assert(aggregate_right_line_count==aggregate_total_line_count);
+		fc_assert(aggregate_left_line_count==aggregate_total_line_count);
 
 		/* precalculate mode-specific data */
 		switch (polygon->transfer_mode)
@@ -394,7 +387,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 				break;
 			
 			default:
-				vhalt(csprintf(temporary, "horizontal_polygons dont support mode #%d", polygon->transfer_mode));
+				VHALT_DEBUG(csprintf(temporary, "horizontal_polygons dont support mode #%d", polygon->transfer_mode));
 		}
 		
 		/* render all lines */
@@ -414,7 +407,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 						break;
 						
 					default:
-						assert(false);
+						fc_assert(false);
 						break;
 				}
 				break;
@@ -449,7 +442,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 							vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count);
 						break;
 					default:
-						assert(false);
+						fc_assert(false);
 						break;
 				}
 				break;
@@ -489,13 +482,13 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 						break;
 					
 					default:
-						assert(false);
+						fc_assert(false);
 						break;
 				}
 				break;
 
 			default:
-				assert(false);
+				fc_assert(false);
 				break;
 		}
 	}
@@ -507,7 +500,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 	short vertex, highest_vertex, lowest_vertex;
 	point2d *vertices= polygon->vertices;
 
-	assert(polygon->vertex_count>=MINIMUM_VERTICES_PER_SCREEN_POLYGON&&polygon->vertex_count<MAXIMUM_VERTICES_PER_SCREEN_POLYGON);
+	fc_assert(polygon->vertex_count>=MINIMUM_VERTICES_PER_SCREEN_POLYGON&&polygon->vertex_count<MAXIMUM_VERTICES_PER_SCREEN_POLYGON);
 
     if (polygon->transfer_mode == _big_landscaped_transfer) {
         texture_horizontal_polygon(textured_polygon);
@@ -544,7 +537,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 		left_vertex= right_vertex= highest_vertex; /* both sides start at the highest vertex */
 		total_line_count= vertices[lowest_vertex].x-vertices[highest_vertex].x; /* calculate vertical line count */
 
-		assert(total_line_count<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* make sure we have enough scratch space */
+		fc_assert(total_line_count<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* make sure we have enough scratch space */
 		
 		/* precalculate high and low y-coordinates for every x-coordinate */			
 		aggregate_total_line_count= total_line_count;
@@ -584,17 +577,17 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 			
 			/* advance by the minimum of left_line_count and right_line_count */
 			short delta= MIN(left_line_count, right_line_count);
-			assert(delta);
+			fc_assert(delta);
 			total_line_count-= delta;
 			left_line_count-= delta;
 			right_line_count-= delta;
 			
-			assert(delta||!total_line_count); /* if our delta is zero, weÕd better be out of lines */
+			fc_assert(delta||!total_line_count); /* if our delta is zero, weÕd better be out of lines */
 		}
 		
 		/* make sure every coordinate is accounted for in our tables */
-		assert(aggregate_right_line_count==aggregate_total_line_count);
-		assert(aggregate_left_line_count==aggregate_total_line_count);
+		fc_assert(aggregate_right_line_count==aggregate_total_line_count);
+		fc_assert(aggregate_left_line_count==aggregate_total_line_count);
 
 		/* precalculate mode-specific data */
 
@@ -602,7 +595,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
           {
               _pretexture_vertical_polygon_lines(polygon, screen, view, (struct _vertical_polygon_data *)precalculation_table, vertices[highest_vertex].x, left_table, right_table, aggregate_total_line_count);
           }
-          else vhalt(csprintf(temporary, "vertical_polygons dont support mode #%d", polygon->transfer_mode));
+          else VHALT_DEBUG(csprintf(temporary, "vertical_polygons dont support mode #%d", polygon->transfer_mode));
           
 		/* render all lines */
 		switch (bit_depth)
@@ -624,7 +617,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 						break;
 						
 				default:
-					assert(false);
+					fc_assert(false);
 					break;
 				}
 				break;
@@ -672,7 +665,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 					}
 					break;
 				default:
-					assert(false);
+					fc_assert(false);
 					break;
 				}
 				break;
@@ -718,13 +711,13 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 						break;
 						
 				default:
-					assert(false);
+					fc_assert(false);
 					break;
 				}
 				break;
 				
 		default:
-			assert(false);
+			fc_assert(false);
 			break;
 		}
 	}
@@ -830,7 +823,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 						break;
 					
 					default:
-						vhalt(csprintf(temporary, "rectangles dont support mode #%d", rectangle->transfer_mode));
+						VHALT_DEBUG(csprintf(temporary, "rectangles dont support mode #%d", rectangle->transfer_mode));
 				}
 		
 				for (; screen_width; --screen_width)
@@ -847,7 +840,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 					if (FIXED_INTEGERAL_PART(texture_y0)<first)
 					{
 						delta= (INTEGER_TO_FIXED(first) - texture_y0)/texture_dy + 1;
-						vassert(delta>=0, csprintf(temporary, "[%x,%x] ¶=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
+						fc_vassert(delta>=0, csprintf(temporary, "[%x,%x] ¶=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
 						
 						y0= MIN(y1, y0+delta);
 						texture_y+= delta*texture_dy;
@@ -856,7 +849,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 					if (FIXED_INTEGERAL_PART(texture_y1)>last)
 					{
 						delta= (texture_y1 - INTEGER_TO_FIXED(last))/texture_dy + 1;
-						vassert(delta>=0, csprintf(temporary, "[%x,%x] ¶=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
+						fc_vassert(delta>=0, csprintf(temporary, "[%x,%x] ¶=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
 						
 						y1= MAX(y0, y1-delta);
 					}
@@ -872,10 +865,10 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 					*y0_table++= y0;
 					*y1_table++= y1;
 					
-					assert(y0<=y1);
-					assert(y0>=0 && y1>=0);
-					assert(y0<=screen->height);
-					assert(y1<=screen->height);
+					fc_assert(y0<=y1);
+					fc_assert(y0>=0 && y1>=0);
+					fc_assert(y0<=screen->height);
+					fc_assert(y1<=screen->height);
 				}
 		
 				switch (bit_depth)
@@ -899,7 +892,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 								break;
 							
 							default:
-								assert(false);
+								fc_assert(false);
 								break;
 						}
 						break;
@@ -922,7 +915,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 								break;
 							
 							default:
-								assert(false);
+								fc_assert(false);
 								break;
 						}
 						break;
@@ -946,13 +939,13 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 								break;
 							
 							default:
-								assert(false);
+								fc_assert(false);
 								break;
 						}
 						break;
 		
 					default:
-						assert(false);
+						fc_assert(false);
 						break;
 				}
 			}
@@ -982,7 +975,7 @@ static void _pretexture_vertical_polygon_lines(
 
 	(void) (screen);
 
-	assert(sizeof(struct _vertical_polygon_line_data)<=MAXIMUM_PRECALCULATION_TABLE_ENTRY_SIZE);
+	fc_assert(sizeof(struct _vertical_polygon_line_data)<=MAXIMUM_PRECALCULATION_TABLE_ENTRY_SIZE);
 
 	data->downshift= VERTICAL_TEXTURE_DOWNSHIFT;
 	data->x0= x0;
@@ -1054,7 +1047,7 @@ static void _pretexture_vertical_polygon_lines(
 		if (!adjusted_ty_denominator) adjusted_ty_denominator= 1; /* -1 will still be -1 */
 		ty_delta= - INTEGER_TO_FIXED(adjusted_world_x)/adjusted_ty_denominator;
 		
-		vassert(ty_delta>=0, csprintf(temporary, "ty_delta=W2F(%d)/%d=%d", world_x, unadjusted_ty_denominator, ty_delta));
+		fc_vassert(ty_delta>=0, csprintf(temporary, "ty_delta=W2F(%d)/%d=%d", world_x, unadjusted_ty_denominator, ty_delta));
 
 		/* calculate the shading table for this column */
 		if (polygon->flags&_SHADELESS_BIT)
@@ -1260,7 +1253,7 @@ static short *build_x_table(
 	dx= x1-x0, adx= ABS(dx), dx= SGN(dx);
 	dy= y1-y0, ady= ABS(dy), dy= SGN(dy);
 
-	assert(ady<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* can't overflow table */
+	fc_assert(ady<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* can't overflow table */
 	if (dy>0)
 	{
 		/* setup initial (x,y) location and initialize a pointer to our table */
@@ -1277,7 +1270,7 @@ static short *build_x_table(
 				if (d<0) y+= 1, d+= d_max, *record++= x, ady-= 1;
 				x+= dx, d+= delta_d;
 			}
-			if (ady==1) *record++= x; else assert(!ady);
+			if (ady==1) *record++= x; else fc_assert(!ady);
 		}
 		else
 		{
@@ -1318,7 +1311,7 @@ static short *build_y_table(
 	dx= x1-x0, adx= ABS(dx), dx= SGN(dx);
 	dy= y1-y0, ady= ABS(dy), dy= SGN(dy);
 
-	assert(adx<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* can't overflow table */
+	fc_assert(adx<MAXIMUM_SCRATCH_TABLE_ENTRIES); /* can't overflow table */
 	if (dx>=0) /* vertical lines allowed */
 	{
 		/* setup initial (x,y) location and initialize a pointer to our table */
@@ -1355,7 +1348,7 @@ static short *build_y_table(
 				if (d<0) { x+= dx, d+= d_max, adx-= 1; if (dy>=0) *record++= y; else *--record= y; }
 				y+= 1, d+= delta_d;
 			}
-			if (adx==1) if (dy>=0) *record++= y; else *--record= y; else assert(!adx);
+			if (adx==1) if (dy>=0) *record++= y; else *--record= y; else fc_assert(!adx);
 		}
 	}
 	else

--- a/Source_Files/RenderMain/scottish_textures.h
+++ b/Source_Files/RenderMain/scottish_textures.h
@@ -42,9 +42,15 @@ May 3, 2003 (Br'fin (Jeremy Parsons))
 	instead of abusing/overflowing shape_descriptors
 */
 
+#include "cseries.h"
+#include "OGL_Headers.h"
+#include "world.h"
 #include "shape_descriptors.h"
 
 /* ---------- constants */
+
+#define MINIMUM_VERTICES_PER_SCREEN_POLYGON ((short)3)
+#define MAXIMUM_VERTICES_PER_SCREEN_POLYGON ((short)16)
 
 enum /* transfer modes */
 {
@@ -89,6 +95,11 @@ struct tint_table32
 };
 
 /* ---------- structures */
+
+struct point2d
+{
+	short x, y;
+};
 
 /* ignore multiple shading tables if set */
 #define _SHADELESS_BIT 0x8000


### PR DESCRIPTION
See commit descriptions for detailed explanations.

Some of these changes were aided by the header test tool (#47), and with all changes applied, all headers pass (at least for my build environment).