### PR TITLE
Fix tiny heap overflows in Lua script support

### DIFF
--- a/Source_Files/Lua/lua_hud_objects.cpp
+++ b/Source_Files/Lua/lua_hud_objects.cpp
@@ -789,7 +789,7 @@ public:
 
 Lua_Font *Lua_Font::Push(lua_State *L, FontSpecifier *fs)
 {
-	Lua_Font *t = static_cast<Lua_Font *>(L_ObjectClass<Lua_Font_Name, FontSpecifier *>::Push(L, fs));
+	Lua_Font *t = L_ObjectClass::Push<Lua_Font>(L, fs);
 	if (t)
 	{
 		t->m_font_scale = 1.0;
@@ -800,14 +800,14 @@ Lua_Font *Lua_Font::Push(lua_State *L, FontSpecifier *fs)
 
 float Lua_Font::Scale(lua_State *L, int index)
 {
-	Lua_Font *t = static_cast<Lua_Font *>(lua_touserdata(L, index));
+	Lua_Font *t = static_cast<Lua_Font *>(Instance(L, index));
 	if (!t) luaL_typerror(L, index, Lua_Font_Name);
 	return t->m_font_scale;
 }
 
 void Lua_Font::SetScale(lua_State *L, int index, float new_scale)
 {
-	Lua_Font *t = static_cast<Lua_Font *>(lua_touserdata(L, index));
+	Lua_Font *t = static_cast<Lua_Font *>(Instance(L, index));
 	if (!t) luaL_typerror(L, index, Lua_Font_Name);
 	t->m_font_scale = new_scale;
 }
@@ -1081,7 +1081,7 @@ public:
 
 Lua_HUDPlayer_Weapon_Trigger_Bullet *Lua_HUDPlayer_Weapon_Trigger_Bullet::Push(lua_State *L, int16 weapon_index, int16 index)
 {
-	Lua_HUDPlayer_Weapon_Trigger_Bullet *t = static_cast<Lua_HUDPlayer_Weapon_Trigger_Bullet *>(L_Class<Lua_HUDPlayer_Weapon_Trigger_Bullet_Name>::Push(L, index));
+	Lua_HUDPlayer_Weapon_Trigger_Bullet *t = L_Class::Push<Lua_HUDPlayer_Weapon_Trigger_Bullet>(L, index);
 	if (t)
 	{
 		t->m_weapon_index = weapon_index;
@@ -1092,7 +1092,7 @@ Lua_HUDPlayer_Weapon_Trigger_Bullet *Lua_HUDPlayer_Weapon_Trigger_Bullet::Push(l
 
 int16 Lua_HUDPlayer_Weapon_Trigger_Bullet::WeaponIndex(lua_State *L, int index)
 {
-	Lua_HUDPlayer_Weapon_Trigger_Bullet *t = static_cast<Lua_HUDPlayer_Weapon_Trigger_Bullet*>(lua_touserdata(L, index));
+	Lua_HUDPlayer_Weapon_Trigger_Bullet *t = static_cast<Lua_HUDPlayer_Weapon_Trigger_Bullet*>(Instance(L, index));
 	if (!t) luaL_typerror(L, index, Lua_HUDPlayer_Weapon_Trigger_Bullet_Name);
 	return t->m_weapon_index;
 }
@@ -1199,7 +1199,7 @@ public:
 
 Lua_HUDPlayer_Weapon_Trigger_Energy *Lua_HUDPlayer_Weapon_Trigger_Energy::Push(lua_State *L, int16 weapon_index, int16 index)
 {
-	Lua_HUDPlayer_Weapon_Trigger_Energy *t = static_cast<Lua_HUDPlayer_Weapon_Trigger_Energy *>(L_Class<Lua_HUDPlayer_Weapon_Trigger_Energy_Name>::Push(L, index));
+	Lua_HUDPlayer_Weapon_Trigger_Energy *t = L_Class::Push<Lua_HUDPlayer_Weapon_Trigger_Energy>(L, index);
 	if (t)
 	{
 		t->m_weapon_index = weapon_index;
@@ -1210,7 +1210,7 @@ Lua_HUDPlayer_Weapon_Trigger_Energy *Lua_HUDPlayer_Weapon_Trigger_Energy::Push(l
 
 int16 Lua_HUDPlayer_Weapon_Trigger_Energy::WeaponIndex(lua_State *L, int index)
 {
-	Lua_HUDPlayer_Weapon_Trigger_Energy *t = static_cast<Lua_HUDPlayer_Weapon_Trigger_Energy*>(lua_touserdata(L, index));
+	Lua_HUDPlayer_Weapon_Trigger_Energy *t = static_cast<Lua_HUDPlayer_Weapon_Trigger_Energy*>(Instance(L, index));
 	if (!t) luaL_typerror(L, index, Lua_HUDPlayer_Weapon_Trigger_Energy_Name);
 	return t->m_weapon_index;
 }
@@ -1296,7 +1296,7 @@ public:
 
 Lua_HUDPlayer_Weapon_Trigger *Lua_HUDPlayer_Weapon_Trigger::Push(lua_State *L, int16 weapon_index, int16 index)
 {
-	Lua_HUDPlayer_Weapon_Trigger *t = static_cast<Lua_HUDPlayer_Weapon_Trigger *>(L_Class<Lua_HUDPlayer_Weapon_Trigger_Name>::Push(L, index));
+	Lua_HUDPlayer_Weapon_Trigger *t = L_Class::Push<Lua_HUDPlayer_Weapon_Trigger>(L, index);
 	if (t)
 	{
 		t->m_weapon_index = weapon_index;
@@ -1307,7 +1307,7 @@ Lua_HUDPlayer_Weapon_Trigger *Lua_HUDPlayer_Weapon_Trigger::Push(lua_State *L, i
 
 int16 Lua_HUDPlayer_Weapon_Trigger::WeaponIndex(lua_State *L, int index)
 {
-	Lua_HUDPlayer_Weapon_Trigger *t = static_cast<Lua_HUDPlayer_Weapon_Trigger*>(lua_touserdata(L, index));
+	Lua_HUDPlayer_Weapon_Trigger *t = static_cast<Lua_HUDPlayer_Weapon_Trigger*>(Instance(L, index));
 	if (!t) luaL_typerror(L, index, Lua_HUDPlayer_Weapon_Trigger_Name);
 	return t->m_weapon_index;
 }

--- a/Source_Files/Lua/lua_map.cpp
+++ b/Source_Files/Lua/lua_map.cpp
@@ -2215,10 +2215,7 @@ Lua_Light_State* Lua_Light_State::Push(lua_State* L, int16 light_index, int16 in
 		return 0;
 	}
 
-	t = static_cast<Lua_Light_State*>(lua_newuserdata(L, sizeof(Lua_Light_State)));
-	luaL_getmetatable(L, Lua_Light_State_Name);
-	lua_setmetatable(L, -2);
-	t->m_index = index;
+	t = NewInstance<Lua_Light_State>(L, index);
 	t->m_light_index = light_index;
 
 	return t;
@@ -2226,7 +2223,7 @@ Lua_Light_State* Lua_Light_State::Push(lua_State* L, int16 light_index, int16 in
 
 int16 Lua_Light_State::LightIndex(lua_State* L, int index)
 {
-	Lua_Light_State* t = static_cast<Lua_Light_State*>(lua_touserdata(L, index));
+	Lua_Light_State* t = static_cast<Lua_Light_State*>(Instance(L, index));
 	if (!t) luaL_typerror(L, index, Lua_Light_State_Name);
 	return t->m_light_index;
 }

--- a/Source_Files/Lua/lua_player.cpp
+++ b/Source_Files/Lua/lua_player.cpp
@@ -379,14 +379,18 @@ class PlayerSubtable : public L_Class<name>
 {
 public:
 	int16 m_player_index;
-	static PlayerSubtable *Push(lua_State *L, int16 player_index, int16 index);
+
+	template<typename instance_t = PlayerSubtable /*or a derived class*/>
+	static instance_t *Push(lua_State *L, int16 player_index, int16 index);
+
 	static int16 PlayerIndex(lua_State *L, int index);
 };
 
 template<char *name>
-PlayerSubtable<name> *PlayerSubtable<name>::Push(lua_State *L, int16 player_index, int16 index)
+template<typename instance_t>
+instance_t *PlayerSubtable<name>::Push(lua_State *L, int16 player_index, int16 index)
 {
-	PlayerSubtable<name> *t = 0;
+	instance_t *t = 0;
 
 	if (!L_Class<name, int16>::Valid(index) || !Lua_Player::Valid(player_index))
 	{
@@ -394,10 +398,7 @@ PlayerSubtable<name> *PlayerSubtable<name>::Push(lua_State *L, int16 player_inde
 		return 0;
 	}
 
-	t = static_cast<PlayerSubtable<name>*>(lua_newuserdata(L, sizeof(PlayerSubtable<name>)));
-	luaL_getmetatable(L, name);
-	lua_setmetatable(L, -2);
-	t->m_index = index;
+	t = L_Class<name>::template NewInstance<instance_t>(L, index);
 	t->m_player_index = player_index;
 
 	return t;
@@ -406,7 +407,7 @@ PlayerSubtable<name> *PlayerSubtable<name>::Push(lua_State *L, int16 player_inde
 template<char *name>
 int16 PlayerSubtable<name>::PlayerIndex(lua_State *L, int index)
 {
-	PlayerSubtable<name> *t = static_cast<PlayerSubtable<name> *>(lua_touserdata(L, index));
+	PlayerSubtable<name> *t = static_cast<PlayerSubtable<name> *>(L_Class<name>::Instance(L, index));
 	if (!t) luaL_typerror(L, index, name);
 	return t->m_player_index;
 }
@@ -1150,7 +1151,7 @@ public:
 
 Lua_Player_Weapon_Trigger *Lua_Player_Weapon_Trigger::Push(lua_State *L, int16 player_index, int16 weapon_index, int16 index)
 {
-	Lua_Player_Weapon_Trigger *t = static_cast<Lua_Player_Weapon_Trigger *>(PlayerSubtable<Lua_Player_Weapon_Trigger_Name>::Push(L, player_index, index));
+	Lua_Player_Weapon_Trigger *t = PlayerSubtable::Push<Lua_Player_Weapon_Trigger>(L, player_index, index);
 	if (t)
 	{
 		t->m_weapon_index = weapon_index;
@@ -1161,7 +1162,7 @@ Lua_Player_Weapon_Trigger *Lua_Player_Weapon_Trigger::Push(lua_State *L, int16 p
 
 int16 Lua_Player_Weapon_Trigger::WeaponIndex(lua_State *L, int index)
 {
-	Lua_Player_Weapon_Trigger *t = static_cast<Lua_Player_Weapon_Trigger*>(lua_touserdata(L, index));
+	Lua_Player_Weapon_Trigger *t = static_cast<Lua_Player_Weapon_Trigger*>(Instance(L, index));
 	if (!t) luaL_typerror(L, index, Lua_Player_Weapon_Trigger_Name);
 	return t->m_weapon_index;
 }

--- a/Source_Files/Lua/lua_templates.h
+++ b/Source_Files/Lua/lua_templates.h
@@ -38,6 +38,7 @@ extern "C"
 #include "lua_mnemonics.h" // for lang_def and mnemonics
 #include <sstream>
 #include <map>
+#include <new>
 
 static inline int luaL_typerror(lua_State* L, int narg, const char* tname)
 {
@@ -75,7 +76,11 @@ public:
 	typedef index_t index_type;
 
 	static void Register(lua_State *L, const luaL_Reg get[] = 0, const luaL_Reg set[] = 0, const luaL_Reg metatable[] = 0);
-	static L_Class *Push(lua_State *L, index_t index);
+
+	template<typename instance_t = L_Class /*or a derived class*/>
+	static instance_t *Push(lua_State *L, index_t index);
+
+	static L_Class *Instance(lua_State *L, index_t index);
 	static index_t Index(lua_State *L, int index);
 	static bool Is(lua_State *L, int index);
 	static void Invalidate(lua_State *L, index_t index);
@@ -102,6 +107,9 @@ private:
 	static int _tostring(lua_State *L);
 
 protected:
+	template<typename instance_t /*L_Class or a derived class*/>
+	static instance_t *NewInstance(lua_State *L, index_t index);
+
 	static int _get(lua_State *L);
 	
 	// registry keys
@@ -193,9 +201,42 @@ void L_Class<name, index_t>::Register(lua_State *L, const luaL_Reg get[], const 
 }
 
 template<char *name, typename index_t>
-L_Class<name, index_t> *L_Class<name, index_t>::Push(lua_State *L, index_t index)
+template<typename instance_t>
+instance_t *L_Class<name, index_t>::NewInstance(lua_State *L, index_t index)
 {
-	L_Class<name, index_t>* t = 0;
+	// Storing an L_Class ptr at offset 0 in the userdata block lets
+	// L_Class::Instance() avoid having to be type-dependent on instance_t
+	
+	struct UserdataBlock // standard-layout
+	{
+		L_Class *basePtr; // offset 0
+		alignas(instance_t) unsigned char instanceBuffer[sizeof(instance_t)];
+	};
+	
+	auto blockPtr = new (lua_newuserdata(L, sizeof(UserdataBlock))) UserdataBlock;
+	auto instancePtr = new (blockPtr->instanceBuffer) instance_t();
+	
+	blockPtr->basePtr = instancePtr;
+	blockPtr->basePtr->m_index = index;
+	luaL_getmetatable(L, name);
+	lua_setmetatable(L, -2);
+	
+	return instancePtr;
+}
+
+template<char *name, typename index_t>
+L_Class<name, index_t> *L_Class<name, index_t>::Instance(lua_State *L, index_t index)
+{
+	// The userdata block is assumed to start with an L_Class ptr; see L_Class::NewInstance()
+	void * blockPtr = lua_touserdata(L, index);
+	return blockPtr ? *static_cast<L_Class **>(blockPtr) : nullptr;
+}
+
+template<char *name, typename index_t>
+template<typename instance_t>
+instance_t *L_Class<name, index_t>::Push(lua_State *L, index_t index)
+{
+	instance_t* t = 0;
 
 	if (!Valid(index))
 	{
@@ -215,10 +256,7 @@ L_Class<name, index_t> *L_Class<name, index_t>::Push(lua_State *L, index_t index
 		lua_pop(L, 1);
 
 		// create an instance
-		t = static_cast<L_Class<name, index_t> *>(lua_newuserdata(L, sizeof(L_Class<name, index_t>)));
-		luaL_getmetatable(L, name);
-		lua_setmetatable(L, -2);
-		t->m_index = index;
+		t = NewInstance<instance_t>(L, index);
 
 		// insert it into the instance table
 		lua_pushnumber(L, index);
@@ -228,7 +266,7 @@ L_Class<name, index_t> *L_Class<name, index_t>::Push(lua_State *L, index_t index
 	}
 	else
 	{
-		t = static_cast<L_Class<name, index_t> *>(lua_touserdata(L, -1));
+		t = static_cast<instance_t *>(Instance(L, -1));
 	}
 
 	// remove the instance table
@@ -240,7 +278,7 @@ L_Class<name, index_t> *L_Class<name, index_t>::Push(lua_State *L, index_t index
 template<char *name, typename index_t>
 index_t L_Class<name, index_t>::Index(lua_State *L, int index)
 {
-	L_Class<name, index_t> *t = static_cast<L_Class<name, index_t> *>(lua_touserdata(L, index));
+	L_Class<name, index_t> *t = Instance(L, index);
 	if (!t) luaL_typerror(L, index, name);
 	return t->m_index;
 }
@@ -248,7 +286,7 @@ index_t L_Class<name, index_t>::Index(lua_State *L, int index)
 template<char *name, typename index_t>
 bool L_Class<name, index_t>::Is(lua_State *L, int index)
 {
-	L_Class<name, index_t>* t = static_cast<L_Class<name, index_t>*>(lua_touserdata(L, index));
+	L_Class<name, index_t>* t = Instance(L, index);
 	if (!t) return false;
 
 	if (lua_getmetatable(L, index))
@@ -908,9 +946,11 @@ int L_EnumContainer<name, T>::_get_enumcontainer(lua_State *L)
 
 // object classes hold an object_t as well as numeric index_t
 template<char *name, typename object_t, typename index_t = int16>
-class L_ObjectClass : L_Class<name, index_t> {
+class L_ObjectClass : public L_Class<name, index_t> {
 public:
-	static L_ObjectClass<name, object_t, index_t> *Push(lua_State *L, object_t object);
+	template<typename instance_t = L_ObjectClass /*or a derived class*/>
+	static instance_t *Push(lua_State *L, object_t object);
+
 	static object_t ObjectAtIndex(lua_State *L, index_t index);
 	static object_t Object(lua_State *L, int index);
 	static void Invalidate(lua_State *L, index_t index);
@@ -946,7 +986,8 @@ boost::function<bool (index_t)> L_ObjectClass<name, object_t, index_t>::Valid = 
 
 
 template<char *name, typename object_t, typename index_t>
-L_ObjectClass<name, object_t, index_t> *L_ObjectClass<name, object_t, index_t>::Push(lua_State *L, object_t object)
+template<typename instance_t>
+instance_t *L_ObjectClass<name, object_t, index_t>::Push(lua_State *L, object_t object)
 {
 	// find unused index in our map
 	index_t idx = 0;
@@ -955,10 +996,7 @@ L_ObjectClass<name, object_t, index_t> *L_ObjectClass<name, object_t, index_t>::
 	_objects[idx] = object;
 	
 	// create an instance
-	L_ObjectClass<name, object_t, index_t> *t = static_cast<L_ObjectClass<name, object_t, index_t> *>(lua_newuserdata(L, sizeof(L_ObjectClass<name, object_t, index_t>)));
-	luaL_getmetatable(L, name);
-	lua_setmetatable(L, -2);
-	t->m_index = idx;
+	instance_t *t = L_Class<name, index_t>::template NewInstance<instance_t>(L, idx);
 	
 	return t;
 }


### PR DESCRIPTION
This PR fixes tiny heap overflows in the Lua script support code by refactoring the bits that create and query Lua "full userdata" blocks. This refactoring makes use of C++11 features (default template parameters in member templates, alignas) for code clarity, so there is a soft dependency on #82.

I found these overflows because they trigger Windows' built-in heap consistency checks that are automatically enabled for processes started attached to a debugger. Using [GFlags](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/gflags) to make allocation checking more aggressive let me locate the offending code more precisely.