### PR TITLE
Improve mouse delta calculations (pre-action flags)

### DIFF
--- a/Source_Files/Input/mouse_sdl.cpp
+++ b/Source_Files/Input/mouse_sdl.cpp
@@ -40,7 +40,7 @@
 // Global variables
 static bool mouse_active = false;
 static uint8 button_mask = 0;		// Mask of enabled buttons
-static _fixed snapshot_delta_yaw, snapshot_delta_pitch, snapshot_delta_velocity;
+static _fixed snapshot_delta_yaw, snapshot_delta_pitch;
 static _fixed snapshot_delta_scrollwheel;
 static int snapshot_delta_x, snapshot_delta_y;
 
@@ -54,7 +54,7 @@ void enter_mouse(short type)
 	if (type != _keyboard_or_game_pad) {
 		SDL_SetRelativeMouseMode(SDL_TRUE);
 		mouse_active = true;
-		snapshot_delta_yaw = snapshot_delta_pitch = snapshot_delta_velocity = 0;
+		snapshot_delta_yaw = snapshot_delta_pitch = 0;
 		snapshot_delta_scrollwheel = 0;
 		snapshot_delta_x = snapshot_delta_y = 0;
 		button_mask = 0;	// Disable all buttons (so a shot won't be fired if we enter the game with a mouse button down from clicking a GUI widget)
@@ -146,9 +146,9 @@ void test_mouse(short type, uint32 *flags, _fixed *delta_yaw, _fixed *delta_pitc
 	if (mouse_active) {
 		*delta_yaw = snapshot_delta_yaw;
 		*delta_pitch = snapshot_delta_pitch;
-		*delta_velocity = snapshot_delta_velocity;
+		*delta_velocity = 0;  // Mouse-driven player velocity is unimplemented
 
-		snapshot_delta_yaw = snapshot_delta_pitch = snapshot_delta_velocity = 0;
+		snapshot_delta_yaw = snapshot_delta_pitch = 0;
 	} else {
 		*delta_yaw = 0;
 		*delta_pitch = 0;

--- a/Source_Files/Input/mouse_sdl.cpp
+++ b/Source_Files/Input/mouse_sdl.cpp
@@ -159,9 +159,9 @@ void test_mouse(short type, uint32 *flags, _fixed *delta_yaw, _fixed *delta_pitc
 
 		snapshot_delta_yaw = snapshot_delta_pitch = snapshot_delta_velocity = 0;
 	} else {
-	  delta_yaw = 0;
-	  delta_pitch = 0;
-	  delta_velocity = 0;
+		*delta_yaw = 0;
+		*delta_pitch = 0;
+		*delta_velocity = 0;
 	}
 }
 

--- a/Source_Files/shell.h
+++ b/Source_Files/shell.h
@@ -90,7 +90,6 @@ enum // input devices
 {
 	_keyboard_or_game_pad,
 	_mouse_yaw_pitch,
-	_mouse_yaw_velocity,
 	_cybermaxx_input,  // only put "_input" here because it was defined elsewhere.
 	_input_sprocket_only
 };


### PR DESCRIPTION
These commits clean up and make corrections to calculations that govern the input yaw and pitch values _before_ they get encoded into action flags (consequently, there is no compatibility impact).
- Mouse velocity is no longer used (and wasn't being calculated accurately anyway). Yaw/pitch is now proportional to mouse delta (when mouse acceleration is off), scaled such that there is no perceived difference under normal framerate. The effect is that the mouse sensitivity perceived by the player is now framerate-independent, and the mouse handles better under periods of unstable framerate.
- X/Y mouse delta limits in a single frame are almost doubled, up to implementation limits imposed by action flags. This makes it easier to make very hard, rapid turns with the mouse (up to about 44.3° yaw-wise in a single frame, up from 22.5°).
- Vestigial remnants of a bizarre "mouse-controlled player velocity" feature have been removed. This feature makes the player go forward/backward in proportion to mouse Y velocity, but it has not been fully implemented since the M2 source release: 1) it doesn't have a Preferences checkbox; 2) it can't reach maximum forward speed due to incomplete/inappropriate calculations; and 3) it is completely impractical unless you're using a trackball, because you have to keep moving the mouse forward to go forward and looking up/down can only be done with the keyboard. (As a side note, I vaguely remember using this feature (and not liking it much, mainly due to the lower forward speed) in M1 or maybe just the M1 demo... is my memory faulty? Was this implemented in M1?).
