### PR TITLE
update startup error for M1 & SDL

### DIFF
--- a/Source_Files/Misc/DefaultStringSets.cpp
+++ b/Source_Files/Misc/DefaultStringSets.cpp
@@ -50,7 +50,7 @@ static const char* sStringSetNumber128[] = {
     "Sorry, $appName$ requires System Software 7.0 or higher.",
     "Sorry, $appName$ requires at least 3000k of free RAM.",
     "Sorry, $appName$ requires a 13\" monitor (640x480) or larger which can be set to at least 256 colors or grays.",
-    "Please be sure the files 'Map', 'Shapes', 'Images' and 'Sounds' are correctly installed and try again.",
+    "Please be sure the 'Map' file, 'Shapes' file, 'Images' or 'Marathon.appl' files, 'Sounds' file, and a theme plugin are correctly installed and try again.  If this message persists, check your Aleph One preferences, scenario preferences, and scenario MML for misnamed files.",
     "$appName$ couldn't initialize the sound.",
     "$appName$ has encountered a file system error.  Check to make sure you have enough disk space and that you are not trying to save to a locked volume.",
     "This copy of $appName$ has been modified, perhaps by a virus.  Please re-install it from the original disks.",


### PR DESCRIPTION
This error message is misleading and caused me a great deal of frustration when I was new, so I've updated it to help new players.   It gets triggered if Aleph One does not have a theme plugin, yet says nothing about that.  Furthermore, M1 scenarios have a 'Marathon.appl' file, not an Images file.  Finally, even if all files are present A1 skips them over if they are not correctly referenced in preferences or MML, so I've added a helpful note to check there, too.