### PR TITLE
Update to C++11

### DIFF
--- a/Source_Files/CSeries/BStream.cpp
+++ b/Source_Files/CSeries/BStream.cpp
@@ -35,7 +35,7 @@ std::streampos BIStream::maxg() const
 	return max;
 }
 
-BIStream& BIStream::read(char *s, std::streamsize n) throw(failure)
+BIStream& BIStream::read(char *s, std::streamsize n)
 {
 	if (rdbuf()->sgetn(s, n) != n)
 	{
@@ -45,7 +45,7 @@ BIStream& BIStream::read(char *s, std::streamsize n) throw(failure)
 	return *this;
 }
 
-BIStream& BIStream::ignore(std::streamsize n) throw(failure)
+BIStream& BIStream::ignore(std::streamsize n)
 {
 	if (rdbuf()->pubseekoff(n, std::ios_base::cur, std::ios_base::in) < 0)
 	{
@@ -55,12 +55,12 @@ BIStream& BIStream::ignore(std::streamsize n) throw(failure)
 	return *this;
 }
 
-BIStream& BIStream::operator>>(uint8& value) throw(failure)
+BIStream& BIStream::operator>>(uint8& value)
 {
 	return read(reinterpret_cast<char*>(&value), 1);
 }
 
-BIStream& BIStream::operator>>(int8& value) throw(failure)
+BIStream& BIStream::operator>>(int8& value)
 {
 	uint8 uvalue;
 	operator>>(uvalue);
@@ -68,14 +68,14 @@ BIStream& BIStream::operator>>(int8& value) throw(failure)
 	return *this;
 }
 
-BIStream& BIStreamBE::operator>>(uint16& value) throw(failure)
+BIStream& BIStreamBE::operator>>(uint16& value)
 {
 	read(reinterpret_cast<char*>(&value), 2);
 	value = SDL_SwapBE16(value);
 	return *this;
 }
 
-BIStream& BIStreamBE::operator>>(int16& value) throw(failure)
+BIStream& BIStreamBE::operator>>(int16& value)
 {
 	uint16 uvalue;
 	operator>>(uvalue);
@@ -83,14 +83,14 @@ BIStream& BIStreamBE::operator>>(int16& value) throw(failure)
 	return *this;
 }
 
-BIStream& BIStreamBE::operator>>(uint32& value) throw(failure)
+BIStream& BIStreamBE::operator>>(uint32& value)
 {
 	read(reinterpret_cast<char*>(&value), 4);
 	value = SDL_SwapBE32(value);
 	return *this;
 }
 
-BIStream& BIStreamBE::operator>>(int32& value) throw(failure)
+BIStream& BIStreamBE::operator>>(int32& value)
 {
 	uint32 uvalue;
 	operator>>(uvalue);
@@ -98,7 +98,7 @@ BIStream& BIStreamBE::operator>>(int32& value) throw(failure)
 	return *this;
 }
 
-BIStream& BIStreamBE::operator>>(double& value) throw(failure)
+BIStream& BIStreamBE::operator>>(double& value)
 {
 	Uint64 ivalue;
 	read(reinterpret_cast<char*>(&ivalue), 8);
@@ -120,7 +120,7 @@ std::streampos BOStream::maxp() const
 	return max;
 }
 
-BOStream& BOStream::write(const char *s, std::streamsize n) throw(failure)
+BOStream& BOStream::write(const char *s, std::streamsize n)
 {
 	if (rdbuf()->sputn(s, n) != n)
 	{
@@ -130,39 +130,39 @@ BOStream& BOStream::write(const char *s, std::streamsize n) throw(failure)
 	return *this;
 }
 
-BOStream& BOStream::operator<<(uint8 value) throw(failure)
+BOStream& BOStream::operator<<(uint8 value)
 {
 	return write(reinterpret_cast<char*>(&value), 1);
 }
 
-BOStream& BOStream::operator<<(int8 value) throw(failure)
+BOStream& BOStream::operator<<(int8 value)
 {
 	return operator<<(static_cast<uint8>(value));
 }
 
-BOStream& BOStreamBE::operator<<(uint16 value) throw(failure)
+BOStream& BOStreamBE::operator<<(uint16 value)
 {
 	value = SDL_SwapBE16(value);
 	return write(reinterpret_cast<char*>(&value), 2);
 }
 
-BOStream& BOStreamBE::operator<<(int16 value) throw(failure)
+BOStream& BOStreamBE::operator<<(int16 value)
 {
 	return operator<<(static_cast<uint16>(value));
 }
 
-BOStream& BOStreamBE::operator<<(uint32 value) throw(failure)
+BOStream& BOStreamBE::operator<<(uint32 value)
 {
 	value = SDL_SwapBE32(value);
 	return write(reinterpret_cast<char*>(&value), 4);
 }
 
-BOStream& BOStreamBE::operator<<(int32 value) throw(failure)
+BOStream& BOStreamBE::operator<<(int32 value)
 {
 	return operator<<(static_cast<uint32>(value));
 }
 
-BOStream& BOStreamBE::operator<<(double value) throw(failure)
+BOStream& BOStreamBE::operator<<(double value)
 {
 	Uint64 ivalue;
 	memcpy(reinterpret_cast<char*>(&ivalue), reinterpret_cast<char*>(&value), 8);

--- a/Source_Files/CSeries/BStream.h
+++ b/Source_Files/CSeries/BStream.h
@@ -48,17 +48,17 @@ public:
 	std::streampos tellg() const;
 	std::streampos maxg() const;
 
-	BIStream& operator>>(uint8& value) throw(failure);
-	BIStream& operator>>(int8& value) throw(failure);
+	BIStream& operator>>(uint8& value);
+	BIStream& operator>>(int8& value);
 
-	virtual BIStream& operator>>(int16& value) throw(failure) = 0;
-	virtual BIStream& operator>>(uint16& value) throw(failure) = 0;
-	virtual BIStream& operator>>(int32& value) throw(failure) = 0;
-	virtual BIStream& operator>>(uint32& value) throw(failure) = 0;
-	virtual BIStream& operator>>(double& value) throw(failure) = 0;
+	virtual BIStream& operator>>(int16& value) = 0;
+	virtual BIStream& operator>>(uint16& value) = 0;
+	virtual BIStream& operator>>(int32& value) = 0;
+	virtual BIStream& operator>>(uint32& value) = 0;
+	virtual BIStream& operator>>(double& value) = 0;
 
-	BIStream& read(char *s, std::streamsize n) throw(failure);
-	BIStream& ignore(std::streamsize n) throw(failure);
+	BIStream& read(char *s, std::streamsize n);
+	BIStream& ignore(std::streamsize n);
 };
 
 class BIStreamBE : public BIStream
@@ -66,19 +66,19 @@ class BIStreamBE : public BIStream
 public:
 	BIStreamBE(std::streambuf* sb) : BIStream(sb) {}
 	
-	BIStream& operator>>(uint8& value) throw(failure) {
+	BIStream& operator>>(uint8& value) {
 		return BIStream::operator>>(value);
 	}
 
-	BIStream& operator>>(int8& value) throw(failure) {
+	BIStream& operator>>(int8& value) {
 		return BIStream::operator>>(value);
 	}
 
-	BIStream& operator>>(int16& value) throw(failure);
-	BIStream& operator>>(uint16& value) throw(failure);
-	BIStream& operator>>(int32& value) throw(failure);
-	BIStream& operator>>(uint32& value) throw(failure);
-	BIStream& operator>>(double& value) throw(failure);
+	BIStream& operator>>(int16& value);
+	BIStream& operator>>(uint16& value);
+	BIStream& operator>>(int32& value);
+	BIStream& operator>>(uint32& value);
+	BIStream& operator>>(double& value);
 };
 	
 class BOStream : public basic_bstream
@@ -89,16 +89,16 @@ public:
 	std::streampos tellp() const;
 	std::streampos maxp() const;
 	
-	BOStream& operator<<(uint8 value) throw(failure);
-	BOStream& operator<<(int8 value) throw(failure);
+	BOStream& operator<<(uint8 value);
+	BOStream& operator<<(int8 value);
 
-	virtual BOStream& operator<<(int16 value) throw(failure) = 0;
-	virtual BOStream& operator<<(uint16 value) throw(failure) = 0;
-	virtual BOStream& operator<<(int32 value) throw(failure) = 0;
-	virtual BOStream& operator<<(uint32 value) throw(failure) = 0;
-	virtual BOStream& operator<<(double value) throw(failure) = 0;
+	virtual BOStream& operator<<(int16 value) = 0;
+	virtual BOStream& operator<<(uint16 value) = 0;
+	virtual BOStream& operator<<(int32 value) = 0;
+	virtual BOStream& operator<<(uint32 value) = 0;
+	virtual BOStream& operator<<(double value) = 0;
 
-	BOStream& write(const char *s, std::streamsize n) throw(failure);
+	BOStream& write(const char *s, std::streamsize n);
 };
 
 class BOStreamBE : public BOStream
@@ -106,19 +106,19 @@ class BOStreamBE : public BOStream
 public:
 	BOStreamBE(std::streambuf* sb) : BOStream(sb) {}
 	
-	BOStream& operator<<(uint8 value) throw(failure) {
+	BOStream& operator<<(uint8 value) {
 		return BOStream::operator<<(value);
 	}
 
-	BOStream& operator<<(int8 value) throw(failure) {
+	BOStream& operator<<(int8 value) {
 		return BOStream::operator<<(value);
 	}
 
-	BOStream& operator<<(int16 value) throw(failure);
-	BOStream& operator<<(uint16 value) throw(failure);
-	BOStream& operator<<(int32 value) throw(failure);
-	BOStream& operator<<(uint32 value) throw(failure);
-	BOStream& operator<<(double value) throw(failure);
+	BOStream& operator<<(int16 value);
+	BOStream& operator<<(uint16 value);
+	BOStream& operator<<(int32 value);
+	BOStream& operator<<(uint32 value);
+	BOStream& operator<<(double value);
 };
 
 #endif

--- a/Source_Files/CSeries/cseries.h
+++ b/Source_Files/CSeries/cseries.h
@@ -74,6 +74,12 @@ struct Rect {
 const int noErr = 0;
 #endif
 
+constexpr Rect MakeRect(int16 top, int16 left, int16 bottom, int16 right)
+	{ return {top, left, bottom, right}; }
+
+constexpr Rect MakeRect(SDL_Rect r)
+	{ return {int16(r.y), int16(r.x), int16(r.y + r.h), int16(r.x + r.w)}; }
+
 struct RGBColor {
 	uint16 red, green, blue;
 };

--- a/Source_Files/CSeries/csstrings.h
+++ b/Source_Files/CSeries/csstrings.h
@@ -27,7 +27,7 @@
 #define _CSERIES_STRINGS_
 
 #if defined(__GNUC__)
-#define PRINTF_STYLE_ARGS(n,m) __attribute__((format(printf,n,m)))
+#define PRINTF_STYLE_ARGS(n,m) __attribute__((format(gnu_printf,n,m)))
 #else
 #define PRINTF_STYLE_ARGS(n,m)
 #endif

--- a/Source_Files/FFmpeg/Movie.cpp
+++ b/Source_Files/FFmpeg/Movie.cpp
@@ -424,7 +424,7 @@ bool Movie::Setup()
         video_stream->codec->codec_type = AVMEDIA_TYPE_VIDEO;
         video_stream->codec->width = view_rect.w;
         video_stream->codec->height = view_rect.h;
-        video_stream->codec->time_base = (AVRational){1, TICKS_PER_SECOND};
+        video_stream->codec->time_base = AVRational{1, TICKS_PER_SECOND};
         video_stream->codec->pix_fmt = AV_PIX_FMT_YUV420P;
         video_stream->codec->flags |= CODEC_FLAG_CLOSED_GOP;
         video_stream->codec->thread_count = get_cpu_count();
@@ -495,7 +495,7 @@ bool Movie::Setup()
         audio_stream->codec->codec_id = audio_codec->id;
         audio_stream->codec->codec_type = AVMEDIA_TYPE_AUDIO;
         audio_stream->codec->sample_rate = mx->obtained.freq;
-        audio_stream->codec->time_base = (AVRational){1, mx->obtained.freq};
+        audio_stream->codec->time_base = AVRational{1, mx->obtained.freq};
         audio_stream->codec->channels = 2;
         
         if (av->fmt_ctx->oformat->flags & AVFMT_GLOBALHEADER)
@@ -557,8 +557,8 @@ bool Movie::Setup()
     // Start movie file
     if (success)
     {
-        video_stream->time_base = (AVRational){1, TICKS_PER_SECOND};
-        audio_stream->time_base = (AVRational){1, mx->obtained.freq};
+        video_stream->time_base = AVRational{1, TICKS_PER_SECOND};
+        audio_stream->time_base = AVRational{1, mx->obtained.freq};
         avformat_write_header(av->fmt_ctx, NULL);
     }
     
@@ -693,7 +693,7 @@ void Movie::EncodeAudio(bool last)
 #endif
         av->audio_frame->nb_samples = write_samples;
         av->audio_frame->pts = av_rescale_q(av->audio_counter,
-                                            (AVRational){1, acodec->sample_rate},
+                                            AVRational{1, acodec->sample_rate},
                                             acodec->time_base);
         av->audio_counter += write_samples;
         int asize = avcodec_fill_audio_frame(av->audio_frame, acodec->channels,

--- a/Source_Files/Files/AStream.cpp
+++ b/Source_Files/Files/AStream.cpp
@@ -42,7 +42,6 @@
 using namespace std;
 
 AIStream& AIStream::operator>>(uint8 &value)
-	throw(AStream::failure)
 {
 	if(bound_check(1))
 	{
@@ -52,7 +51,6 @@ AIStream& AIStream::operator>>(uint8 &value)
 }
 
 AIStream& AIStream::operator>>(int8 &value)
-	throw(AStream::failure)
 {
 	uint8 UValue = 0;
 	operator>>(UValue);
@@ -62,7 +60,6 @@ AIStream& AIStream::operator>>(int8 &value)
 }
 
 AIStream& AIStream::operator>>(bool &value)
-  throw(AStream::failure)
 {
   uint8 UValue = 0;
   operator>>(UValue);
@@ -72,7 +69,6 @@ AIStream& AIStream::operator>>(bool &value)
 }
 
 AIStream& AIStream::read(char *ptr, uint32 count)
-	throw(AStream::failure)
 {
 	if(bound_check(count))
 	{
@@ -83,7 +79,6 @@ AIStream& AIStream::read(char *ptr, uint32 count)
 }
 
 AIStream& AIStream::ignore(uint32 count)
-	throw(AStream::failure)
 {
 	if(bound_check(count))
 	{
@@ -93,7 +88,6 @@ AIStream& AIStream::ignore(uint32 count)
 }
 
 AOStream& AOStream::operator<<(uint8 value)
-	throw(AStream::failure)
 {
 	if(bound_check(1))
 	{
@@ -103,19 +97,16 @@ AOStream& AOStream::operator<<(uint8 value)
 }
 
 AOStream& AOStream::operator<<(int8 value)
-	throw(AStream::failure)
 {
 	return operator<<(uint8(value));
 }
 
 AOStream& AOStream::operator<<(bool value)
-  throw(AStream::failure)
 {
   return operator<<(uint8(value ? 1 : 0));
 }
 
 AOStream& AOStream::write(char *ptr, uint32 count)
-	throw(AStream::failure)
 {
 	if(bound_check(count))
 	{
@@ -126,7 +117,6 @@ AOStream& AOStream::write(char *ptr, uint32 count)
 }
 
 AOStream& AOStream::ignore(uint32 count)
-	throw(AStream::failure)
 {
 	if(bound_check(count))
 	{
@@ -138,7 +128,6 @@ AOStream& AOStream::ignore(uint32 count)
 //big endian
 
 AIStream& AIStreamBE::operator>>(uint16 &value)
-	throw(AStream::failure)
 {
 	if(bound_check(2))
 	{
@@ -152,7 +141,6 @@ AIStream& AIStreamBE::operator>>(uint16 &value)
 }
 
 AIStream& AIStreamBE::operator>>(int16 &value)
-	throw(AStream::failure)
 {
 	uint16 UValue = 0;
 	operator>>(UValue);
@@ -162,7 +150,6 @@ AIStream& AIStreamBE::operator>>(int16 &value)
 }
 
 AIStream& AIStreamBE::operator>>(uint32 &value)
-	throw(AStream::failure)
 {
 	if(bound_check(4))
 	{
@@ -178,7 +165,6 @@ AIStream& AIStreamBE::operator>>(uint32 &value)
 }
 
 AIStream& AIStreamBE::operator>>(int32 &value)
-	throw(AStream::failure)
 {
 	uint32 UValue = 0;
 	operator>>(UValue);
@@ -188,7 +174,6 @@ AIStream& AIStreamBE::operator>>(int32 &value)
 }
 
 AOStream& AOStreamBE::operator<<(uint16 value)
-	throw(AStream::failure)
 {
 	if(bound_check(2))
 	{
@@ -199,13 +184,11 @@ AOStream& AOStreamBE::operator<<(uint16 value)
 }
 
 AOStream& AOStreamBE::operator<<(int16 value)
-	throw(AStream::failure)
 {
 	return operator<<(uint16(value));
 }
 
 AOStream& AOStreamBE::operator<<(uint32 value)
-	throw(AStream::failure)
 {
 	if(bound_check(4))
 	{
@@ -218,7 +201,6 @@ AOStream& AOStreamBE::operator<<(uint32 value)
 }
 
 AOStream& AOStreamBE::operator<<(int32 value)
-	throw(AStream::failure)
 {
 	return operator<<(uint32(value));
 }
@@ -227,7 +209,6 @@ AOStream& AOStreamBE::operator<<(int32 value)
 // little endian
 
 AIStream& AIStreamLE::operator>>(uint16 &value)
-	throw(AStream::failure)
 {
 	if(bound_check(2))
 	{
@@ -241,7 +222,6 @@ AIStream& AIStreamLE::operator>>(uint16 &value)
 }
 
 AIStream& AIStreamLE::operator>>(int16 &value)
-	throw(AStream::failure)
 {
 	uint16 UValue = 0;
 	operator>>(UValue);
@@ -251,7 +231,6 @@ AIStream& AIStreamLE::operator>>(int16 &value)
 }
 
 AIStream& AIStreamLE::operator>>(uint32 &value)
-	throw(AStream::failure)
 {
 	if(bound_check(4))
 	{
@@ -267,7 +246,6 @@ AIStream& AIStreamLE::operator>>(uint32 &value)
 }
 
 AIStream& AIStreamLE::operator>>(int32 &value)
-	throw(AStream::failure)
 {
 	uint32 UValue = 0;
 	operator>>(UValue);
@@ -277,7 +255,6 @@ AIStream& AIStreamLE::operator>>(int32 &value)
 }
 
 AOStream& AOStreamLE::operator<<(uint16 value)
-	throw(AStream::failure)
 {
 	if(bound_check(2))
 	{
@@ -288,13 +265,11 @@ AOStream& AOStreamLE::operator<<(uint16 value)
 }
 
 AOStream& AOStreamLE::operator<<(int16 value)
-	throw(AStream::failure)
 {
 	return operator<<(uint16(value));
 }
 
 AOStream& AOStreamLE::operator<<(uint32 value)
-	throw(AStream::failure)
 {
 	if(bound_check(4))
 	{
@@ -307,14 +282,12 @@ AOStream& AOStreamLE::operator<<(uint32 value)
 }
 
 AOStream& AOStreamLE::operator<<(int32 value)
-	throw(AStream::failure)
 {
 	return operator<<(uint32(value));
 }
 
 template<typename T>
 bool AStream::basic_astream<T>::bound_check(uint32 delta)
-	throw(AStream::failure)
 {
 	if(_M_stream_pos + delta > _M_stream_end)
 	{
@@ -327,7 +300,7 @@ bool AStream::basic_astream<T>::bound_check(uint32 delta)
 	return !(this->fail());
 }
 
-AStream::failure::failure(const std::string& str) throw()
+AStream::failure::failure(const std::string& str) noexcept
 {
 	_M_name = strdup(str.c_str());
 }
@@ -338,14 +311,14 @@ AStream::failure::failure(const failure &f) {
 	}
 }
 
-AStream::failure::~failure() throw() {
+AStream::failure::~failure() noexcept {
 	if (_M_name) {
 		free(_M_name);
 		_M_name = NULL;
 	}
 }
 
- const char*	AStream::failure::what() const throw()
+ const char*	AStream::failure::what() const noexcept
  {
 	 return _M_name;
  }

--- a/Source_Files/Files/AStream.h
+++ b/Source_Files/Files/AStream.h
@@ -55,11 +55,11 @@ namespace AStream
 	class failure : public std::exception
 	{
 		public:
-			failure(const std::string& __str) throw();
+			failure(const std::string& __str) noexcept;
 			failure(const failure &f);
-			~failure() throw();
+			~failure() noexcept;
 			const char*
-			what() const throw();
+			what() const noexcept;
 
 		private:
 			char * _M_name;
@@ -76,7 +76,7 @@ namespace AStream
 	protected:
 		T *_M_stream_pos;
 		bool
-		bound_check(uint32 __delta) throw(AStream::failure);
+		bound_check(uint32 __delta);
 		
 		uint32
 		tell_pos() const
@@ -144,44 +144,44 @@ public:
 	{ return this->max_pos(); }
 
 	AIStream&
-	operator>>(uint8 &__value) throw(AStream::failure);
+	operator>>(uint8 &__value);
 	
 	AIStream&
-	operator>>(int8 &__value) throw(AStream::failure);
+	operator>>(int8 &__value);
 	
 	virtual AIStream&
-	  operator>>(bool &__value) throw(AStream::failure);
+	  operator>>(bool &__value);
   
 	virtual AIStream&
-	operator>>(uint16 &__value) throw(AStream::failure) = 0;
+	operator>>(uint16 &__value) = 0;
 	
 	virtual AIStream&
-	operator>>(int16 &__value) throw(AStream::failure) = 0;
+	operator>>(int16 &__value) = 0;
 	
 	virtual AIStream&
-	operator>>(uint32 &__value) throw(AStream::failure) = 0;
+	operator>>(uint32 &__value) = 0;
 	
 	virtual AIStream&
-	operator>>(int32 &__value) throw(AStream::failure) = 0;
+	operator>>(int32 &__value) = 0;
 
 	AIStream&
-	read(char *__ptr, uint32 __count) throw(AStream::failure);
+	read(char *__ptr, uint32 __count);
 	
 	AIStream&
-	read(unsigned char * __ptr, uint32 __count) throw(AStream::failure)
+	read(unsigned char * __ptr, uint32 __count)
 	{ return read((char *) __ptr, __count); }
 	
 	AIStream&
-	read(signed char * __ptr, uint32 __count) throw(AStream::failure)
+	read(signed char * __ptr, uint32 __count)
 	{ return read((char *) __ptr, __count); }
 	
 	AIStream&
-	ignore(uint32 __count) throw(AStream::failure);
+	ignore(uint32 __count);
 
 	// Uses >> instead of operator>> so as to pick up friendly operator>>
 	template<class T>
 	inline AIStream&
-	read(T* __list, uint32 __count) throw(AStream::failure)
+	read(T* __list, uint32 __count)
 	{
 		T* ValuePtr = __list;
 		for (unsigned int k=0; k<__count; k++)
@@ -199,24 +199,24 @@ public:
 		AIStream(__stream, __length, __offset) {};
 
 	AIStream& 
-	operator>>(uint8 &__value) throw(AStream::failure)
+	operator>>(uint8 &__value)
 		{ return AIStream::operator>>(__value); }
 
 	AIStream&
-	operator>>(int8 &__value) throw(AStream::failure)
+	operator>>(int8 &__value)
 		{ return AIStream::operator>>(__value); }
 	
 	AIStream&
-	operator>>(uint16 &__value) throw(AStream::failure);
+	operator>>(uint16 &__value);
 	
 	AIStream&
-	operator>>(int16 &__value) throw(AStream::failure);
+	operator>>(int16 &__value);
 	
 	AIStream&
-	operator>>(uint32 &__value) throw(AStream::failure);
+	operator>>(uint32 &__value);
 	
 	AIStream&
-	operator>>(int32 &__value) throw(AStream::failure);
+	operator>>(int32 &__value);
 };
 
 class AIStreamLE : public AIStream
@@ -226,24 +226,24 @@ public:
 		AIStream(__stream, __length, __offset) {};
 
   	AIStream& 
-	operator>>(uint8 &__value) throw(AStream::failure)
+	operator>>(uint8 &__value)
 		{ return AIStream::operator>>(__value); }
 
 	AIStream&
-	operator>>(int8 &__value) throw(AStream::failure)
+	operator>>(int8 &__value)
 		{ return AIStream::operator>>(__value); }
 
 	AIStream&
-	operator>>(uint16 &__value) throw(AStream::failure);
+	operator>>(uint16 &__value);
 	
 	AIStream&
-	operator>>(int16 &__value) throw(AStream::failure);
+	operator>>(int16 &__value);
 	
 	AIStream&
-	operator>>(uint32 &__value) throw(AStream::failure);
+	operator>>(uint32 &__value);
 	
 	AIStream&
-	operator>>(int32 &__value) throw(AStream::failure);
+	operator>>(int32 &__value);
 };
 
 /* Output Streams, serializing */
@@ -263,44 +263,44 @@ public:
 	{ return this->max_pos(); }
 		
 	AOStream&
-	operator<<(uint8 __value) throw(AStream::failure);
+	operator<<(uint8 __value);
 	
 	AOStream&
-	operator<<(int8 __value) throw(AStream::failure);
+	operator<<(int8 __value);
 
 	virtual AOStream&
-        operator<<(bool __value) throw (AStream::failure);  
+        operator<<(bool __value);  
 
 	virtual AOStream&
-	operator<<(uint16 __value) throw(AStream::failure) = 0;
+	operator<<(uint16 __value) = 0;
 	
 	virtual AOStream&
-	operator<<(int16 __value) throw(AStream::failure) = 0;
+	operator<<(int16 __value) = 0;
 	
 	virtual AOStream&
-	operator<<(uint32 __value) throw(AStream::failure) = 0;
+	operator<<(uint32 __value) = 0;
 	
 	virtual AOStream&
-	operator<<(int32 __value) throw(AStream::failure) = 0;
+	operator<<(int32 __value) = 0;
 
 
 	AOStream&
-	write(char *__ptr, uint32 __count) throw(AStream::failure);
+	write(char *__ptr, uint32 __count);
 	
 	AOStream&
-	write(unsigned char * __ptr, uint32 __count) throw(AStream::failure)
+	write(unsigned char * __ptr, uint32 __count)
 	{ return write((char *) __ptr, __count); }
 	
 	AOStream&
-	write(signed char * __ptr, uint32 __count) throw(AStream::failure)
+	write(signed char * __ptr, uint32 __count)
 	{ return write((char *) __ptr, __count); }
 	
-	AOStream& ignore(uint32 __count) throw(AStream::failure);
+	AOStream& ignore(uint32 __count);
 
 	// Uses << instead of operator>> so as to pick up friendly operator<<
 	template<class T>
 	inline AOStream&
-	write(T* __list, uint32 __count) throw(AStream::failure)
+	write(T* __list, uint32 __count)
 	{
 		T* ValuePtr = __list;
 		for (unsigned int k=0; k<__count; k++)
@@ -317,24 +317,24 @@ public:
 		AOStream(__stream, __length, __offset) {};
 
 	AOStream&
-	operator<<(uint8 __value) throw (AStream::failure)
+	operator<<(uint8 __value)
 		{ return AOStream::operator<<(__value); }
 
 	AOStream&
-	operator<<(int8 __value) throw (AStream::failure)
+	operator<<(int8 __value)
 		{ return AOStream::operator<<(__value); }
   
 	AOStream&
-	operator<<(uint16 __value) throw(AStream::failure);
+	operator<<(uint16 __value);
 	
 	AOStream&
-	operator<<(int16 __value) throw(AStream::failure);
+	operator<<(int16 __value);
 	
 	AOStream&
-	operator<<(uint32 __value) throw(AStream::failure);
+	operator<<(uint32 __value);
 	
 	AOStream&
-	operator<<(int32 __value) throw(AStream::failure);
+	operator<<(int32 __value);
 };
 
 class AOStreamLE: public AOStream
@@ -344,24 +344,24 @@ public:
 		AOStream(__stream, __length, __offset) {}
 
   	AOStream&
-	operator<<(uint8 __value) throw (AStream::failure)
+	operator<<(uint8 __value)
 		{ return AOStream::operator<<(__value); }
 
 	AOStream&
-	operator<<(int8 __value) throw (AStream::failure)
+	operator<<(int8 __value)
 		{ return AOStream::operator<<(__value); }
  
 	AOStream&
-	operator<<(uint16 __value) throw(AStream::failure);
+	operator<<(uint16 __value);
 	
 	AOStream&
-	operator<<(int16 __value) throw(AStream::failure);
+	operator<<(int16 __value);
 	
 	AOStream&
-	operator<<(uint32 __value) throw(AStream::failure);
+	operator<<(uint32 __value);
 	
 	AOStream&
-	operator<<(int32 __value) throw(AStream::failure);
+	operator<<(int32 __value);
 };
 
 #endif

--- a/Source_Files/Files/AStream.h
+++ b/Source_Files/Files/AStream.h
@@ -188,7 +188,7 @@ public:
 			*this >> *(ValuePtr++);
   
 		return *this;
-	};
+	}
   
 };
 

--- a/Source_Files/Files/FileHandler.cpp
+++ b/Source_Files/Files/FileHandler.cpp
@@ -926,7 +926,7 @@ public:
 
 			if (time_info) 
 			{
-				strftime(date, 256, "%x %R", time_info);
+				strftime(date, 256, "%x %H:%M", time_info);
 				int date_width = text_width(date, font, style);
 				draw_text(s, date, x + width - date_width, y, selected ? get_theme_color(ITEM_WIDGET, ACTIVE_STATE) : get_theme_color(ITEM_WIDGET, DEFAULT_STATE), font, style);
 				set_drawing_clip_rectangle(0, x, s->h, x + width - date_width - 4);

--- a/Source_Files/Files/FileHandler.h
+++ b/Source_Files/Files/FileHandler.h
@@ -54,7 +54,6 @@ March 18, 2002 (Br'fin (Jeremy Parsons)):
 #include <time.h>	// For time_t
 #include <vector>
 #include <SDL.h>
-using namespace std;
 
 #include <errno.h>
 #include <string>

--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -1830,7 +1830,7 @@ bool process_map_wad(
 		count= data_length/SIZEOF_object_data;
 		assert(count*SIZEOF_object_data==data_length);
 		vassert(count <= MAXIMUM_OBJECTS_PER_MAP,
-			csprintf(temporary,"Number of map objects %lu > limit %u",count,MAXIMUM_OBJECTS_PER_MAP));
+			csprintf(temporary,"Number of map objects %zu > limit %u",count,MAXIMUM_OBJECTS_PER_MAP));
 		unpack_object_data(data,objects,count);
 		
 		// Unpacking is E-Z here...
@@ -1843,21 +1843,21 @@ bool process_map_wad(
 		count= data_length/SIZEOF_monster_data;
 		assert(count*SIZEOF_monster_data==data_length);
 		vassert(count <= MAXIMUM_MONSTERS_PER_MAP,
-			csprintf(temporary,"Number of monsters %lu > limit %u",count,MAXIMUM_MONSTERS_PER_MAP));
+			csprintf(temporary,"Number of monsters %zu > limit %u",count,MAXIMUM_MONSTERS_PER_MAP));
 		unpack_monster_data(data,monsters,count);
 
 		data= (uint8 *)extract_type_from_wad(wad, EFFECTS_STRUCTURE_TAG, &data_length);
 		count= data_length/SIZEOF_effect_data;
 		assert(count*SIZEOF_effect_data==data_length);
 		vassert(count <= MAXIMUM_EFFECTS_PER_MAP,
-			csprintf(temporary,"Number of effects %lu > limit %u",count,MAXIMUM_EFFECTS_PER_MAP));
+			csprintf(temporary,"Number of effects %zu > limit %u",count,MAXIMUM_EFFECTS_PER_MAP));
 		unpack_effect_data(data,effects,count);
 
 		data= (uint8 *)extract_type_from_wad(wad, PROJECTILES_STRUCTURE_TAG, &data_length);
 		count= data_length/SIZEOF_projectile_data;
 		assert(count*SIZEOF_projectile_data==data_length);
 		vassert(count <= MAXIMUM_PROJECTILES_PER_MAP,
-			csprintf(temporary,"Number of projectiles %lu > limit %u",count,MAXIMUM_PROJECTILES_PER_MAP));
+			csprintf(temporary,"Number of projectiles %zu > limit %u",count,MAXIMUM_PROJECTILES_PER_MAP));
 		unpack_projectile_data(data,projectiles,count);
 		
 		data= (uint8 *)extract_type_from_wad(wad, PLATFORM_STRUCTURE_TAG, &data_length);

--- a/Source_Files/GameWorld/effects.cpp
+++ b/Source_Files/GameWorld/effects.cpp
@@ -73,7 +73,7 @@ effect_data *get_effect_data(
 	struct effect_data *effect = GetMemberWithBounds(effects,effect_index,MAXIMUM_EFFECTS_PER_MAP);
 	
 	vassert(effect, csprintf(temporary, "effect index #%d is out of range", effect_index));
-	vassert(SLOT_IS_USED(effect), csprintf(temporary, "effect index #%d (%p) is unused", effect_index, effect));
+	vassert(SLOT_IS_USED(effect), csprintf(temporary, "effect index #%d (%p) is unused", effect_index, (void*)effect));
 	
 	return effect;
 }

--- a/Source_Files/GameWorld/map.cpp
+++ b/Source_Files/GameWorld/map.cpp
@@ -1007,7 +1007,7 @@ void get_object_shape_and_transfer_mode(
 	struct shape_and_transfer_mode *data)
 {
 	struct object_data *object= get_object_data(object_index);
-	register struct shape_animation_data *animation;
+	struct shape_animation_data *animation;
 	angle theta;
 	short view;
 	
@@ -1130,7 +1130,7 @@ bool randomize_object_sequence(
 	shape_descriptor shape)
 {
 	struct object_data *object= get_object_data(object_index);
-	register struct shape_animation_data *animation;
+	struct shape_animation_data *animation;
 	bool randomized= false;
 	
 	animation= get_shape_animation_data(shape);

--- a/Source_Files/GameWorld/map.h
+++ b/Source_Files/GameWorld/map.h
@@ -58,7 +58,8 @@ Nov 19, 2000 (Loren Petrich):
 #include "dynamic_limits.h"
 
 #include <vector>
-using namespace std;
+
+using std::vector;
 
 /* ---------- constants */
 

--- a/Source_Files/GameWorld/monsters.cpp
+++ b/Source_Files/GameWorld/monsters.cpp
@@ -318,7 +318,7 @@ monster_data *get_monster_data(
 	struct monster_data *monster = GetMemberWithBounds(monsters,monster_index,MAXIMUM_MONSTERS_PER_MAP);
 	
 	vassert(monster, csprintf(temporary, "monster index #%d is out of range", monster_index));
-	vassert(SLOT_IS_USED(monster), csprintf(temporary, "monster index #%d (%p) is unused", monster_index, monster));
+	vassert(SLOT_IS_USED(monster), csprintf(temporary, "monster index #%d (%p) is unused", monster_index, (void*)monster));
 	
 	return monster;
 }

--- a/Source_Files/GameWorld/monsters.h
+++ b/Source_Files/GameWorld/monsters.h
@@ -48,9 +48,10 @@ Oct 24, 2000 (Mark Levin)
 // LP additions:
 #include "dynamic_limits.h"
 #include <vector>
-using namespace std;
 
 #include "world.h"
+
+using std::vector;
 
 /* ---------- constants */
 

--- a/Source_Files/GameWorld/player.cpp
+++ b/Source_Files/GameWorld/player.cpp
@@ -390,7 +390,7 @@ player_data *get_player_data(
 {
 	player_data *data = GetMemberWithBounds(players,player_index,dynamic_world->player_count);
 	vassert(data,
-		csprintf(temporary, "asked for player #%lu/#%d", player_index, dynamic_world->player_count));
+		csprintf(temporary, "asked for player #%zu/#%d", player_index, dynamic_world->player_count));
 	
 	return data;
 }

--- a/Source_Files/GameWorld/projectiles.cpp
+++ b/Source_Files/GameWorld/projectiles.cpp
@@ -161,7 +161,7 @@ projectile_data *get_projectile_data(
 	struct projectile_data *projectile =  GetMemberWithBounds(projectiles,projectile_index,MAXIMUM_PROJECTILES_PER_MAP);
 	
 	vassert(projectile, csprintf(temporary, "projectile index #%d is out of range", projectile_index));
-	vassert(SLOT_IS_USED(projectile), csprintf(temporary, "projectile index #%d (%p) is unused", projectile_index, projectile));
+	vassert(SLOT_IS_USED(projectile), csprintf(temporary, "projectile index #%d (%p) is unused", projectile_index, (void*)projectile));
 	
 	return projectile;
 }

--- a/Source_Files/GameWorld/world.cpp
+++ b/Source_Files/GameWorld/world.cpp
@@ -250,7 +250,7 @@ static angle m2_arctangent(
 	world_distance y = yy;
 
 	long tangent;
-	register long last_difference, new_difference;
+	long last_difference, new_difference;
 	angle search_arc, theta;
 	
 	if (x)
@@ -608,10 +608,9 @@ world_distance distance2d(
  *              r++;
  */
 
-int32 isqrt(
-	register uint32 x)
+int32 isqrt(uint32 x)
 {
-	register uint32 r, nr, m;
+	uint32 r, nr, m;
 
 	r= 0;
 	m= 0x40000000;

--- a/Source_Files/GameWorld/world.h
+++ b/Source_Files/GameWorld/world.h
@@ -207,7 +207,7 @@ world_distance guess_distance2d(world_point2d *p0, world_point2d *p1);
 world_distance distance3d(world_point3d *p0, world_point3d *p1);
 world_distance distance2d(world_point2d *p0, world_point2d *p1); /* calls isqrt() */
 
-int32 isqrt(register uint32 x);
+int32 isqrt(uint32 x);
 
 // LP additions: kludges for doing long-distance calculation
 // by storing the upper digits in the upper byte of a "flags" value.

--- a/Source_Files/LibNAT/os_common.c
+++ b/Source_Files/LibNAT/os_common.c
@@ -86,7 +86,7 @@ int LNat_Common_Socket_Udp_Recv(OsSocket * s, const char * host_addr,
   int recv_sofar = 0;
   struct sockaddr_in server;
   struct hostent* hp;
-  unsigned int sender_addr_sz = sizeof(server);
+  socklen_t sender_addr_sz = sizeof(server);
 
   if((ret = Common_Initialize_Sockaddr_in(&server, &hp, host_addr, port)) != OK) {
     return ret;

--- a/Source_Files/Lua/lua_hud_objects.cpp
+++ b/Source_Files/Lua/lua_hud_objects.cpp
@@ -952,7 +952,7 @@ int Lua_Fonts_New(lua_State *L)
 	lua_pop(L, 1);
 	
 	std::string search_path = L_Get_Search_Path(L);
-	std::auto_ptr<ScopedSearchPath> ssp;
+	std::unique_ptr<ScopedSearchPath> ssp;
 	if (search_path.size())
 	{
 		ssp.reset(new ScopedSearchPath(DirectorySpecifier(search_path)));

--- a/Source_Files/Lua/lua_hud_script.cpp
+++ b/Source_Files/Lua/lua_hud_script.cpp
@@ -36,7 +36,6 @@ extern "C"
 #endif
 
 #include <string>
-using namespace std;
 #include <stdlib.h>
 #include <set>
 
@@ -399,7 +398,7 @@ void CloseLuaHUDScript()
 
 void MarkLuaHUDCollections(bool loading)
 {
-	static set<short> collections;
+	static std::set<short> collections;
 	if (loading)
 	{
 		collections.clear();
@@ -408,7 +407,7 @@ void MarkLuaHUDCollections(bool loading)
 	}
 	else
 	{
-		for (set<short>::iterator it = collections.begin(); it != collections.end(); it++)
+		for (std::set<short>::iterator it = collections.begin(); it != collections.end(); it++)
 		{
 			mark_collection_for_unloading(*it);
 		}

--- a/Source_Files/Lua/lua_player.cpp
+++ b/Source_Files/Lua/lua_player.cpp
@@ -2781,6 +2781,6 @@ static void Lua_Player_load_compatibility(lua_State *L)
 {
 	luaL_loadbuffer(L, compatibility_script, strlen(compatibility_script), "player_compatibility");
 	lua_pcall(L, 0, 0, 0);
-};
+}
 
 #endif

--- a/Source_Files/Lua/lua_script.cpp
+++ b/Source_Files/Lua/lua_script.cpp
@@ -73,7 +73,6 @@ extern "C"
 #endif
 
 #include <string>
-using namespace std;
 #include <stdlib.h>
 #include <set>
 
@@ -903,7 +902,7 @@ bool LuaState::Run()
 void LuaState::ExecuteCommand(const std::string& line)
 {
 
-	string buffer;
+	std::string buffer;
 	bool print_result = false;
 	if (line[0] == '=') 
 	{
@@ -1056,7 +1055,7 @@ std::string LuaState::SaveAll()
 	}
 	else
 	{
-		return string();
+		return std::string();
 	}
 }
 
@@ -1082,7 +1081,7 @@ std::string LuaState::SavePassed()
 	} 
 	else
 	{
-		return string();
+		return std::string();
 	}
 }
 
@@ -1090,7 +1089,7 @@ typedef boost::ptr_map<int, LuaState> state_map;
 state_map states;
 
 // globals
-vector<lua_camera> lua_cameras;
+std::vector<lua_camera> lua_cameras;
 
 uint32 *action_flags;
 
@@ -2089,7 +2088,7 @@ void ResetLuaMute()
 
 void MarkLuaCollections(bool loading)
 {
-	static set<short> collections;
+	static std::set<short> collections;
 	if (loading)
 	{
 		collections.clear();
@@ -2098,7 +2097,7 @@ void MarkLuaCollections(bool loading)
 	}
 	else
 	{
-		for (set<short>::iterator it = collections.begin(); it != collections.end(); it++)
+		for (std::set<short>::iterator it = collections.begin(); it != collections.end(); it++)
 		{
 			mark_collection_for_unloading(*it);
 		}

--- a/Source_Files/Misc/Scenario.h
+++ b/Source_Files/Misc/Scenario.h
@@ -29,7 +29,8 @@
 #include <string>
 #include <vector>
 
-using namespace std;
+using std::string;
+using std::vector;
 
 class Scenario
 {

--- a/Source_Files/Misc/Statistics.cpp
+++ b/Source_Files/Misc/Statistics.cpp
@@ -118,7 +118,7 @@ int StatsManager::Run(void *pv)
 
 	while (sm->run_)
 	{
-		std::auto_ptr<Entry> entry;
+		std::unique_ptr<Entry> entry;
 		{
 			ScopedMutex mutex(sm->entry_mutex_);
 			if (sm->entries_.empty())

--- a/Source_Files/Misc/preference_dialogs.cpp
+++ b/Source_Files/Misc/preference_dialogs.cpp
@@ -661,8 +661,8 @@ void SdlOpenGLDialog::choose_advanced_tab(void *arg)
 	d->m_dialog.draw();
 }
 
-auto_ptr<OpenGLDialog>
+std::unique_ptr<OpenGLDialog>
 OpenGLDialog::Create(int theSelectedRenderer)
 {
-	return auto_ptr<OpenGLDialog>(new SdlOpenGLDialog(theSelectedRenderer));
+	return std::unique_ptr<OpenGLDialog>(new SdlOpenGLDialog(theSelectedRenderer));
 }

--- a/Source_Files/Misc/preference_dialogs.h
+++ b/Source_Files/Misc/preference_dialogs.h
@@ -29,7 +29,7 @@ class OpenGLDialog
 {
 public:
 	// Abstract factory; concrete type determined at link-time
-	static std::auto_ptr<OpenGLDialog> Create(int theSelectedRenderer);
+	static std::unique_ptr<OpenGLDialog> Create(int theSelectedRenderer);
 
 	void OpenGLPrefsByRunning ();
 

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -325,7 +325,7 @@ static const char *shape_labels[3] = {
 
 enum { kCrosshairWidget };
 
-static auto_ptr<BinderSet> crosshair_binders;
+static std::unique_ptr<BinderSet> crosshair_binders;
 
 struct update_crosshair_display
 {

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -1123,7 +1123,7 @@ std::vector<std::string> build_resolution_labels()
 	bool first_mode = true;
 	for (std::vector<std::pair<int, int> >::const_iterator it = Screen::instance()->GetModes().begin(); it != Screen::instance()->GetModes().end(); ++it)
 	{
-		ostringstream os;
+		std::ostringstream os;
 		os << it->first << "x" << it->second;
 		if (first_mode)
 		{

--- a/Source_Files/Misc/sdl_widgets.cpp
+++ b/Source_Files/Misc/sdl_widgets.cpp
@@ -2013,7 +2013,7 @@ void w_list_base::mouse_move(int x, int y)
 		    || y < get_theme_space(LIST_WIDGET, T_SPACE) || y >= rect.h - get_theme_space(LIST_WIDGET, B_SPACE))
 			return;
 
-		if ((y - get_theme_space(LIST_WIDGET, T_SPACE)) / item_height() + top_item < min(num_items, top_item + shown_items))
+		if ((y - get_theme_space(LIST_WIDGET, T_SPACE)) / item_height() + top_item < std::min(num_items, top_item + shown_items))
 		{	set_selection((y - get_theme_space(LIST_WIDGET, T_SPACE)) / item_height() + top_item); }
 //		else
 //		{	set_selection(num_items - 1); }
@@ -2442,7 +2442,7 @@ void w_games_in_room::draw_item(const GameListMessage::GameListEntry& item, SDL_
 	width -= 2;
 	y += font->get_ascent() + 1;
 
-	ostringstream time_or_ping;
+	std::ostringstream time_or_ping;
 	int right_text_width = 0;
 
 	// first line, game name, ping or time remaining
@@ -2481,7 +2481,7 @@ void w_games_in_room::draw_item(const GameListMessage::GameListEntry& item, SDL_
 
 	y += font->get_line_height();
 
-	ostringstream game_and_map;
+	std::ostringstream game_and_map;
 
 	if (!item.compatible())
 	{
@@ -2505,7 +2505,7 @@ void w_games_in_room::draw_item(const GameListMessage::GameListEntry& item, SDL_
 	right_text_width = font->styled_text_width(item.m_hostPlayerName, item.m_hostPlayerName.size(), game_style);
 	set_drawing_clip_rectangle(0, x, static_cast<short>(s->h), x + width - right_text_width);
 
-	ostringstream game_settings;
+	std::ostringstream game_settings;
 	if (item.running())
 	{
 		if (item.m_description.m_numPlayers == 1)

--- a/Source_Files/ModelView/Model3D.h
+++ b/Source_Files/ModelView/Model3D.h
@@ -27,8 +27,6 @@
 
 #include "cseries.h"
 
-using namespace std;
-
 #ifdef HAVE_OPENGL
 
 #ifdef HAVE_OPENGL
@@ -37,6 +35,8 @@ using namespace std;
 
 #include <vector>
 #include "vec3.h"
+
+using std::vector;
 
 
 // For boned models; calculate vertices from these
@@ -179,7 +179,7 @@ struct Model3D
 	GLushort *SFPtrBase() {return &SeqFrmPointers[0];}
 	
 	// True number of sequences:
-	int TrueNumSeqs() {return max(int(SeqFrmPointers.size()-1),0);}
+	int TrueNumSeqs() {return std::max(int(SeqFrmPointers.size()-1),0);}
 	
 	// Add-on transforms for the positions and the normals
 	Model3D_Transform TransformPos, TransformNorm;

--- a/Source_Files/Network/ConnectPool.cpp
+++ b/Source_Files/Network/ConnectPool.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "ConnectPool.h"
+#include <utility>
 
 ConnectPool* ConnectPool::m_instance = 0;
 
@@ -76,12 +77,12 @@ int NonblockingConnect::Thread()
 
 	}
 
-	std::auto_ptr<CommunicationsChannel> channel(new CommunicationsChannel);
+	std::unique_ptr<CommunicationsChannel> channel(new CommunicationsChannel);
 
 	channel->connect(m_ip);
 	if (channel->isConnected())
 	{
-		m_channel = channel;
+		m_channel = std::move(channel);
 		m_status = Connected;
 		return 0;
 	}

--- a/Source_Files/Network/ConnectPool.h
+++ b/Source_Files/Network/ConnectPool.h
@@ -60,7 +60,7 @@ public:
 
 private:
 	void connect();
-	std::auto_ptr<CommunicationsChannel> m_channel;
+	std::unique_ptr<CommunicationsChannel> m_channel;
 	Status m_status;
 
 	std::string m_address;

--- a/Source_Files/Network/Metaserver/SdlMetaserverClientUi.cpp
+++ b/Source_Files/Network/Metaserver/SdlMetaserverClientUi.cpp
@@ -363,16 +363,16 @@ private:
 
 private:
 	dialog d;
-	std::auto_ptr<dialog> m_info_dialog;
+	std::unique_ptr<dialog> m_info_dialog;
 	bool m_disconnected;
 };
 
 
 
-auto_ptr<MetaserverClientUi>
+std::unique_ptr<MetaserverClientUi>
 MetaserverClientUi::Create()
 {
-	return auto_ptr<MetaserverClientUi>(new SdlMetaserverClientUi);
+	return std::unique_ptr<MetaserverClientUi>(new SdlMetaserverClientUi);
 }
 
 #endif // !defined(DISABLE_NETWORKING)

--- a/Source_Files/Network/Metaserver/metaserver_dialogs.h
+++ b/Source_Files/Network/Metaserver/metaserver_dialogs.h
@@ -68,7 +68,7 @@ class MetaserverClientUi : public GlobalMetaserverChatNotificationAdapter
 {
 public:
 	// Abstract factory; concrete type determined at link-time
-	static std::auto_ptr<MetaserverClientUi> Create();
+	static std::unique_ptr<MetaserverClientUi> Create();
 
 	const IPaddress GetJoinAddressByRunning();
 

--- a/Source_Files/Network/Metaserver/network_metaserver.cpp
+++ b/Source_Files/Network/Metaserver/network_metaserver.cpp
@@ -252,7 +252,7 @@ MetaserverClient::connect(const std::string& serverName, uint16 port, const std:
 		LoginAndPlayerInfoMessage theLoginMessage(userName, m_playerName, m_teamName);
 		m_channel->enqueueOutgoingMessage(theLoginMessage);
 	
-		auto_ptr<Message> theSaltOrAcceptMessage(m_channel->receiveMessage());
+		std::unique_ptr<Message> theSaltOrAcceptMessage(m_channel->receiveMessage());
 		if (theSaltOrAcceptMessage.get() == 0)
 			throw ServerConnectException("Server Disconnected");
 	
@@ -313,7 +313,7 @@ MetaserverClient::connect(const std::string& serverName, uint16 port, const std:
 			BigChunkOfDataMessage theKeyMessage(kCLIENT_KEY, (uint8 *) theKey, sizeof(theKey));
 			m_channel->enqueueOutgoingMessage(theKeyMessage);
 
-			auto_ptr<Message> theResponseMessage(m_channel->receiveMessage());
+			std::unique_ptr<Message> theResponseMessage(m_channel->receiveMessage());
 			if (!theResponseMessage.get())
 			{
 				throw ServerConnectException("Server Disconnected");
@@ -343,11 +343,11 @@ MetaserverClient::connect(const std::string& serverName, uint16 port, const std:
 
 		m_channel->enqueueOutgoingMessage(LocalizationMessage());
 
-		auto_ptr<LoginSuccessfulMessage> theLoginSuccessfulMessage(m_channel->receiveSpecificMessageOrThrow<LoginSuccessfulMessage>());
+		std::unique_ptr<LoginSuccessfulMessage> theLoginSuccessfulMessage(m_channel->receiveSpecificMessageOrThrow<LoginSuccessfulMessage>());
 
-//	auto_ptr<SetPlayerDataMessage> theSetPlayerDataMessage(m_channel->receiveSpecificMessageOrThrow<SetPlayerDataMessage>());
+//	std::unique_ptr<SetPlayerDataMessage> theSetPlayerDataMessage(m_channel->receiveSpecificMessageOrThrow<SetPlayerDataMessage>());
 
-		auto_ptr<RoomListMessage> theRoomListMessage(m_channel->receiveSpecificMessageOrThrow<RoomListMessage>());
+		std::unique_ptr<RoomListMessage> theRoomListMessage(m_channel->receiveSpecificMessageOrThrow<RoomListMessage>());
 		m_dispatcher.get()->handle(theRoomListMessage.get(), m_channel.get());
 
 		m_channel->disconnect();
@@ -379,10 +379,10 @@ MetaserverClient::connect(const std::string& serverName, uint16 port, const std:
 
 		m_channel->enqueueOutgoingMessage(NameAndTeamMessage(m_playerName, m_teamName));
 
-		auto_ptr<IDAndLimitMessage> theIDAndLimitMessage(m_channel->receiveSpecificMessageOrThrow<IDAndLimitMessage>());
+		std::unique_ptr<IDAndLimitMessage> theIDAndLimitMessage(m_channel->receiveSpecificMessageOrThrow<IDAndLimitMessage>());
 		m_playerID = theIDAndLimitMessage->playerID();
 
-		auto_ptr<DenialMessage> theRoomAcceptMessage(m_channel->receiveSpecificMessageOrThrow<DenialMessage>());
+		std::unique_ptr<DenialMessage> theRoomAcceptMessage(m_channel->receiveSpecificMessageOrThrow<DenialMessage>());
 
 		m_channel->setMessageHandler(m_dispatcher.get());
 	} 

--- a/Source_Files/Network/Metaserver/network_metaserver.h
+++ b/Source_Files/Network/Metaserver/network_metaserver.h
@@ -30,7 +30,7 @@
 #include <exception>
 #include <vector>
 #include <map>
-#include <memory> // auto_ptr
+#include <memory> // unique_ptr
 #include <set>
 #include <stdexcept>
 
@@ -311,19 +311,19 @@ private:
         void handleGameListMessage(GameListMessage* inMessage, CommunicationsChannel* inChannel);
 	void handleSetPlayerDataMessage(SetPlayerDataMessage*, CommunicationsChannel *) { }
 
-	std::auto_ptr<CommunicationsChannel>	m_channel;
-	std::auto_ptr<MessageInflater>		m_inflater;
-	std::auto_ptr<MessageDispatcher>	m_dispatcher;
-	std::auto_ptr<MessageDispatcher>        m_loginDispatcher;
-	std::auto_ptr<MessageHandler>		m_unexpectedMessageHandler;
-	std::auto_ptr<MessageHandler>		m_chatMessageHandler;
-	std::auto_ptr<MessageHandler>		m_keepAliveMessageHandler;
-	std::auto_ptr<MessageHandler>		m_broadcastMessageHandler;
-        std::auto_ptr<MessageHandler>		m_playerListMessageHandler;
-        std::auto_ptr<MessageHandler>		m_roomListMessageHandler;
-	std::auto_ptr<MessageHandler>		m_gameListMessageHandler;
-	std::auto_ptr<MessageHandler>           m_privateMessageHandler;
-	std::auto_ptr<MessageHandler>           m_setPlayerDataMessageHandler;
+	std::unique_ptr<CommunicationsChannel>    m_channel;
+	std::unique_ptr<MessageInflater>          m_inflater;
+	std::unique_ptr<MessageDispatcher>        m_dispatcher;
+	std::unique_ptr<MessageDispatcher>        m_loginDispatcher;
+	std::unique_ptr<MessageHandler>           m_unexpectedMessageHandler;
+	std::unique_ptr<MessageHandler>           m_chatMessageHandler;
+	std::unique_ptr<MessageHandler>           m_keepAliveMessageHandler;
+	std::unique_ptr<MessageHandler>           m_broadcastMessageHandler;
+	std::unique_ptr<MessageHandler>           m_playerListMessageHandler;
+	std::unique_ptr<MessageHandler>           m_roomListMessageHandler;
+	std::unique_ptr<MessageHandler>           m_gameListMessageHandler;
+	std::unique_ptr<MessageHandler>           m_privateMessageHandler;
+	std::unique_ptr<MessageHandler>           m_setPlayerDataMessageHandler;
 	Rooms					m_rooms;
 	RoomDescription				m_room;
         PlayersInRoom				m_playersInRoom;

--- a/Source_Files/Network/RingGameProtocol.cpp
+++ b/Source_Files/Network/RingGameProtocol.cpp
@@ -1466,10 +1466,8 @@ static void NetAddFlagsToPacket(
 static size_t NetPacketSize(
 			    NetPacketPtr  packet)
 {
-        // ZZZ: "register"... how quaint... I wonder if the compiler they used was really not smart enough on its own?
-        // Welp, doesn't hurt to give hints anyway, we'll leave it.  :)
-	register size_t   size = 0;
-	register short  i;
+	size_t size = 0;
+	short i;
 
 	/*	ZZZ: should not do this now, data was already converted elsewhere and we've been passed the unpacked version.
 		NetPacket	packet_storage;

--- a/Source_Files/Network/network.cpp
+++ b/Source_Files/Network/network.cpp
@@ -2063,7 +2063,7 @@ OSErr NetDistributeGameDataToAllPlayers(byte *wad_buffer,
 		if (zipCapableChannels.size())
 		{
 			ZippedPhysicsMessage zippedPhysicsMessage(physics_buffer, physics_length);
-			std::auto_ptr<UninflatedMessage> uninflatedMessage(zippedPhysicsMessage.deflate());
+			std::unique_ptr<UninflatedMessage> uninflatedMessage(zippedPhysicsMessage.deflate());
 			std::for_each(zipCapableChannels.begin(), zipCapableChannels.end(), boost::bind(&CommunicationsChannel::enqueueOutgoingMessage, _1, *uninflatedMessage));
 		}
 
@@ -2082,7 +2082,7 @@ OSErr NetDistributeGameDataToAllPlayers(byte *wad_buffer,
 			// zipped messages are compressed when deflated
 			// since we may have to send this to multiple joiners,
 			// deflate it now so that compression only happens once
-			std::auto_ptr<UninflatedMessage> uninflatedMessage(zippedMapMessage.deflate());
+			std::unique_ptr<UninflatedMessage> uninflatedMessage(zippedMapMessage.deflate());
 			std::for_each(zipCapableChannels.begin(), zipCapableChannels.end(), boost::bind(&CommunicationsChannel::enqueueOutgoingMessage, _1, *uninflatedMessage));
 		}
 
@@ -2098,7 +2098,7 @@ OSErr NetDistributeGameDataToAllPlayers(byte *wad_buffer,
 		if (zipCapableChannels.size())
 		{
 			ZippedLuaMessage zippedLuaMessage(deferred_script_data, deferred_script_length);
-			std::auto_ptr<UninflatedMessage> uninflatedMessage(zippedLuaMessage.deflate());
+			std::unique_ptr<UninflatedMessage> uninflatedMessage(zippedLuaMessage.deflate());
 			std::for_each(zipCapableChannels.begin(), zipCapableChannels.end(), boost::bind(&CommunicationsChannel::enqueueOutgoingMessage, _1, *uninflatedMessage));
 		}
 
@@ -2159,7 +2159,7 @@ byte *NetReceiveGameData(bool do_physics)
   
   // handlers will take care of all messages, and when they're done
   // the server will send us this:
-  auto_ptr<EndGameDataMessage> endGameDataMessage(connection_to_server->receiveSpecificMessage<EndGameDataMessage>((Uint32) 60000, (Uint32) 30000));
+  std::unique_ptr<EndGameDataMessage> endGameDataMessage(connection_to_server->receiveSpecificMessage<EndGameDataMessage>((Uint32) 60000, (Uint32) 30000));
   if (endGameDataMessage.get()) {
     // game data was received OK
 	  if (do_physics) {

--- a/Source_Files/Network/network.cpp
+++ b/Source_Files/Network/network.cpp
@@ -1924,7 +1924,7 @@ static void NetUpdateTopology(
 		if (topology->players[localPlayerIndex].identifier==localPlayerIdentifier) break;
 	}
 #ifdef DEBUG
-	if (localPlayerIndex==topology->player_count) fdprintf("couldn't find my identifier: %p", topology);
+	if (localPlayerIndex==topology->player_count) fdprintf("couldn't find my identifier: %p", (void*)topology);
 #endif
 }
 

--- a/Source_Files/Network/network_capabilities.h
+++ b/Source_Files/Network/network_capabilities.h
@@ -28,9 +28,9 @@
 #include <string>
 #include <map>
 
-using namespace std;
+using std::string;
 
-typedef map<string, uint32> capabilities_t;
+typedef std::map<string, uint32> capabilities_t;
 
 class Capabilities : public capabilities_t
 {

--- a/Source_Files/Network/network_dialog_widgets_sdl.cpp
+++ b/Source_Files/Network/network_dialog_widgets_sdl.cpp
@@ -1010,7 +1010,7 @@ w_entry_point_selector::gotSelected() {
 
         placer->add(new w_spacer(), true);
 
-        sprintf(temporary, "%lu %s levels available",
+        sprintf(temporary, "%zu %s levels available",
             mEntryPoints.size(),
             TS_GetCString(kNetworkGameTypesStringSetID, mGameType)
         );

--- a/Source_Files/Network/network_dialogs.cpp
+++ b/Source_Files/Network/network_dialogs.cpp
@@ -358,7 +358,7 @@ void GatherDialog::idle ()
 	}
 	
 	if (m_autogatherWidget->get_value ()) {
-		map<int, prospective_joiner_info>::iterator it;
+		std::map<int, prospective_joiner_info>::iterator it;
 		it = m_ungathered_players.begin ();
 		while (it != m_ungathered_players.end () && NetGetNumberOfPlayers() < MAXIMUM_NUMBER_OF_PLAYERS) {
 			gathered_player ((it++)->second);
@@ -370,7 +370,7 @@ void GatherDialog::update_ungathered_widget ()
 {
 	vector<prospective_joiner_info> temp;
 
-	for (map<int, prospective_joiner_info>::iterator it = m_ungathered_players.begin (); it != m_ungathered_players.end (); ++it)
+	for (std::map<int, prospective_joiner_info>::iterator it = m_ungathered_players.begin (); it != m_ungathered_players.end (); ++it)
 		temp.push_back ((*it).second);
 	
 	m_ungatheredWidget->SetItems (temp);
@@ -403,7 +403,7 @@ bool GatherDialog::gathered_player (const prospective_joiner_info& player)
 
 void GatherDialog::StartGameHit ()
 {
-	for (map<int, prospective_joiner_info>::iterator it = m_ungathered_players.begin (); it != m_ungathered_players.end (); ++it)
+	for (std::map<int, prospective_joiner_info>::iterator it = m_ungathered_players.begin (); it != m_ungathered_players.end (); ++it)
 		NetHandleUngatheredPlayer ((*it).second);
 	
 	Stop (true);
@@ -424,7 +424,7 @@ void GatherDialog::JoinSucceeded(const prospective_joiner_info* player)
 
 void GatherDialog::JoiningPlayerDropped(const prospective_joiner_info* player)
 {
-	map<int, prospective_joiner_info>::iterator it = m_ungathered_players.find (player->stream_id);
+	std::map<int, prospective_joiner_info>::iterator it = m_ungathered_players.find (player->stream_id);
 	if (it != m_ungathered_players.end ())
 		m_ungathered_players.erase (it);
 	

--- a/Source_Files/Network/network_dialogs.cpp
+++ b/Source_Files/Network/network_dialogs.cpp
@@ -197,7 +197,7 @@ bool network_gather(bool inResumingGame)
 		myPlayerInfo.desired_color= myPlayerInfo.color;
 		memcpy(myPlayerInfo.long_serial_number, serial_preferences->long_serial_number, LONG_SERIAL_NUMBER_LENGTH);
 		
-		auto_ptr<GameAvailableMetaserverAnnouncer> metaserverAnnouncer;
+		std::unique_ptr<GameAvailableMetaserverAnnouncer> metaserverAnnouncer;
 		if(NetEnter())
 		{
 			bool gather_dialog_result;
@@ -2498,10 +2498,10 @@ private:
 	dialog m_dialog;
 };
 
-auto_ptr<GatherDialog>
+std::unique_ptr<GatherDialog>
 GatherDialog::Create()
 {
-	return auto_ptr<GatherDialog>(new SdlGatherDialog);
+	return std::unique_ptr<GatherDialog>(new SdlGatherDialog);
 }
 
 extern struct color_table *build_8bit_system_color_table(void);
@@ -2670,10 +2670,10 @@ private:
 	dialog m_dialog;
 };
 
-auto_ptr<JoinDialog>
+std::unique_ptr<JoinDialog>
 JoinDialog::Create()
 {
-	return auto_ptr<JoinDialog>(new SdlJoinDialog);
+	return std::unique_ptr<JoinDialog>(new SdlJoinDialog);
 }
 
 class SdlSetupNetgameDialog : public SetupNetgameDialog
@@ -2944,10 +2944,10 @@ private:
 	dialog m_dialog;
 };
 
-auto_ptr<SetupNetgameDialog>
+std::unique_ptr<SetupNetgameDialog>
 SetupNetgameDialog::Create ()
 {
-	return auto_ptr<SetupNetgameDialog>(new SdlSetupNetgameDialog);
+	return std::unique_ptr<SetupNetgameDialog>(new SdlSetupNetgameDialog);
 }
 
 // This should really be done better, I guess, but most people will never see it long enough to read it.

--- a/Source_Files/Network/network_dialogs.h
+++ b/Source_Files/Network/network_dialogs.h
@@ -274,7 +274,7 @@ protected:
 	void chatTextEntered (char character);
 	void chatChoiceHit ();
 	
-	map<int, prospective_joiner_info> m_ungathered_players;
+	std::map<int, prospective_joiner_info> m_ungathered_players;
 
 	ButtonWidget*			m_cancelWidget;
 	ButtonWidget*			m_startWidget;

--- a/Source_Files/Network/network_dialogs.h
+++ b/Source_Files/Network/network_dialogs.h
@@ -239,7 +239,7 @@ class GatherDialog : public GatherCallbacks, public ChatCallbacks, public Global
 {
 public:
 // Abstract factory; concrete type determined at link-time
-	static std::auto_ptr<GatherDialog> Create();
+	static std::unique_ptr<GatherDialog> Create();
 	
 	bool GatherNetworkGameByRunning ();
 	
@@ -296,7 +296,7 @@ class JoinDialog : public GlobalMetaserverChatNotificationAdapter, public ChatCa
 {
 public:
 	// Abstract factory; concrete type determined at link-time
-	static std::auto_ptr<JoinDialog> Create();
+	static std::unique_ptr<JoinDialog> Create();
 
 	const int JoinNetworkGameByRunning();
 
@@ -345,7 +345,7 @@ protected:
 	
 	enum { kPregameChat = 0, kMetaserverChat };
 	
-	std::auto_ptr<JoinerSeekingGathererAnnouncer> join_announcer;
+	std::unique_ptr<JoinerSeekingGathererAnnouncer> join_announcer;
 	int join_result;
 	bool got_gathered;
 
@@ -359,7 +359,7 @@ class SetupNetgameDialog
 {
 public:
 	// Abstract factory; concrete type determined at link-time
-	static std::auto_ptr<SetupNetgameDialog> Create();
+	static std::unique_ptr<SetupNetgameDialog> Create();
 
 	bool SetupNetworkGameByRunning (
 		player_info *player_information,

--- a/Source_Files/Network/network_games.cpp
+++ b/Source_Files/Network/network_games.cpp
@@ -1121,7 +1121,7 @@ long get_entry_point_flags_for_game_type(
 			break;
 		// END Benad
 		default:
-			vhalt(csprintf(temporary, "What is game type %lu?", game_type));
+			vhalt(csprintf(temporary, "What is game type %zu?", game_type));
 			break;
 	}
 		

--- a/Source_Files/Network/network_messages.h
+++ b/Source_Files/Network/network_messages.h
@@ -467,13 +467,13 @@ struct Client {
 	void handleChatMessage(NetworkChatMessage*, CommunicationsChannel*);
 	void handleChangeColorsMessage(ChangeColorsMessage*, CommunicationsChannel*);
 
-	std::auto_ptr<MessageDispatcher> mDispatcher;
-	std::auto_ptr<MessageHandler> mJoinerInfoMessageHandler;
-	std::auto_ptr<MessageHandler> mUnexpectedMessageHandler;
-	std::auto_ptr<MessageHandler> mCapabilitiesMessageHandler;
-	std::auto_ptr<MessageHandler> mAcceptJoinMessageHandler;
-	std::auto_ptr<MessageHandler> mChatMessageHandler;
-	std::auto_ptr<MessageHandler> mChangeColorsMessageHandler;
+	std::unique_ptr<MessageDispatcher> mDispatcher;
+	std::unique_ptr<MessageHandler> mJoinerInfoMessageHandler;
+	std::unique_ptr<MessageHandler> mUnexpectedMessageHandler;
+	std::unique_ptr<MessageHandler> mCapabilitiesMessageHandler;
+	std::unique_ptr<MessageHandler> mAcceptJoinMessageHandler;
+	std::unique_ptr<MessageHandler> mChatMessageHandler;
+	std::unique_ptr<MessageHandler> mChangeColorsMessageHandler;
 };
 
 typedef TemplatizedDataMessage<kGAME_SESSION_MESSAGE, BigChunkOfDataMessage> GameSessionMessage;

--- a/Source_Files/Network/network_star_hub.cpp
+++ b/Source_Files/Network/network_star_hub.cpp
@@ -233,7 +233,7 @@ struct NetworkPlayer_hub {
 
 	// latency stuff
 	int32 mLatencyTicks; // sum of the latency ticks from the last second
-	deque<int32> mLatencyBuffer;
+	std::deque<int32> mLatencyBuffer;
 
 	NetworkStats mStats;
 };
@@ -943,21 +943,21 @@ hub_received_game_data_packet_v1(AIStream& ps, int inSenderIndex)
 				dout << "S";
 				for (int i = 0; i < 20; ++i)
 				{
-					dout << setw(3) 
+					dout << std::setw(3) 
 					     << thePlayer.mNthElementFinder.nth_smallest_element(i)
 					     << " ";
 				}
 				dout << "M";
 				for (int i = kDefaultInGameWindowSize / 2 - 10; i < kDefaultInGameWindowSize / 2 + 10; ++i)
 				{
-					dout << setw(3)
+					dout << std::setw(3)
 					     << thePlayer.mNthElementFinder.nth_smallest_element(i)
 					     << " ";
 				}
 				dout << "L";
 				for (int i = 19; i >= 0; --i)
 				{
-					dout << setw(3)
+					dout << std::setw(3)
 					     << thePlayer.mNthElementFinder.nth_largest_element(i)
 					     << " ";
 				}

--- a/Source_Files/RenderMain/ImageLoader.h
+++ b/Source_Files/RenderMain/ImageLoader.h
@@ -33,8 +33,6 @@
 #include "cseries.h"
 #include "FileHandler.h"
 
-using namespace std;
-
 // Need an object to hold the read-in image.
 class ImageDescriptor
 {

--- a/Source_Files/RenderMain/ImageLoader_Shared.cpp
+++ b/Source_Files/RenderMain/ImageLoader_Shared.cpp
@@ -43,9 +43,12 @@
 #endif
 
 #include <cmath>
-static inline float log2(int x) { return std::log((float) x) / std::log(2.0); }
-
 #include <stdlib.h>
+
+using std::min;
+using std::max;
+
+static inline float log2(int x) { return std::log((float) x) / std::log(2.0); }
 
 int ImageDescriptor::GetMipMapSize(int level) const
 {

--- a/Source_Files/RenderMain/OGL_FBO.cpp
+++ b/Source_Files/RenderMain/OGL_FBO.cpp
@@ -191,7 +191,7 @@ void FBOSwapper::blend_multisample(FBO& other) {
 	
 	glClientActiveTextureARB(GL_TEXTURE1_ARB);
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-	GLint multi_coordinates[8] = { 0, other._h, other._w, other._h, other._w, 0, 0, 0 };
+	GLint multi_coordinates[8] = { 0, GLint(other._h), GLint(other._w), GLint(other._h), GLint(other._w), 0, 0, 0 };
 	glTexCoordPointer(2, GL_INT, 0, multi_coordinates);
 	glClientActiveTextureARB(GL_TEXTURE0_ARB);
 	

--- a/Source_Files/RenderMain/OGL_Model_Def.cpp
+++ b/Source_Files/RenderMain/OGL_Model_Def.cpp
@@ -526,8 +526,8 @@ void OGL_ModelData::Load()
 						// Find minimum and maximum for each coordinate
 						for (int ic=0; ic<3; ic++)
 						{
-							NewBoundingBox[0][ic] = min(NewBoundingBox[0][ic],Corner[ic]);
-							NewBoundingBox[1][ic] = max(NewBoundingBox[1][ic],Corner[ic]);
+							NewBoundingBox[0][ic] = std::min(NewBoundingBox[0][ic],Corner[ic]);
+							NewBoundingBox[1][ic] = std::max(NewBoundingBox[1][ic],Corner[ic]);
 						}
 					}
 					else

--- a/Source_Files/RenderMain/OGL_Render.cpp
+++ b/Source_Files/RenderMain/OGL_Render.cpp
@@ -172,7 +172,7 @@ static bool _OGL_IsActive = false;
 
 // Reads off of the current map;
 // call it to avoid lazy loading of textures
-typedef pair<shape_descriptor,int16> TextureWithTransferMode;
+typedef std::pair<shape_descriptor,int16> TextureWithTransferMode;
 static void PreloadTextures();
 static void PreloadWallTexture(const TextureWithTransferMode& inTexture);
 
@@ -672,7 +672,7 @@ bool OGL_StopRun()
 // ZZZ: changes to try to do less redundant work (using a set of pairs etc.)
 void PreloadTextures()
 {
-	typedef set<TextureWithTransferMode> TextureWithTransferModeSet;
+	typedef std::set<TextureWithTransferMode> TextureWithTransferModeSet;
 
 	TextureWithTransferModeSet theSetOfTexturesUsed;
 

--- a/Source_Files/RenderMain/OGL_Render.cpp
+++ b/Source_Files/RenderMain/OGL_Render.cpp
@@ -2988,7 +2988,7 @@ bool OGL_RenderCrosshairs()
 				int LenMin = std::min(LenMid, static_cast<int>(Crosshairs.FromCenter));
 				
 				// at the initial rotation, this is the bottom right
-				GLfloat vertices[16] = {
+				GLint vertices[16] = {
 					LenMax + WidthMin, LenMin + HeightMin,
 					LenMax + WidthMax, LenMin + HeightMin,
 					LenMax + WidthMin, LenMid + HeightMin,
@@ -2998,7 +2998,7 @@ bool OGL_RenderCrosshairs()
 					LenMin + WidthMin, LenMax + HeightMin,
 					LenMin + WidthMin, LenMax + HeightMax
 				};
-				glVertexPointer(2, GL_FLOAT, 0, vertices);
+				glVertexPointer(2, GL_INT, 0, vertices);
 				glDrawArrays(GL_TRIANGLE_STRIP, 0, 8);
 			}
 			break;

--- a/Source_Files/RenderMain/OGL_Texture_Def.h
+++ b/Source_Files/RenderMain/OGL_Texture_Def.h
@@ -30,7 +30,6 @@
 
 
 #include <vector>
-using namespace std;
 
 #include "shape_descriptors.h"
 #include "ImageLoader.h"

--- a/Source_Files/RenderMain/OGL_Textures.cpp
+++ b/Source_Files/RenderMain/OGL_Textures.cpp
@@ -101,6 +101,9 @@ May 3, 2003 (Br'fin (Jeremy Parsons))
 #include "OGL_Textures.h"
 #include "screen.h"
 
+using std::min;
+using std::max;
+
 OGL_TexturesStats gGLTxStats = {0,0,0,500000,0,0, 0};
 
 // Texture mapping
@@ -167,7 +170,7 @@ struct InfravisionData IVDataList[NUMBER_OF_COLLECTIONS] =
 // Is infravision currently active?
 static bool InfravisionActive = false;
 
-static list<TextureState*> sgActiveTextureStates;
+static std::list<TextureState*> sgActiveTextureStates;
 
 
 // Allocate some textures and indicate whether an allocation had happened.
@@ -393,7 +396,7 @@ void OGL_StopTextures()
 
 void OGL_FrameTickTextures()
 {
-	list<TextureState*>::iterator i;
+	std::list<TextureState*>::iterator i;
 	
 	for (i=sgActiveTextureStates.begin() ; i!= sgActiveTextureStates.end() ; i++) {
 		(*i)->FrameTick();

--- a/Source_Files/RenderMain/Rasterizer_Shader.cpp
+++ b/Source_Files/RenderMain/Rasterizer_Shader.cpp
@@ -42,6 +42,9 @@ const GLdouble kViewBaseMatrixInverse[16] = {
 	0,	0,	0,	1
 };
 
+Rasterizer_Shader_Class::Rasterizer_Shader_Class() = default;
+Rasterizer_Shader_Class::~Rasterizer_Shader_Class() = default;
+
 void Rasterizer_Shader_Class::SetView(view_data& view) {
 	OGL_SetView(view);
 	

--- a/Source_Files/RenderMain/Rasterizer_Shader.h
+++ b/Source_Files/RenderMain/Rasterizer_Shader.h
@@ -20,14 +20,15 @@ class Rasterizer_Shader_Class : public Rasterizer_OGL_Class {
 	friend class RenderRasterize_Shader;
 	
 protected:
-	std::auto_ptr<FBOSwapper> swapper;
+	std::unique_ptr<FBOSwapper> swapper;
 	bool smear_the_void;
 	short view_width;
 	short view_height;
 
 public:
 
-	Rasterizer_Shader_Class() : Rasterizer_OGL_Class() {}
+	Rasterizer_Shader_Class();
+	~Rasterizer_Shader_Class();
 
 	virtual void SetView(view_data& View);
 	virtual void setupGL();

--- a/Source_Files/RenderMain/RenderRasterize_Shader.cpp
+++ b/Source_Files/RenderMain/RenderRasterize_Shader.cpp
@@ -82,6 +82,9 @@ public:
 };
 
 
+RenderRasterize_Shader::RenderRasterize_Shader() = default;
+RenderRasterize_Shader::~RenderRasterize_Shader() = default;
+
 /*
  * initialize some stuff
  * happens once after opengl, shaders and textures are setup

--- a/Source_Files/RenderMain/RenderRasterize_Shader.h
+++ b/Source_Files/RenderMain/RenderRasterize_Shader.h
@@ -22,7 +22,7 @@
 class Blur;
 class RenderRasterize_Shader : public RenderRasterizerClass {
 
-	std::auto_ptr<Blur> blur;
+	std::unique_ptr<Blur> blur;
 	Rasterizer_Shader_Class *RasPtr;
 	
 	int objectCount;
@@ -50,7 +50,8 @@ protected:
 	
 public:
 
-	RenderRasterize_Shader() : blur(NULL), RenderRasterizerClass() {}
+	RenderRasterize_Shader();
+	~RenderRasterize_Shader();
 
 	virtual void setupGL(Rasterizer_Shader_Class& Rasterizer);
 

--- a/Source_Files/RenderMain/low_level_textures.h
+++ b/Source_Files/RenderMain/low_level_textures.h
@@ -183,14 +183,14 @@ void texture_horizontal_polygon_lines
 	{
 		short x0= *x0_table++, x1= *x1_table++;
 		
-		register T *shading_table= (T *)data->shading_table;
-		register T *write= (T *) screen->row_addresses[y0] + x0;
-		register pixel8 *base_address= texture->row_addresses[0];
-		register uint32 source_x= data->source_x;
-		register uint32 source_y= data->source_y;
-		register uint32 source_dx= data->source_dx;
-		register uint32 source_dy= data->source_dy;
-		register short count= x1-x0;
+		T *shading_table= (T *)data->shading_table;
+		T *write= (T *) screen->row_addresses[y0] + x0;
+		pixel8 *base_address= texture->row_addresses[0];
+		uint32 source_x= data->source_x;
+		uint32 source_y= data->source_y;
+		uint32 source_dx= data->source_dx;
+		uint32 source_dy= data->source_dy;
+		short count= x1-x0;
 		
 		while ((count-= 1)>=0)
 		{
@@ -217,7 +217,7 @@ void landscape_horizontal_polygon_lines(
 	short *x1_table,
 	short line_count)
 {
-	register short landscape_texture_width_downshift= 32 - NextLowerExponent(texture->height);
+	short landscape_texture_width_downshift= 32 - NextLowerExponent(texture->height);
 
 	(void) (view);
 
@@ -225,12 +225,12 @@ void landscape_horizontal_polygon_lines(
 	{
 		short x0= *x0_table++, x1= *x1_table++;
 		
-		register T *shading_table= (T *)data->shading_table;
-		register T *write= (T *)screen->row_addresses[y0] + x0;
-		register pixel8 *read= texture->row_addresses[data->source_y];
-		register uint32 source_x= data->source_x;
-		register uint32 source_dx= data->source_dx;
-		register short count= x1-x0;
+		T *shading_table= (T *)data->shading_table;
+		T *write= (T *)screen->row_addresses[y0] + x0;
+		pixel8 *read= texture->row_addresses[data->source_y];
+		uint32 source_x= data->source_x;
+		uint32 source_dx= data->source_dx;
+		short count= x1-x0;
 		
 		while ((count-= 1)>=0)
 		{
@@ -523,7 +523,7 @@ void tint_vertical_polygon_lines(
 {
 	short tint_table_index= transfer_data&0xff;
 	struct _vertical_polygon_line_data *line= (struct _vertical_polygon_line_data *) (data+1);
-	register short bytes_per_row= screen->bytes_per_row;
+	short bytes_per_row= screen->bytes_per_row;
 	int line_count= data->width;
 	int x= data->x0;
 
@@ -538,10 +538,10 @@ void tint_vertical_polygon_lines(
 	while ((line_count-= 1)>=0)
 	{
 		short y0= *y0_table++, y1= *y1_table++;
-		register T *write= (T *) screen->row_addresses[y0] + x;
-		register pixel8 *read= line->texture;
-		register _fixed texture_y= line->texture_y, texture_dy= line->texture_dy;
-		register short count= y1-y0;
+		T *write= (T *) screen->row_addresses[y0] + x;
+		pixel8 *read= line->texture;
+		_fixed texture_y= line->texture_y, texture_dy= line->texture_dy;
+		short count= y1-y0;
 
 		while ((count-=1)>=0)
 		{
@@ -583,21 +583,21 @@ void randomize_vertical_polygon_lines(
 	uint16 transfer_data)
 {
 	struct _vertical_polygon_line_data *line= (struct _vertical_polygon_line_data *) (data+1);
-	register short bytes_per_row= screen->bytes_per_row;
+	short bytes_per_row= screen->bytes_per_row;
 	int line_count= data->width;
 	int x= data->x0;
-	register uint16 seed= texture_random_seed();
-	register uint16 drop_less_than= transfer_data;
+	uint16 seed= texture_random_seed();
+	uint16 drop_less_than= transfer_data;
 
 	(void) (view);
 
 	while ((line_count-= 1)>=0)
 	{
 		short y0= *y0_table++, y1= *y1_table++;
-		register T *write= (T *) screen->row_addresses[y0] + x;
-		register pixel8 *read= line->texture;
-		register _fixed texture_y= line->texture_y, texture_dy= line->texture_dy;
-		register short count= y1-y0;
+		T *write= (T *) screen->row_addresses[y0] + x;
+		pixel8 *read= line->texture;
+		_fixed texture_y= line->texture_y, texture_dy= line->texture_dy;
+		short count= y1-y0;
 
 		while ((count-=1)>=0)
 		{

--- a/Source_Files/RenderMain/shapes.cpp
+++ b/Source_Files/RenderMain/shapes.cpp
@@ -1525,14 +1525,14 @@ static void precalculate_bit_depth_constants(
 	aren’t any matches, add a new entry and return that index. */
 static short find_or_add_color(
 	struct rgb_color_value *color,
-	register struct rgb_color_value *colors,
+	struct rgb_color_value *colors,
 	short *color_count, 
 	bool update_flags = true)
 {
 	short i;
 	
 	// LP addition: save initial color-table pointer, just in case we overflow
-	register struct rgb_color_value *colors_saved = colors;
+	struct rgb_color_value *colors_saved = colors;
 	
 	// = 1 to skip the transparent color
 	for (i= 1, colors+= 1; i<*color_count; ++i, ++colors)
@@ -1774,7 +1774,7 @@ static void build_shading_tables8(
 #else
 short find_closest_color(
 	struct rgb_color_value *color,
-	register struct rgb_color_value *colors,
+	struct rgb_color_value *colors,
 	short color_count)
 {
 	short i;

--- a/Source_Files/RenderMain/shapes.cpp
+++ b/Source_Files/RenderMain/shapes.cpp
@@ -788,7 +788,7 @@ static bool load_collection(short collection_index, bool strip)
 	}
 
 	// Read collection definition
-	std::auto_ptr<collection_definition> cd(new collection_definition);
+	std::unique_ptr<collection_definition> cd(new collection_definition);
 	SDL_RWseek(p, src_offset, RW_SEEK_SET);
 	load_collection_definition(cd.get(), p);
 	header->status &= ~markPATCHED;

--- a/Source_Files/RenderMain/textures.cpp
+++ b/Source_Files/RenderMain/textures.cpp
@@ -159,9 +159,9 @@ void precalculate_bitmap_row_addresses(
 }
 
 void map_bytes(
-	register byte *buffer,
-	register byte *table,
-	register int32 size)
+	byte *buffer,
+	byte *table,
+	int32 size)
 {
 	while ((size-=1)>=0)
 	{

--- a/Source_Files/RenderOther/FontHandler.cpp
+++ b/Source_Files/RenderOther/FontHandler.cpp
@@ -51,7 +51,7 @@ Jan 12, 2001 (Loren Petrich):
 #include "screen.h"
 
 #ifdef HAVE_OPENGL
-set<FontSpecifier*> *FontSpecifier::m_font_registry = NULL;
+std::set<FontSpecifier*> *FontSpecifier::m_font_registry = NULL;
 #endif
 
 // MacOS-specific: stuff that gets reused
@@ -461,7 +461,7 @@ void FontSpecifier::OGL_ResetFonts(bool IsStarting)
     if (!m_font_registry)
         return;
     
-	set<FontSpecifier*>::iterator it;
+	std::set<FontSpecifier*>::iterator it;
 	if (IsStarting)
 	{
 		for (it = m_font_registry->begin();
@@ -481,7 +481,7 @@ void FontSpecifier::OGL_ResetFonts(bool IsStarting)
 void FontSpecifier::OGL_Register(FontSpecifier *F)
 {
 	if (!m_font_registry)
-		m_font_registry = new set<FontSpecifier*>;
+		m_font_registry = new std::set<FontSpecifier*>;
 	m_font_registry->insert(F);
 }
 

--- a/Source_Files/RenderOther/FontHandler.h
+++ b/Source_Files/RenderOther/FontHandler.h
@@ -135,7 +135,7 @@ public:
 	int GetTxtrSize() {return int(TxtrWidth)*int(TxtrHeight);}
 	GLuint TxtrID;
 	uint32 DispList;
-	static set<FontSpecifier*> *m_font_registry;
+	static std::set<FontSpecifier*> *m_font_registry;
 #endif
 };
 

--- a/Source_Files/RenderOther/HUDRenderer_Lua.cpp
+++ b/Source_Files/RenderOther/HUDRenderer_Lua.cpp
@@ -448,7 +448,7 @@ void HUD_Lua_Class::draw_image(Image_Blitter *image, float x, float y)
 	if (!m_drawing)
 		return;
 	
-	Image_Rect r = { x, y, image->crop_rect.w, image->crop_rect.h };
+	Image_Rect r{ x, y, image->crop_rect.w, image->crop_rect.h };
 	
 	if (!r.w || !r.h)
 		return;

--- a/Source_Files/RenderOther/Image_Blitter.cpp
+++ b/Source_Files/RenderOther/Image_Blitter.cpp
@@ -183,8 +183,8 @@ void Image_Blitter::Draw(SDL_Surface *dst_surface, const Image_Rect& dst, const 
 	if (!src_surface)
 		return;
   
-    SDL_Rect ssrc = { src.x, src.y, src.w, src.h };
-    SDL_Rect sdst = { dst.x, dst.y, dst.w, dst.h };
+	SDL_Rect ssrc = { int(src.x), int(src.y), int(src.w), int(src.h) };
+	SDL_Rect sdst = { int(dst.x), int(dst.y), int(dst.w), int(dst.h) };
 	SDL_BlitSurface(src_surface, &ssrc, dst_surface, &sdst);
 }
 

--- a/Source_Files/RenderOther/Image_Blitter.cpp
+++ b/Source_Files/RenderOther/Image_Blitter.cpp
@@ -152,19 +152,6 @@ int Image_Blitter::UnscaledHeight()
 	return m_src.h;
 }
 
-void Image_Blitter::Draw(SDL_Surface *dst_surface, const SDL_Rect& dst)
-{
-    Image_Rect idst = { dst.x, dst.y, dst.w, dst.h };
-    Draw(dst_surface, idst);
-}
-
-void Image_Blitter::Draw(SDL_Surface *dst_surface, const SDL_Rect& dst, const SDL_Rect& src)
-{
-    Image_Rect idst = { dst.x, dst.y, dst.w, dst.h };
-    Image_Rect isrc = { src.x, src.y, src.w, src.h };
-    Draw(dst_surface, idst, isrc);
-}
-
 void Image_Blitter::Draw(SDL_Surface *dst_surface, const Image_Rect& dst, const Image_Rect& src)
 {
 	if (!Loaded())

--- a/Source_Files/RenderOther/Image_Blitter.h
+++ b/Source_Files/RenderOther/Image_Blitter.h
@@ -27,7 +27,6 @@ IMAGE_BLITTER.H
 
 #include <vector>
 #include <set>
-using namespace std;
 
 struct Image_Rect
 {

--- a/Source_Files/RenderOther/Image_Blitter.h
+++ b/Source_Files/RenderOther/Image_Blitter.h
@@ -29,10 +29,18 @@ IMAGE_BLITTER.H
 #include <set>
 using namespace std;
 
-typedef struct Image_Rect {
-    float x, y;
-    float w, h;
-} Image_Rect;
+struct Image_Rect
+{
+	float x = 0, y = 0, w = 0, h = 0;
+	
+	Image_Rect() = default;
+	
+	explicit constexpr Image_Rect(float x, float y, float w, float h)
+		: x(x), y(y), w(w), h(h) {}
+	
+	/*implicit*/ constexpr Image_Rect(SDL_Rect r)
+		: x(r.x), y(r.y), w(r.w), h(r.h) {}
+};
 
 class Image_Blitter
 {
@@ -52,9 +60,6 @@ public:
 	int UnscaledWidth();
 	int UnscaledHeight();
 	
-    void Draw(SDL_Surface *dst_surface, const SDL_Rect& dst);
-    void Draw(SDL_Surface *dst_surface, const SDL_Rect& dst, const SDL_Rect& src);
-    
 	virtual void Draw(SDL_Surface *dst_surface, const Image_Rect& dst) { Draw(dst_surface, dst, crop_rect); }
 	virtual void Draw(SDL_Surface *dst_surface, const Image_Rect& dst, const Image_Rect& src);
 		

--- a/Source_Files/RenderOther/OGL_Blitter.cpp
+++ b/Source_Files/RenderOther/OGL_Blitter.cpp
@@ -30,7 +30,7 @@
 #include "OGL_Render.h"
 
 const int OGL_Blitter::tile_size;
-set<OGL_Blitter*> *OGL_Blitter::m_blitter_registry = NULL;
+std::set<OGL_Blitter*> *OGL_Blitter::m_blitter_registry = NULL;
 
 OGL_Blitter::OGL_Blitter() : m_textures_loaded(false)
 {
@@ -156,7 +156,7 @@ void OGL_Blitter::StopTextures()
 	if (!m_blitter_registry)
 		return;
 	
-	set<OGL_Blitter*>::iterator it;
+	std::set<OGL_Blitter*>::iterator it;
 	for (it = m_blitter_registry->begin();
 	     it != m_blitter_registry->end();
 	     it = m_blitter_registry->begin())
@@ -282,7 +282,7 @@ void OGL_Blitter::Draw(const Image_Rect& dst, const Image_Rect& raw_src)
 void OGL_Blitter::Register(OGL_Blitter *B)
 {
 	if (!m_blitter_registry)
-		m_blitter_registry = new set<OGL_Blitter*>;
+		m_blitter_registry = new std::set<OGL_Blitter*>;
 	m_blitter_registry->insert(B);
 }
 

--- a/Source_Files/RenderOther/OGL_Blitter.cpp
+++ b/Source_Files/RenderOther/OGL_Blitter.cpp
@@ -188,12 +188,6 @@ void OGL_Blitter::WindowToScreen(int& x, int& y, bool in_game)
 	alephone::Screen::instance()->window_to_screen(x, y);
 }
 
-void OGL_Blitter::Draw(const SDL_Rect& dst)
-{
-    Image_Rect idst = { dst.x, dst.y, dst.w, dst.h };
-    Draw(idst);
-}
-
 void OGL_Blitter::Draw(const Image_Rect& dst, const Image_Rect& raw_src)
 {
 	if (!Loaded())

--- a/Source_Files/RenderOther/OGL_Blitter.h
+++ b/Source_Files/RenderOther/OGL_Blitter.h
@@ -33,7 +33,8 @@
 
 #include <vector>
 #include <set>
-using namespace std;
+
+using std::vector;
 
 #ifdef HAVE_OPENGL
 class OGL_Blitter;
@@ -74,7 +75,7 @@ private:
 	bool m_textures_loaded;
 	
 	static const int tile_size = 256;
-	static set<OGL_Blitter*> *m_blitter_registry;
+	static std::set<OGL_Blitter*> *m_blitter_registry;
 };
 
 #endif

--- a/Source_Files/RenderOther/OGL_Blitter.h
+++ b/Source_Files/RenderOther/OGL_Blitter.h
@@ -46,7 +46,6 @@ public:
 	void Unload();
 
 	void Draw(SDL_Surface *dst_surface, const Image_Rect& dst, const Image_Rect& src) { Draw(dst, src); }
-    void Draw(const SDL_Rect& dst);
 	void Draw(const Image_Rect& dst) { Draw(dst, crop_rect); }
 	void Draw(const Image_Rect& dst, const Image_Rect& src);
 	

--- a/Source_Files/RenderOther/OverheadMap_SDL.cpp
+++ b/Source_Files/RenderOther/OverheadMap_SDL.cpp
@@ -99,14 +99,14 @@ void OverheadMap_SDL_Class::draw_thing(world_point2d &center, rgb_color &color, 
 			break;
 		case _circle_thing: {
 			world_point2d circle[8] = {
-				{int16(-0.75 * radius) + center.x, int16(-0.3 * radius) + center.y},
-				{int16(-0.75 * radius) + center.x, int16(0.3 * radius) + center.y},
-				{int16(-0.3 * radius) + center.x, int16(0.75 * radius) + center.y},
-				{int16(0.3 * radius) + center.x, int16(0.75 * radius) + center.y},
-				{int16(0.75 * radius) + center.x, int16(0.3 * radius) + center.y},
-				{int16(0.75 * radius) + center.x, int16(-0.3 * radius) + center.y},
-				{int16(0.3 * radius) + center.x, int16(-0.75 * radius) + center.y},
-				{int16(-0.3 * radius) + center.x, int16(-0.75 * radius) + center.y}
+				{int16(-0.75 * radius + center.x), int16(-0.30 * radius + center.y)},
+				{int16(-0.75 * radius + center.x), int16(+0.30 * radius + center.y)},
+				{int16(-0.30 * radius + center.x), int16(+0.75 * radius + center.y)},
+				{int16(+0.30 * radius + center.x), int16(+0.75 * radius + center.y)},
+				{int16(+0.75 * radius + center.x), int16(+0.30 * radius + center.y)},
+				{int16(+0.75 * radius + center.x), int16(-0.30 * radius + center.y)},
+				{int16(+0.30 * radius + center.x), int16(-0.75 * radius + center.y)},
+				{int16(-0.30 * radius + center.x), int16(-0.75 * radius + center.y)}
 			};
 			for (int i=0; i<7; i++)
 				::draw_line(draw_surface, circle + i, circle + i + 1, pixel, 2);

--- a/Source_Files/RenderOther/Shape_Blitter.cpp
+++ b/Source_Files/RenderOther/Shape_Blitter.cpp
@@ -214,10 +214,10 @@ void Shape_Blitter::OGL_Draw(const Image_Rect& dst)
             U_Scale *= crop_rect.h / static_cast<double>(m_scaled_src.h);
 
 		GLfloat texcoords[8] = {
-			U_Offset, V_Offset,
-			U_Offset, V_Offset + V_Scale,
-			U_Offset + U_Scale, V_Offset + V_Scale,
-			U_Offset + U_Scale, V_Offset
+			GLfloat(U_Offset),           GLfloat(V_Offset),
+			GLfloat(U_Offset),           GLfloat(V_Offset + V_Scale),
+			GLfloat(U_Offset + U_Scale), GLfloat(V_Offset + V_Scale),
+			GLfloat(U_Offset + U_Scale), GLfloat(V_Offset)
 		};
 		GLfloat vertices[8] = {
 			dst.x, dst.y,
@@ -337,8 +337,8 @@ void Shape_Blitter::SDL_Draw(SDL_Surface *dst_surface, const Image_Rect& dst)
     if (!m_scaled_surface)
         return;
     
-    SDL_Rect r = { crop_rect.x, crop_rect.y, crop_rect.w, crop_rect.h };
-    SDL_Rect sdst = { dst.x, dst.y, dst.w, dst.h };
+	SDL_Rect r = { int(crop_rect.x), int(crop_rect.y), int(crop_rect.w), int(crop_rect.h) };
+	SDL_Rect sdst = { int(dst.x), int(dst.y), int(dst.w), int(dst.h) };
 	SDL_BlitSurface(m_scaled_surface, &r, dst_surface, &sdst);
 }
 

--- a/Source_Files/RenderOther/Shape_Blitter.cpp
+++ b/Source_Files/RenderOther/Shape_Blitter.cpp
@@ -91,11 +91,6 @@ int Shape_Blitter::UnscaledHeight()
 	return m_src.h;
 }
 
-void Shape_Blitter::OGL_Draw(const SDL_Rect& dst)
-{
-    Image_Rect idst = { dst.x, dst.y, dst.w, dst.h };
-    OGL_Draw(idst);
-}
 void Shape_Blitter::OGL_Draw(const Image_Rect& dst)
 {
 #ifdef HAVE_OPENGL
@@ -275,12 +270,6 @@ SDL_Surface *flip_surface(SDL_Surface *s, int width, int height)
     
 	return s2;
 }	
-
-void Shape_Blitter::SDL_Draw(SDL_Surface *dst_surface, const SDL_Rect& dst)
-{
-    Image_Rect idst = { dst.x, dst.y, dst.w, dst.h };
-    SDL_Draw(dst_surface, idst);
-}
 
 void Shape_Blitter::SDL_Draw(SDL_Surface *dst_surface, const Image_Rect& dst)
 {

--- a/Source_Files/RenderOther/Shape_Blitter.h
+++ b/Source_Files/RenderOther/Shape_Blitter.h
@@ -28,7 +28,6 @@ SHAPE_BLITTER.H
 
 #include <vector>
 #include <set>
-using namespace std;
 
 // texture types
 enum {

--- a/Source_Files/RenderOther/Shape_Blitter.h
+++ b/Source_Files/RenderOther/Shape_Blitter.h
@@ -51,9 +51,7 @@ public:
 	int UnscaledWidth();
 	int UnscaledHeight();
 	
-    void OGL_Draw(const SDL_Rect& dst);
     void OGL_Draw(const Image_Rect& dst);
-    void SDL_Draw(SDL_Surface *dst_surface, const SDL_Rect& dst);
     void SDL_Draw(SDL_Surface *dst_surface, const Image_Rect& dst);
 	
     ~Shape_Blitter();

--- a/Source_Files/RenderOther/TextLayoutHelper.cpp
+++ b/Source_Files/RenderOther/TextLayoutHelper.cpp
@@ -73,7 +73,7 @@ TextLayoutHelper::reserveSpaceFor(int inLeft, unsigned int inWidth, int inLowest
     theRightEnd.mStartOfReservation	= false;
     
     // Walk through, finding place for left end.  Keep track of reservations opened and not closed.
-    typedef multiset<Reservation*>	CollectionOfReservationPointers;
+    typedef std::multiset<Reservation*>	CollectionOfReservationPointers;
     CollectionOfReservationPointers	theReservations;
 
     CollectionOfReservationEnds::iterator	i	= mReservationEnds.begin();

--- a/Source_Files/RenderOther/TextLayoutHelper.h
+++ b/Source_Files/RenderOther/TextLayoutHelper.h
@@ -37,7 +37,7 @@
 // should eventually use list and some other sort mechanism, probably, for cheaper insertions.
 #include <vector>
 
-using namespace std;
+using std::vector;
 
 class TextLayoutHelper {
 public:

--- a/Source_Files/RenderOther/computer_interface.cpp
+++ b/Source_Files/RenderOther/computer_interface.cpp
@@ -2057,7 +2057,7 @@ private:
 	void BuildSuccessGroup();
 	void BuildFailureGroup();
 
-	std::auto_ptr<terminal_text_t> terminal;
+	std::unique_ptr<terminal_text_t> terminal;
 	
 	io::stream_buffer<io::array_source> in_buffer;
 	std::istream in;

--- a/Source_Files/RenderOther/motion_sensor.cpp
+++ b/Source_Files/RenderOther/motion_sensor.cpp
@@ -683,8 +683,8 @@ static void bitmap_window_copy(
 	
 	for (y=y0;y<y1;++y)
 	{
-		register pixel8 *read= source->row_addresses[y]+x0;
-		register pixel8 *write= destination->row_addresses[y]+x0;
+		pixel8 *read= source->row_addresses[y]+x0;
+		pixel8 *write= destination->row_addresses[y]+x0;
 		
 		for (count=x1-x0;count>0;--count) *write++= *read++;
 	}
@@ -713,8 +713,8 @@ static void clipped_transparent_sprite_copy(
 
 	while ((height-= 1)>=0)	
 	{
-		register pixel8 pixel, *read, *write;
-		register short width= source->width;
+		pixel8 pixel, *read, *write;
+		short width= source->width;
 		short clip_left= region[y0+y].x0, clip_right= region[y0+y].x1;
 		short offset= 0;
 		
@@ -753,8 +753,8 @@ static void unclipped_solid_sprite_copy(
 
 	while ((height-= 1)>=0)	
 	{
-		register pixel8 *read, *write;
-		register short width= source->width;
+		pixel8 *read, *write;
+		short width= source->width;
 
 		assert(y>=0&&y<source->height);
 		assert(y0+y>=0&&y0+y<destination->height);

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -1376,8 +1376,8 @@ void render_screen(short ticks_elapsed)
 		OGL_MapActive = false;
 
 	// Set OpenGL viewport to world view
-	Rect sr = {0, 0, Screen::instance()->height(), Screen::instance()->width()};
-	Rect vr = {ViewRect.y, ViewRect.x, ViewRect.y + ViewRect.h, ViewRect.x + ViewRect.w};
+	Rect sr = MakeRect(0, 0, Screen::instance()->height(), Screen::instance()->width());
+	Rect vr = MakeRect(ViewRect);
 	Screen::instance()->bound_screen_to_rect(ViewRect);
 	OGL_SetWindow(sr, vr, true);
 	
@@ -1438,7 +1438,7 @@ void render_screen(short ticks_elapsed)
 			if (Screen::instance()->lua_hud())
 				Lua_DrawHUD(ticks_elapsed);
 			else {
-				Rect dr = {HUD_DestRect.y, HUD_DestRect.x, HUD_DestRect.y + HUD_DestRect.h, HUD_DestRect.x + HUD_DestRect.w};
+				Rect dr = MakeRect(HUD_DestRect);
 				OGL_DrawHUD(dr, ticks_elapsed);
 			}
 		}
@@ -1766,9 +1766,9 @@ void render_overhead_map(struct view_data *view)
 #ifdef HAVE_OPENGL
 	if (OGL_IsActive()) {
 		// Set OpenGL viewport to world view
-		Rect sr = {0, 0, Screen::instance()->height(), Screen::instance()->width()};
+		Rect sr = MakeRect(0, 0, Screen::instance()->height(), Screen::instance()->width());
 		SDL_Rect MapRect = Screen::instance()->map_rect();
-		Rect mr = {MapRect.y, MapRect.x, MapRect.y + MapRect.h, MapRect.x + MapRect.w};
+		Rect mr = MakeRect(MapRect);
 		Screen::instance()->bound_screen_to_rect(MapRect);
 		OGL_SetWindow(sr, mr, true);
 	}

--- a/Source_Files/RenderOther/sdl_fonts.h
+++ b/Source_Files/RenderOther/sdl_fonts.h
@@ -117,7 +117,7 @@ class ttf_font_info : public font_info {
 public:
 	uint16 get_ascent() const { return TTF_FontAscent(m_styles[styleNormal]); };
 	uint16 get_height() const { return TTF_FontHeight(m_styles[styleNormal]); };
-	uint16 get_line_height() const { return max(TTF_FontLineSkip(m_styles[styleNormal]), TTF_FontHeight(m_styles[styleNormal])) + m_adjust_height; }
+	uint16 get_line_height() const { return std::max(TTF_FontLineSkip(m_styles[styleNormal]), TTF_FontHeight(m_styles[styleNormal])) + m_adjust_height; }
 	uint16 get_descent() const { return -TTF_FontDescent(m_styles[styleNormal]); }
 	int16 get_leading() const { return get_line_height() - get_ascent() - get_descent(); }
 

--- a/Source_Files/Sound/Decoder.cpp
+++ b/Source_Files/Sound/Decoder.cpp
@@ -30,7 +30,7 @@
 #include "FFmpegDecoder.h"
 #include <memory>
 
-using std::auto_ptr;
+using std::unique_ptr;
 
 StreamDecoder *StreamDecoder::Get(FileSpecifier& File)
 {
@@ -38,7 +38,7 @@ StreamDecoder *StreamDecoder::Get(FileSpecifier& File)
 
 #ifdef HAVE_FFMPEG
 	{
-		auto_ptr<FFmpegDecoder> ffmpegDecoder(new FFmpegDecoder);
+		unique_ptr<FFmpegDecoder> ffmpegDecoder(new FFmpegDecoder);
 		if (ffmpegDecoder->Open(File))
 			return ffmpegDecoder.release();
 	}
@@ -46,13 +46,13 @@ StreamDecoder *StreamDecoder::Get(FileSpecifier& File)
 
 #ifdef HAVE_SNDFILE
 	{ 
-		auto_ptr<SndfileDecoder> sndfileDecoder(new SndfileDecoder);
+		unique_ptr<SndfileDecoder> sndfileDecoder(new SndfileDecoder);
 		if (sndfileDecoder->Open(File))
 			return sndfileDecoder.release();
 	}
 #else
 	{
-		auto_ptr<BasicIFFDecoder> iffDecoder(new BasicIFFDecoder);
+		unique_ptr<BasicIFFDecoder> iffDecoder(new BasicIFFDecoder);
 		if (iffDecoder->Open(File))
 			return iffDecoder.release();
 	}
@@ -60,7 +60,7 @@ StreamDecoder *StreamDecoder::Get(FileSpecifier& File)
 
 #ifdef HAVE_VORBISFILE
 	{
-		auto_ptr<VorbisDecoder> vorbisDecoder(new VorbisDecoder);
+		unique_ptr<VorbisDecoder> vorbisDecoder(new VorbisDecoder);
 		if (vorbisDecoder->Open(File))
 			return vorbisDecoder.release();
 	}
@@ -68,7 +68,7 @@ StreamDecoder *StreamDecoder::Get(FileSpecifier& File)
 
 #ifdef HAVE_MAD
 	{
-		auto_ptr<MADDecoder> madDecoder(new MADDecoder);
+		unique_ptr<MADDecoder> madDecoder(new MADDecoder);
 		if (madDecoder->Open(File))
 			return madDecoder.release();
 	}
@@ -83,7 +83,7 @@ Decoder *Decoder::Get(FileSpecifier &File)
 
 #ifdef HAVE_FFMPEG
 	{
-		auto_ptr<FFmpegDecoder> ffmpegDecoder(new FFmpegDecoder);
+		unique_ptr<FFmpegDecoder> ffmpegDecoder(new FFmpegDecoder);
 		if (ffmpegDecoder->Open(File))
 			return ffmpegDecoder.release();
 	}
@@ -91,13 +91,13 @@ Decoder *Decoder::Get(FileSpecifier &File)
 
 #ifdef HAVE_SNDFILE
 	{
-		auto_ptr<SndfileDecoder> sndfileDecoder(new SndfileDecoder);
+		unique_ptr<SndfileDecoder> sndfileDecoder(new SndfileDecoder);
 		if (sndfileDecoder->Open(File))
 			return sndfileDecoder.release();
 	}
 #else
 	{
-		auto_ptr<BasicIFFDecoder> iffDecoder(new BasicIFFDecoder);
+		unique_ptr<BasicIFFDecoder> iffDecoder(new BasicIFFDecoder);
 		if (iffDecoder->Open(File))
 			return iffDecoder.release();
 	}

--- a/Source_Files/Sound/ReplacementSounds.cpp
+++ b/Source_Files/Sound/ReplacementSounds.cpp
@@ -30,7 +30,7 @@ SoundReplacements *SoundReplacements::m_instance = 0;
 boost::shared_ptr<SoundData> ExternalSoundHeader::LoadExternal(FileSpecifier& File)
 {
 	boost::shared_ptr<SoundData> p;
-	auto_ptr<Decoder> decoder(Decoder::Get(File));
+	std::unique_ptr<Decoder> decoder(Decoder::Get(File));
 	if (!decoder.get()) return p;
 
 	length = decoder->Frames() * decoder->BytesPerFrame();

--- a/Source_Files/Sound/SoundFile.cpp
+++ b/Source_Files/Sound/SoundFile.cpp
@@ -30,6 +30,7 @@ SOUNDFILE.CPP
 
 #include "BStream.h"
 #include <boost/iostreams/stream_buffer.hpp>
+#include <utility>
 
 namespace io = boost::iostreams;
 
@@ -342,7 +343,7 @@ bool M2SoundFile::Open(FileSpecifier& SoundFileSpec)
 {
 	Close();
 
-	std::auto_ptr<OpenedFile> sound_file(new OpenedFile);
+	std::unique_ptr<OpenedFile> sound_file(new OpenedFile);
 
 	if (!SoundFileSpec.Open(*sound_file, false)) return false;
 
@@ -398,7 +399,7 @@ bool M2SoundFile::Open(FileSpecifier& SoundFileSpec)
 	}
 
 	// keep the sound file opened
-	opened_sound_file = sound_file;
+	opened_sound_file = std::move(sound_file);
 	
 	return true;
 }

--- a/Source_Files/Sound/SoundFile.h
+++ b/Source_Files/Sound/SoundFile.h
@@ -186,7 +186,7 @@ private:
 	std::vector< std::vector<SoundDefinition> > sound_definitions;
 
 	static int HeaderSize() { return 260; }
-	std::auto_ptr<OpenedFile> opened_sound_file;
+	std::unique_ptr<OpenedFile> opened_sound_file;
 };
 
 #endif

--- a/Source_Files/TCPMess/CommunicationsChannel.h
+++ b/Source_Files/TCPMess/CommunicationsChannel.h
@@ -119,7 +119,7 @@ public:
 				  Uint32 inOverallTimeout = kSSRSpecificMessageTimeout,
 				  Uint32 inInactivityTimeout = kSSRAnyDataTimeout)
 	{
-		std::auto_ptr<Message> receivedMessage(receiveSpecificMessage(inType, inOverallTimeout, inInactivityTimeout));
+		std::unique_ptr<Message> receivedMessage(receiveSpecificMessage(inType, inOverallTimeout, inInactivityTimeout));
 		tMessage* result = dynamic_cast<tMessage*>(receivedMessage.get());
 		if(result != NULL)
 			receivedMessage.release();

--- a/Source_Files/XML/QuickSave.cpp
+++ b/Source_Files/XML/QuickSave.cpp
@@ -660,7 +660,7 @@ bool create_quick_save(void)
     time(&(save.save_time));
     char fmt_time[256];
     tm *time_info = localtime(&(save.save_time));
-    strftime(fmt_time, 256, "%x %R", time_info);
+    strftime(fmt_time, 256, "%x %H:%M", time_info);
     save.formatted_time = fmt_time;
 
     save.level_name = mac_roman_to_utf8(static_world->level_name);

--- a/Source_Files/XML/QuickSave.cpp
+++ b/Source_Files/XML/QuickSave.cpp
@@ -207,7 +207,7 @@ void w_saves::click(int x, int y)
             || y < get_theme_space(LIST_WIDGET, T_SPACE) || y >= rect.h - get_theme_space(LIST_WIDGET, B_SPACE))
             return;
         
-        if ((y - get_theme_space(LIST_WIDGET, T_SPACE)) / item_height() + top_item < min(num_items, top_item + shown_items))
+        if ((y - get_theme_space(LIST_WIDGET, T_SPACE)) / item_height() + top_item < std::min(num_items, top_item + shown_items))
         {
             size_t old_sel = selection;
             set_selection((y - get_theme_space(LIST_WIDGET, T_SPACE)) / item_height() + top_item);

--- a/Source_Files/shell.cpp
+++ b/Source_Files/shell.cpp
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 		// Run the main loop
 		main_event_loop();
 
-	} catch (exception &e) {
+	} catch (std::exception &e) {
 		try 
 		{
 			logFatal("Unhandled exception: %s", e.what());

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,7 @@ AS_CASE([$target],
           ax_boost_user_filesystem_lib="boost_filesystem-mt"
           AC_CHECK_TOOL([WINDRES], [windres], [:])
           AC_DEFINE([WIN32_DISABLE_MUSIC], [1], [Win32 music disabled])
+          CPPFLAGS="-D__USE_MINGW_ANSI_STDIO $CPPFLAGS"
           LIBS="$LIBS -ldsound -lwsock32"
           LDFLAGS="$LDFLAGS -Wl,-subsystem,windows" ],
         [*-*-netbsd*],

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,9 @@ AC_PROG_OBJCXX
 AC_PROG_INSTALL
 AC_PROG_RANLIB
 
+dnl Require C++11 or newer and enable C++11 if needed.
+AX_CXX_COMPILE_STDCXX([11], [], [mandatory])
+
 dnl Some platform specific stuff.
 AS_CASE([$target],
         [*-*-mingw32*],

--- a/m4/m4-ax_cxx_compile_stdcxx.m4
+++ b/m4/m4-ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,982 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
+#   or '14' (for the C++14 standard).
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016 Krzesimir Nowak <qdlacz@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AX_REQUIRE_DEFINED([AC_MSG_WARN])
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+  ax_cv_cxx_compile_cxx$1,
+  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+    [ax_cv_cxx_compile_cxx$1=yes],
+    [ax_cv_cxx_compile_cxx$1=no])])
+  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+    ac_success=yes
+  fi
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXX="$CXX"
+         CXX="$CXX $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXX="$ac_save_CXX"])
+      if eval test x\$$cachevar = xyes; then
+        CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
+        fi
+      done
+      if test x$ac_success = xyes; then
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+  m4_if([$1], [17], [AC_MSG_WARN([C++17 is not yet standardized, so the checks may change in incompatible ways anytime])])
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+)
+
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+)
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201103L
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_separators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus <= 201402L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#if defined(__clang__)
+  #define REALLY_CLANG
+#else
+  #if defined(__GNUC__)
+    #define REALLY_GCC
+  #endif
+#endif
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+#if !defined(REALLY_CLANG)
+  namespace test_constexpr_lambdas
+  {
+
+    // TODO: test it with clang++ from git
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+#if !defined(REALLY_CLANG)
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    // TODO: test it with clang++ from git
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+#if !defined(REALLY_CLANG)
+  namespace test_structured_bindings
+  {
+
+    // TODO: test it with clang++ from git
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+#if !defined(REALLY_CLANG)
+  namespace test_exception_spec_type_system
+  {
+
+    // TODO: test it with clang++ from git
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus <= 201402L
+
+]])


### PR DESCRIPTION
This PR updates the C++ code to conform to C++11 and allows (and requires) the compilation mode to be C++11 or newer. The driving motivation is to completely drop support for C++03 in order to ease further development. In particular, I have an upcoming change that will have less boilerplate and be more intuitive if it can rely on C++11 features.

Numerous C++11/14/17 conformance-related warnings (including all `Wpedantic`, `Wnarrowing`, `Wformat`, `Wdeprecated` and standard library `Wdeprecated-declarations` warnings) are resolved except for those coming from Boost header `boost/ptr_container/ptr_map.hpp`, which internally references `std::auto_ptr`. Also, GCC 4.8.5 emits a bogus warning about a legal function-ptr-to-object-ptr cast (later versions don't complain).

A major side effect of this PR that warrants attention is that `using namespace std;` directives are removed from all headers. This is done to resolve ambiguity conflicts with `std::byte` under C++17 but it seems like a good practice in any case. (An alternative solution that almost works is to rename all current uses of `byte` to something like `a1_byte` or even just `uint8`, but Win32 headers also potentially define and reference `byte` internally.)

I've successfully compiled this PR with
- GCC versions 4.8.5, 4.9.4, 5.4.1, 6.3.0, and 7.0.1 on Ubuntu (64-bit)
- MinGW-w64 7.1.0 on Windows, both 32- and 64-bit toolchains
- 64-bit Clang 6.0.0 (2017-08-18 snapshot) for Windows, using MinGW headers

The tests were done with all features enabled except for SMPEG (which hasn't been updated to work with SDL2 yet).

Side note: the `headertest` tool proved useful in catching a small, needed change (`Rasterizer_Shader_Class` needing to have its ctor and dtor defined in the .cpp or, alternatively, to have its header include `OGL_FBO.h`) that wasn't caught during the normal build process.