### PR TITLE
Fix initial positions of mouse sensitivity sliders

### DIFF
--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -1618,7 +1618,7 @@ static void controls_dialog(void *arg)
 	if (theSensitivity <= 0.0f) theSensitivity = 1.0f;
 	theSensitivityLog = std::log(theSensitivity);
 	int theVerticalSliderPosition =
-		(int) ((theSensitivityLog - kMinSensitivityLog) * (1000.0f / kSensitivityLogRange));
+		(int) ((theSensitivityLog - kMinSensitivityLog) * (1000.0f / kSensitivityLogRange) + 0.5f);
 	
 	w_sens_slider* sens_vertical_w = new w_sens_slider(1000, theVerticalSliderPosition);
 	mouse->dual_add(sens_vertical_w->label("Mouse Vertical Sensitivity"), d);
@@ -1630,7 +1630,7 @@ static void controls_dialog(void *arg)
 	if (theSensitivity <= 0.0f) theSensitivity = 1.0f;
 	theSensitivityLog = std::log(theSensitivity);
 	int theHorizontalSliderPosition =
-		(int) ((theSensitivityLog - kMinSensitivityLog) * (1000.0f / kSensitivityLogRange));
+		(int) ((theSensitivityLog - kMinSensitivityLog) * (1000.0f / kSensitivityLogRange) + 0.5f);
 
 	w_sens_slider* sens_horizontal_w = new w_sens_slider(1000, theHorizontalSliderPosition);
 	mouse->dual_add(sens_horizontal_w->label("Mouse Horizontal Sensitivity"), d);


### PR DESCRIPTION
This fixes a tiny UI bug in Preferences where, due to integer truncation, the sensitivity sliders for the mouse get initialized to slightly incorrect positions whenever the Controls dialog is opened.

The bug can be observed by setting the sensitivity sliders to new values, hitting "Accept", then re-opening Controls->Mouse to see that the slider positions are one tick lower than before.