### PR TITLE
Restore yaw/pitch delta limits, centralize clamping

### DIFF
--- a/Source_Files/Input/joystick_sdl.cpp
+++ b/Source_Files/Input/joystick_sdl.cpp
@@ -125,7 +125,7 @@ int process_joystick_axes(int flags, int tick) {
     if (!joystick_active)
         return flags;
 
-	int axis_data[NUMBER_OF_JOYSTICK_MAPPINGS] = { 0, 0, 0, 0 };
+	_fixed axis_data[NUMBER_OF_JOYSTICK_MAPPINGS] = { 0, 0, 0, 0 };
     for (int i = 0; i < NUMBER_OF_JOYSTICK_MAPPINGS; i++) {
 		int axis = input_preferences->joystick_axis_mappings[i];
 		if (axis < 0)
@@ -149,26 +149,7 @@ int process_joystick_axes(int flags, int tick) {
 				break;
 		}
 		
-		// pin to largest d for which both -d and +d can be
-		// represented in 1 action flags bitset
-		float limit = 0.5f - 1.f / (1<<FIXED_FRACTIONAL_BITS);
-		switch (i) {
-			case _joystick_yaw:
-				limit = 0.5f - 1.f / (1<<ABSOLUTE_YAW_BITS);
-				break;
-			case _joystick_pitch:
-				limit = 0.5f - 1.f / (1<<ABSOLUTE_PITCH_BITS);
-				break;
-			case _joystick_velocity:
-				// forward and backward limits are independent and capped,
-				// so there's no need to ensure symmetry
-				limit = 0.5f;
-				break;
-			case _joystick_strafe:
-			default:
-				break;
-		}
-		axis_data[i] = PIN(val, -limit, limit) * FIXED_ONE;
+		axis_data[i] = static_cast<_fixed>(val * FIXED_ONE);
     }
     // we have intelligently set up ways to allow variably throttled movement
     // for these controls

--- a/Source_Files/Input/mouse_sdl.cpp
+++ b/Source_Files/Input/mouse_sdl.cpp
@@ -134,15 +134,6 @@ void mouse_idle(short type)
 		// 1 dy unit = 1 * 2^ABSOLUTE_PITCH_BITS * (360 deg / 2^ANGULAR_BITS)
 		//           = 22.5 deg
 		
-		// Largest dx for which both -dx and +dx can be represented in 1 action flags bitset
-		const float dxLimit = 0.5f - 1.f / (1<<ABSOLUTE_YAW_BITS);  // 0.4921875 dx units (~44.30 deg)
-		
-		// Largest dy for which both -dy and +dy can be represented in 1 action flags bitset
-		const float dyLimit = 0.5f - 1.f / (1<<ABSOLUTE_PITCH_BITS);  // 0.46875 dy units (~10.55 deg)
-		
-		dx = PIN(dx, -dxLimit, dxLimit);
-		dy = PIN(dy, -dyLimit, dyLimit);
-		
 		snapshot_delta_yaw   = static_cast<_fixed>(dx * FIXED_ONE);
 		snapshot_delta_pitch = static_cast<_fixed>(dy * FIXED_ONE);
 	}


### PR DESCRIPTION
This pull request reverts the yaw/pitch delta limits to their original values as essential elements of Marathon gameplay and also cleans up the code a little. See commit description for details. This partially reverts #52 and was prompted by a [discussion](https://github.com/Aleph-One-Marathon/alephone/pull/52#issuecomment-273617613) in its comments.