### PR TITLE
replace isqrt with simpler equivalent version

### DIFF
--- a/Source_Files/GameWorld/monsters.h
+++ b/Source_Files/GameWorld/monsters.h
@@ -371,4 +371,11 @@ public:
 	}
 };
 
+class monster_ref {
+	monster_data* m_dataptr;
+public:
+	monster_ref(monster_data* data) : m_dataptr(data) {}
+	monster_ref() : m_dataptr(nullptr) {}
+};
+
 #endif

--- a/Source_Files/GameWorld/monsters.h
+++ b/Source_Files/GameWorld/monsters.h
@@ -165,7 +165,7 @@ enum /* monster types */
 #define MONSTER_IS_IDLE(m) ((m)->flags&(uint16)0x0800)
 #define SET_MONSTER_IDLE_STATUS(m,v) ((void)((v)?((m)->flags|=(uint16)0x0800):((m)->flags&=(uint16)~0x0800)))
 
-/* this flag is set if our current target has inflicted damage on us (because if he hasn’t, we’ll
+/* this flag is set if our current target has inflicted damage on us (because if he hasn√ït, we√ïll
 	probably go after somebody else if they hit us first) */
 #define TARGET_HAS_DONE_DAMAGE(m) ((m)->flags&(uint16)0x0200)
 #define CLEAR_TARGET_DAMAGE_FLAG(m) ((m)->flags&=(uint16)~0x0200)
@@ -226,7 +226,7 @@ struct monster_data /* 64 bytes */
 	uint16 flags; /* [slot_used.1] [need_path.1] [recovering_from_hit.1] [active.1] [idle.1] [berserk.1] [target_damage.1] [unused.6] [never_activated.1] [demoted.1] [promoted.1] */
 	
 	short path; /* NONE is no path (the need path bit should be set in this case) */
-	world_distance path_segment_length; /* distance until we’re through with this segment of the path */
+	world_distance path_segment_length; /* distance until we√ïre through with this segment of the path */
 	world_distance desired_height;
 	
 	short mode, action;
@@ -246,7 +246,7 @@ struct monster_data /* 64 bytes */
 	
 	short goal_polygon_index; // used instead of NONE when generating random paths
 
-	// copied from monster’s object every tick but updated with height
+	// copied from monster√ïs object every tick but updated with height
 	world_point3d sound_location;
 	short sound_polygon_index;
 
@@ -254,9 +254,12 @@ struct monster_data /* 64 bytes */
 	
 	short unused[7];
 };
-const int SIZEOF_monster_data = 64;
+constexpr int SIZEOF_monster_data = 64;
 
-const int SIZEOF_monster_definition = 156;
+constexpr int SIZEOF_monster_definition = 156;
+
+
+
 
 /* ---------- globals */
 
@@ -272,7 +275,7 @@ extern vector<monster_data> MonsterList;
 void initialize_monsters(void);
 void initialize_monsters_for_new_level(void); /* when a map is loaded */
 
-void move_monsters(void); /* assumes ∂t==1 tick */
+void move_monsters(void); /* assumes ¬∂t==1 tick */
 
 short new_monster(struct object_location *location, short monster_code);
 void remove_monster(short monster_index);
@@ -348,5 +351,24 @@ void parse_mml_damage_kicks(const InfoTree& root);
 void reset_mml_damage_kicks();
 void parse_mml_monsters(const InfoTree& root);
 void reset_mml_monsters();
+
+class monster_handle {
+	short m_monster_idx;
+public:
+	constexpr monster_handle() : m_monster_idx(NONE) {}
+	constexpr monster_handle(short monster_idx) : m_monster_idx(monster_idx) {}
+	
+	constexpr short get_handle() const {
+		return m_monster_idx;
+	}
+	
+	constexpr bool is_none() const {
+		return get_handle() == NONE;
+	}
+	
+	monster_data* get_data() {
+		return get_monster_data(m_monster_idx);
+	}
+};
 
 #endif

--- a/Source_Files/GameWorld/world.h
+++ b/Source_Files/GameWorld/world.h
@@ -43,31 +43,32 @@ Jul 1, 2000 (Loren Petrich):
 #include "cstypes.h"
 
 /* ---------- constants */
-
 #define TRIG_SHIFT 10
 #define TRIG_MAGNITUDE (1<<TRIG_SHIFT)
 
 #define ANGULAR_BITS 9
-#define NUMBER_OF_ANGLES ((short)(1<<ANGULAR_BITS))
-#define FULL_CIRCLE NUMBER_OF_ANGLES
-#define QUARTER_CIRCLE ((short)(NUMBER_OF_ANGLES/4))
-#define HALF_CIRCLE ((short)(NUMBER_OF_ANGLES/2))
-#define THREE_QUARTER_CIRCLE ((short)((NUMBER_OF_ANGLES*3)/4))
-#define EIGHTH_CIRCLE ((short)(NUMBER_OF_ANGLES/8))
-#define SIXTEENTH_CIRCLE ((short)(NUMBER_OF_ANGLES/16))
+
+constexpr short 
+	NUMBER_OF_ANGLES = 1 << ANGULAR_BITS,
+	FULL_CIRCLE = NUMBER_OF_ANGLES,
+	QUARTER_CIRCLE = NUMBER_OF_ANGLES / 4,
+	HALF_CIRCLE = NUMBER_OF_ANGLES / 2,
+	THREE_QUARTER_CIRCLE = (NUMBER_OF_ANGLES*3) / 4,
+	EIGHTH_CIRCLE = NUMBER_OF_ANGLES / 8,
+	SIXTEENTH_CIRCLE = NUMBER_OF_ANGLES / 16;
 
 #define WORLD_FRACTIONAL_BITS 10
-#define WORLD_ONE ((world_distance)(1<<WORLD_FRACTIONAL_BITS))
-#define WORLD_ONE_HALF ((world_distance)(WORLD_ONE/2))
-#define WORLD_ONE_FOURTH ((world_distance)(WORLD_ONE/4))
-#define WORLD_THREE_FOURTHS ((world_distance)((WORLD_ONE*3)/4))
 
-#define DEFAULT_RANDOM_SEED ((uint16)0xfded)
+constexpr world_distance 
+	WORLD_ONE = 1 << WORLD_FRACTIONAL_BITS,
+	WORLD_ONE_HALF = WORLD_ONE / 2,
+	WORLD_ONE_FOURTH = WORLD_ONE / 4,
+	WORLD_THREE_FOURTHS = (WORLD_ONE*3)/4;
 
+constexpr uint16 DEFAULT_RANDOM_SEED = 0xfded;
 /* ---------- types */
-
-typedef int16 angle;
-typedef int16 world_distance;
+using angle = int16;
+using world_distance = int16;
 
 /* ---------- macros */
 
@@ -85,7 +86,7 @@ typedef int16 world_distance;
 /* arguments must be positive (!) or use guess_hypotenuse() */
 #define GUESS_HYPOTENUSE(x, y) ((x)>(y) ? ((x)+((y)>>1)) : ((y)+((x)>>1)))
 
-/* -360ก<t<720ก (!) or use normalize_angle() */
+/* -360ยก<t<720ยก (!) or use normalize_angle() */
 //#define NORMALIZE_ANGLE(t) ((t)<(angle)0?(t)+NUMBER_OF_ANGLES:((t)>=NUMBER_OF_ANGLES?(t)-NUMBER_OF_ANGLES:(t)))
 #define NORMALIZE_ANGLE(t) ((t)&(angle)(NUMBER_OF_ANGLES-1))
 
@@ -193,7 +194,7 @@ world_point3d *translate_point3d(world_point3d *point, world_distance distance, 
 world_point2d *transform_point2d(world_point2d *point, world_point2d *origin, angle theta);
 world_point3d *transform_point3d(world_point3d *point, world_point3d *origin, angle theta, angle phi);
 
-/* angle is in [0,NUMBER_OF_ANGLES), or, [0,2น) */
+/* angle is in [0,NUMBER_OF_ANGLES), or, [0,2ยน) */
 // LP change: made this long-distance friendly
 angle arctangent(int32 x, int32 y);
 


### PR DESCRIPTION
I tested this using this program

#include <cmath>
#include <iostream>
using int32 = int;
using uint32 = unsigned;
int32 isqrt(
	 uint32 x)
{
	uint32 r, nr, m;

	r = 0;
	m = 0x40000000;

	do
	{
		nr = r + m;
		if (nr <= x)
		{
			x -= nr;
			r = nr + m;
		}
		r >>= 1;
		m >>= 2;
	} while (m != 0);

	if (x>r) r += 1;
	return r;
}


int32 isqrt_modern(uint32 x) {
	return (int32)(sqrt((double)x) + 0.5);
}

int main()
{
	unsigned i = 0;

	do {
		int32 result_old = isqrt(i);
		int32 result_new = isqrt_modern(i);

		if (result_old != result_new) {
			std::cout << "isqrt_modern deviates: input: " << i << ", old_result: " << result_old << ", new_result: " << result_new << "\n";
		}
	} while (++i != 0);
	system("PAUSE");
    return 0;
}

Running this on my system showed that the replacement function is equivalent to the old one. This is easier to read and will run faster on any modern machine. 