### PR TITLE
Make no-auto-recentering film/network compatible; fix jerky recentering

### DIFF
--- a/Source_Files/GameWorld/map.h
+++ b/Source_Files/GameWorld/map.h
@@ -201,24 +201,19 @@ struct entry_point
 struct player_start_data 
 {
 	int16 team;
-	int16 identifier; /* [weapon_switch_flag.1] [recenter_flag.1] [identifier.14] */
+	int16 identifier; /* [weapon_switch_flag.1] [UNUSED.1] [identifier.14] */
 	int16 color;
 	char name[MAXIMUM_PLAYER_START_NAME_LENGTH+1]; /* PLAYER_NAME_LENGTH+1 */
 };
 
 enum {
-	_player_start_doesnt_auto_recenter_flag= 0x4000,
 	_player_start_doesnt_auto_switch_weapons_flag= 0x8000
 };
 
-const uint16 player_start_identifier_mask=
-	(uint16)~(_player_start_doesnt_auto_recenter_flag | _player_start_doesnt_auto_switch_weapons_flag);
+const uint16 player_start_identifier_mask = (1<<14) - 1;
 
 int16 player_identifier_value(int16 identifier);
 int16 player_start_identifier_value(const player_start_data * const p);
-bool player_identifier_doesnt_auto_recenter(int16 identifier);
-bool player_start_doesnt_auto_recenter(const player_start_data * const p);
-void set_player_start_doesnt_auto_recenter_status(player_start_data * const p, bool v);
 bool player_identifier_doesnt_auto_switch_weapons(int16 identifier);
 bool player_start_doesnt_auto_switch_Weapons(const player_start_data * const p);
 void set_player_start_doesnt_auto_switch_weapons_status(player_start_data * const p, bool v);
@@ -229,15 +224,6 @@ inline int16 player_identifier_value(int16 identifier)
 
 inline int16 player_start_identifier_value(const player_start_data * const p)
 { return (p)->identifier & player_start_identifier_mask; }
-
-inline bool player_identifier_doesnt_auto_recenter(int16 identifier)
-{ return TEST_FLAG(identifier, _player_start_doesnt_auto_recenter_flag); }
-
-inline bool player_start_doesnt_auto_recenter(const player_start_data * const p)
-{ return TEST_FLAG(p->identifier, _player_start_doesnt_auto_recenter_flag); }
-
-inline void set_player_start_doesnt_auto_recenter_status(player_start_data * const p, bool v)
-{	SET_FLAG(p->identifier, _player_start_doesnt_auto_recenter_flag, v); }
 
 inline bool player_identifier_doesnt_auto_switch_weapons(int16 identifier)
 { return TEST_FLAG(identifier, _player_start_doesnt_auto_switch_weapons_flag); }

--- a/Source_Files/GameWorld/physics.cpp
+++ b/Source_Files/GameWorld/physics.cpp
@@ -307,7 +307,15 @@ uint32 mask_in_absolute_positioning_information(
 		action_flags= SET_ABSOLUTE_YAW(action_flags, encoded_delta)|_absolute_yaw_mode;
 	}
 
-	if ((delta_pitch||variables->vertical_angular_velocity) && !(action_flags&_override_absolute_pitch))
+	// Explicit and automatic recentering do not occur under absolute pitch mode; therefore we
+	// 1) try to always use absolute pitch mode if the user doesn't want auto-recentering; and
+	// 2) always avoid absolute pitch mode while an explicit recentering operation is in progress
+	// (pitch control is necessarily locked out until the recentering completes; no way to cancel)
+	
+	const bool explicitlyRecentering = variables->flags & _RECENTERING_BIT;
+	
+	if ((delta_pitch || variables->vertical_angular_velocity || dont_auto_recenter()) &&
+		!(action_flags & _override_absolute_pitch) && !explicitlyRecentering)
 	{
 		int sign_pitch = 1.0;
 		if (delta_pitch < 0)
@@ -611,24 +619,21 @@ static void physics_update(
 		/* handle looking up and down; if weÕre moving at our terminal velocity forward or backward,
 			without any side-to-side motion, recenter our head vertically */
 
-        // ZZZ: only do auto-recentering if the user wants it
-        if(!PLAYER_DOESNT_AUTO_RECENTER(player)) {
-            if (!(action_flags&FLAGS_WHICH_PREVENT_RECENTERING)) /* canÕt recenter if any of these are true */
-		    {
-			    if (((action_flags&_moving_forward) && (variables->velocity==constants->maximum_forward_velocity)) ||
-				    ((action_flags&_moving_backward) && (variables->velocity==-constants->maximum_backward_velocity)))
-			    {
-				    if (variables->elevation<0)
-				    {
-					    variables->elevation= CEILING(variables->elevation+constants->angular_recentering_velocity, 0);
-				    }
-				    else
-				    {
-					    variables->elevation= FLOOR(variables->elevation-constants->angular_recentering_velocity, 0);
-				    }
-			    }
-		    }
-        }
+		if (!(action_flags&FLAGS_WHICH_PREVENT_RECENTERING)) /* canÕt recenter if any of these are true */
+		{
+			if (((action_flags&_moving_forward) && (variables->velocity==constants->maximum_forward_velocity)) ||
+				((action_flags&_moving_backward) && (variables->velocity==-constants->maximum_backward_velocity)))
+			{
+				if (variables->elevation<0)
+				{
+					variables->elevation= CEILING(variables->elevation+constants->angular_recentering_velocity, 0);
+				}
+				else
+				{
+					variables->elevation= FLOOR(variables->elevation-constants->angular_recentering_velocity, 0);
+				}
+			}
+		}
 
 		switch (action_flags&_looking_vertically)
 		{

--- a/Source_Files/GameWorld/player.cpp
+++ b/Source_Files/GameWorld/player.cpp
@@ -441,7 +441,6 @@ short new_player(
 	player->extravision_duration= 0;
 	player->identifier= player_identifier_value(identifier);
 
-	SET_PLAYER_DOESNT_AUTO_RECENTER_STATUS(player, player_identifier_doesnt_auto_recenter(identifier));
 	SET_PLAYER_DOESNT_AUTO_SWITCH_WEAPONS_STATUS(player, player_identifier_doesnt_auto_switch_weapons(identifier));
 	
 	/* initialize inventory */	

--- a/Source_Files/GameWorld/player.h
+++ b/Source_Files/GameWorld/player.h
@@ -298,7 +298,6 @@ struct physics_variables
 };
 
 enum { /* Player flags */
-	_player_doesnt_auto_recenter_flag= 0x0040,
 	_player_doesnt_auto_switch_weapons_flag= 0x0080,
 	_player_is_interlevel_teleporting_flag= 0x0100,
 	_player_has_cheated_flag= 0x0200,
@@ -310,7 +309,7 @@ enum { /* Player flags */
 	_player_is_pfhortran_controlled_flag= 0x8000
 };
 
-#define PLAYER_PERSISTANT_FLAGS (_player_has_cheated_flag | _player_doesnt_auto_recenter_flag | _player_doesnt_auto_switch_weapons_flag)
+#define PLAYER_PERSISTANT_FLAGS (_player_has_cheated_flag | _player_doesnt_auto_switch_weapons_flag)
 
 #define PLAYER_IS_DEAD(p) ((p)->flags&_player_is_dead_flag)
 #define SET_PLAYER_DEAD_STATUS(p,v) ((void)((v)?((p)->flags|=(uint16)_player_is_dead_flag):((p)->flags&=(uint16)~_player_is_dead_flag)))
@@ -337,9 +336,6 @@ enum { /* Player flags */
 #define PLAYER_HAS_CHEATED(p) ((p)->flags&_player_has_cheated_flag)
 #define SET_PLAYER_HAS_CHEATED(p) ((p)->flags|=(uint16)_player_has_cheated_flag)
 
-#define PLAYER_DOESNT_AUTO_RECENTER(p) ((p)->flags&_player_doesnt_auto_recenter_flag)
-#define SET_PLAYER_DOESNT_AUTO_RECENTER_STATUS(p,v) ((void)((v)?((p)->flags|=(uint16)_player_doesnt_auto_recenter_flag):((p)->flags&=(uint16)~_player_doesnt_auto_recenter_flag)))
-
 #define PLAYER_DOESNT_AUTO_SWITCH_WEAPONS(p) ((p)->flags&_player_doesnt_auto_switch_weapons_flag)
 #define SET_PLAYER_DOESNT_AUTO_SWITCH_WEAPONS_STATUS(p,v) ((void)((v)?((p)->flags|=(uint16)_player_doesnt_auto_switch_weapons_flag):((p)->flags&=(uint16)~_player_doesnt_auto_switch_weapons_flag)))
 
@@ -360,7 +356,7 @@ struct damage_record
 struct player_data
 {
 	int16 identifier;
-	int16 flags; /* [unused.1] [dead.1] [zombie.1] [totally_dead.1] [map.1] [teleporting.1] [unused.10] */
+	int16 flags; // Player flags
 
 	int16 color;
 	int16 team;

--- a/Source_Files/Misc/interface.cpp
+++ b/Source_Files/Misc/interface.cpp
@@ -520,7 +520,6 @@ static void construct_single_player_start(player_start_data* outStartArray, shor
         outStartArray[0].identifier = 0;
         strncpy(outStartArray[0].name, player_preferences->name, MAXIMUM_PLAYER_START_NAME_LENGTH+1);
 				
-        set_player_start_doesnt_auto_recenter_status(&outStartArray[0], dont_auto_recenter());
         set_player_start_doesnt_auto_switch_weapons_status(&outStartArray[0], dont_switch_to_new_weapon());
 }
 
@@ -657,8 +656,6 @@ static void synchronize_players_with_starts(const player_start_data* inStartArra
                         thePlayer->identifier = player_identifier_value(inStartArray[s].identifier);
                         strncpy(thePlayer->name, inStartArray[s].name, MAXIMUM_PLAYER_NAME_LENGTH+1);
 
-                        SET_PLAYER_DOESNT_AUTO_RECENTER_STATUS(thePlayer,
-                            player_identifier_doesnt_auto_recenter(inStartArray[s].identifier));
                         SET_PLAYER_DOESNT_AUTO_SWITCH_WEAPONS_STATUS(thePlayer,
                             player_identifier_doesnt_auto_switch_weapons(inStartArray[s].identifier));
 

--- a/Source_Files/Misc/interface.h
+++ b/Source_Files/Misc/interface.h
@@ -444,11 +444,10 @@ void ResetFieldOfView();
 // LP change: modification of Josh Elsasser's dont-switch-weapons patch
 bool dont_switch_to_new_weapon();
 
-// ZZZ: corresponds with dont_switch_to_new_weapon()
 bool dont_auto_recenter();
 
 // ZZZ: let code disable (standardize)/enable behavior modifiers like
-// dont_switch and dont_auto_recenter
+// dont_switch
 void standardize_player_behavior_modifiers();
 void restore_custom_player_behavior_modifiers();
 

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -1715,22 +1715,22 @@ static void controls_dialog(void *arg)
 	general_table->dual_add(always_swim_w->label("Always Swim"), d);
 	general_table->dual_add(always_swim_w, d);
 
+	w_toggle* auto_recenter_w = new w_toggle(!(input_preferences->modifiers & _inputmod_dont_auto_recenter));
+	general_table->dual_add(auto_recenter_w->label("Auto-Recenter View"), d);
+	general_table->dual_add(auto_recenter_w, d);
+
 	general_table->add_row(new w_spacer(), true);
 
 	w_toggle *weapon_w = new w_toggle(!(input_preferences->modifiers & _inputmod_dont_switch_to_new_weapon));
 	general_table->dual_add(weapon_w->label("Auto-Switch Weapons"), d);
 	general_table->dual_add(weapon_w, d);
 
-	w_toggle* auto_recenter_w = new w_toggle(!(input_preferences->modifiers & _inputmod_dont_auto_recenter));
-	general_table->dual_add(auto_recenter_w->label("Auto-Recenter View"), d);
-	general_table->dual_add(auto_recenter_w, d);
-
 	general->add(general_table, true);
 
 	general->add(new w_spacer(), true);
-	general->dual_add(new w_static_text("Warning: Auto-Switch Weapons and Auto-Recenter View"), d);
-	general->dual_add(new w_static_text("are always ON in network play.  Turning either one OFF"), d);
-	general->dual_add(new w_static_text("will also disable film recording for single-player games."), d);
+	general->dual_add(new w_static_text("Warning: Auto-Switch Weapons is always ON in"), d);
+	general->dual_add(new w_static_text("network play.  Turning it OFF will also disable"), d);
+	general->dual_add(new w_static_text("film recording for single-player games."), d);
 		
 	tabs->add(general, true);
 	tabs->add(mouse, true);
@@ -3403,7 +3403,7 @@ restore_custom_player_behavior_modifiers() {
 
 bool
 is_player_behavior_standard() {
-    return (!dont_switch_to_new_weapon() && !dont_auto_recenter());
+	return !dont_switch_to_new_weapon();
 }
 
 
@@ -3418,13 +3418,9 @@ bool dont_switch_to_new_weapon() {
 }
 
 
-// ZZZ addition: like dont_switch_to_new_weapon()
 bool
 dont_auto_recenter() {
-    if(!sStandardizeModifiers)
-        return TEST_FLAG(input_preferences->modifiers, _inputmod_dont_auto_recenter);
-    else
-        return false;
+	return TEST_FLAG(input_preferences->modifiers, _inputmod_dont_auto_recenter);
 }
 
 


### PR DESCRIPTION
1. Reworks the "Auto-Recenter View" preference so that it's purely client-side and therefore can be turned OFF for net play or for recording single player games. Bumping the network version and creating a new film profile are not required.
2. Fixes a Bungie bug where tapping (not holding down) the recenter key results in a slow, jerky recentering.
3. Code cleanup: strips out "Auto-Recenter View" preference tracking infrastructure made redundant by #﻿1.