### PR TITLE
M2 rescue mission fix

### DIFF
--- a/Source_Files/GameWorld/monsters.cpp
+++ b/Source_Files/GameWorld/monsters.cpp
@@ -448,9 +448,9 @@ short new_monster(
 	}
 
 	/* keep track of how many civilians we drop on this level */
-	if ((static_world->mission_flags & _mission_rescue_m1) &&
+	if ((static_world->mission_flags & (_mission_rescue_m1|_mission_rescue)) &&
 	    monster_index!=NONE && 
-	    (definition->_class&_class_human_civilian_m1)) 
+	    (definition->_class&(_class_human_civilian_m1|_class_human_civilian))) 
 	{
 		dynamic_world->current_civilian_count+= 1;
 	}
@@ -1613,7 +1613,7 @@ void damage_monster(
 						if (definition->_class&_class_human_civilian) dynamic_world->civilians_killed_by_players+= 1;
 					}
 
-					if ((static_world->mission_flags & _mission_rescue_m1) && (definition->_class & _class_human_civilian_m1))
+					if ((static_world->mission_flags & (_mission_rescue_m1|_mission_rescue)) && (definition->_class & (_class_human_civilian_m1|_class_human_civilian)))
 					{
 						dynamic_world->current_civilian_causalties += 1;
 					}

--- a/Source_Files/GameWorld/monsters.cpp
+++ b/Source_Files/GameWorld/monsters.cpp
@@ -448,9 +448,15 @@ short new_monster(
 	}
 
 	/* keep track of how many civilians we drop on this level */
-	if ((static_world->mission_flags & (_mission_rescue_m1|_mission_rescue)) &&
+	if ((static_world->mission_flags & _mission_rescue_m1) &&
 	    monster_index!=NONE && 
-	    (definition->_class&(_class_human_civilian_m1|_class_human_civilian))) 
+	    (definition->_class&_class_human_civilian_m1)) 
+	{
+		dynamic_world->current_civilian_count+= 1;
+	}
+	if ((static_world->mission_flags & _mission_rescue) &&
+	    monster_index!=NONE && 
+	    (definition->_class&_class_human_civilian)) 
 	{
 		dynamic_world->current_civilian_count+= 1;
 	}
@@ -1613,7 +1619,12 @@ void damage_monster(
 						if (definition->_class&_class_human_civilian) dynamic_world->civilians_killed_by_players+= 1;
 					}
 
-					if ((static_world->mission_flags & (_mission_rescue_m1|_mission_rescue)) && (definition->_class & (_class_human_civilian_m1|_class_human_civilian)))
+					if ((static_world->mission_flags & _mission_rescue_m1) && (definition->_class & _class_human_civilian_m1))
+					{
+						dynamic_world->current_civilian_causalties += 1;
+					}
+
+					if ((static_world->mission_flags & _mission_rescue) && (definition->_class & _class_human_civilian))
 					{
 						dynamic_world->current_civilian_causalties += 1;
 					}


### PR DESCRIPTION
Currently, Aleph One seems to ignore the Rescue mission flag on Infinity/M2 maps - for this reason, M1A1 opted to eliminate the SUCCESS message from The Rose and have the exit term only display the original FAILURE message as a FINISHED message.  This change fixes that behaviour, allowing an Infinity/M2 map to show a FAILED message if you've killed all the BoBs on a level flagged as Rescue.

It appears that the logic in computer_interface.cpp to display a FAILED message compares "current_civilian_casualties" and "current_civilian_count," which are calculated in monsters.cpp.  However, monsters.cpp only performs this calculation for M1 rescue maps, and only counts M1 BoBs.  My change tells it to perform the calculation also on M2 rescue maps, and to also count M2 BoBs.

I'm sure there are other (better?) ways to go about this, and I'm not really a programmer, but I've tested this on the scenario I've been working on and it appears to work!