### PR TITLE
Handle ESC in M1 terminals the way M1 apparently did

### DIFF
--- a/Source_Files/RenderOther/computer_interface.cpp
+++ b/Source_Files/RenderOther/computer_interface.cpp
@@ -2278,6 +2278,10 @@ void MarathonTerminalCompiler::CompileLine(const std::string& line)
 				out.push_back(*it);
 			}
 		}
+		else if (*it == 0x1B)
+		{
+			out.push_back(' ');
+		}
 		else
 		{
 			out.push_back(*it);


### PR DESCRIPTION
In the third level of M1, "Never Burn Money", there is a Compiler-randomized terminal that contains two instances of the ASCII `ESC` character (0x1B). Marathon renders them as spaces. Aleph One ignores them.

The line in question begins with `aAnger made her careless and she mis~`. The ESCs follow the tilde.

![Original](https://bunker.tejat.net/term_escape_original.png)
Original

![Aleph One's rendition (scaled to matching resolution)](https://bunker.tejat.net/term_escape_a1.png)
Aleph One's rendition (scaled to matching resolution)

![Location of terminal](https://bunker.tejat.net/term_escape_location.png)
Location of terminal

I might not have even considered this worth fixing, except that we apparently care enough about accuracy to reproduce the famous "Phhht!" substitution... :)

(The screenshots also show differences in page length and line wrap location, but I haven't checked if that's just because of my unusual screen resolution.)