### PR TITLE
Refactor aim input handling

### DIFF
--- a/Source_Files/GameWorld/player.h
+++ b/Source_Files/GameWorld/player.h
@@ -533,10 +533,19 @@ void accelerate_player(short monster_index, world_distance vertical_velocity, an
 
 void kill_player_physics_variables(short player_index);
 
-uint32 mask_in_absolute_positioning_information(uint32 action_flags, _fixed yaw, _fixed pitch, _fixed velocity);
 void get_absolute_pitch_range(_fixed *minimum, _fixed *maximum);
 
 _fixed get_player_forward_velocity_scale(short player_index);
+
+// Delta from the low-precision physical aim to the virtual "true" aim implied by high-precision aiming input;
+// |<yaw or pitch delta>| <= FIXED_ONE/2
+fixed_yaw_pitch virtual_aim_delta();
+
+// Resync the virtual aim to the current physical aim
+void resync_virtual_aim();
+
+// Update the virtual aim and return action flags updated with yaw/pitch deltas (if appropriate)
+uint32 process_aim_input(uint32 action_flags, fixed_yaw_pitch delta);
 
 
 // LP: to pack and unpack this data;

--- a/Source_Files/GameWorld/world.h
+++ b/Source_Files/GameWorld/world.h
@@ -67,6 +67,7 @@ Jul 1, 2000 (Loren Petrich):
 /* ---------- types */
 
 typedef int16 angle;
+typedef _fixed fixed_angle; // angle with _fixed precision
 typedef int16 world_distance;
 
 /* ---------- macros */
@@ -154,6 +155,11 @@ struct long_vector3d
 	int32 i, j, k;
 };
 typedef struct long_vector3d long_vector3d;
+
+/* ---------- angle structures */
+
+// A relative or (possibly non-normalized) absolute direction
+struct fixed_yaw_pitch { fixed_angle yaw, pitch; };
 
 /* ---------- locations */
 

--- a/Source_Files/Input/mouse.h
+++ b/Source_Files/Input/mouse.h
@@ -27,15 +27,13 @@ Tuesday, January 17, 1995 2:53:17 PM  (Jason')
         semi-hacky scheme in SDL to let mouse buttons simulate keypresses
 */
 
-#include "cstypes.h"
+#include "world.h"
 
 void enter_mouse(short type);
-void test_mouse(short type, uint32 *action_flags, _fixed *delta_yaw, _fixed *delta_pitch, _fixed *delta_velocity);
+fixed_yaw_pitch pull_mouselook_delta();
 void exit_mouse(short type);
 void mouse_idle(short type);
 void recenter_mouse(void);
-float lostMousePrecisionX();
-float lostMousePrecisionY();
 
 // ZZZ: stuff of various hackiness levels to pretend mouse buttons are keys
 void mouse_buttons_become_keypresses(Uint8* ioKeyMap);

--- a/Source_Files/Lua/lua_player.cpp
+++ b/Source_Files/Lua/lua_player.cpp
@@ -2024,7 +2024,11 @@ static int Lua_Player_Set_Direction(lua_State *L)
 	player_data *player = get_player_data(player_index);
 	player->variables.direction = INTEGER_TO_FIXED((int)(facing/AngleConvert));
 	instantiate_physics_variables(get_physics_constants_for_model(static_world->physics_model, 0), &player->variables, player_index, false, false);
-	resync_virtual_aim();
+	
+	// Lua control locks virtual aim to physical aim
+	if (player_index == local_player_index)
+		resync_virtual_aim();
+	
 	return 0;
 }
 
@@ -2039,7 +2043,11 @@ static int Lua_Player_Set_Elevation(lua_State *L)
 	player_data *player = get_player_data(player_index);
 	player->variables.elevation = INTEGER_TO_FIXED((int)(elevation/AngleConvert));
 	instantiate_physics_variables(get_physics_constants_for_model(static_world->physics_model, 0), &player->variables, player_index, false, false);
-	resync_virtual_aim();
+	
+	// Lua control locks virtual aim to physical aim
+	if (player_index == local_player_index)
+		resync_virtual_aim();
+	
 	return 0;
 }
 

--- a/Source_Files/Lua/lua_player.cpp
+++ b/Source_Files/Lua/lua_player.cpp
@@ -2024,6 +2024,7 @@ static int Lua_Player_Set_Direction(lua_State *L)
 	player_data *player = get_player_data(player_index);
 	player->variables.direction = INTEGER_TO_FIXED((int)(facing/AngleConvert));
 	instantiate_physics_variables(get_physics_constants_for_model(static_world->physics_model, 0), &player->variables, player_index, false, false);
+	resync_virtual_aim();
 	return 0;
 }
 
@@ -2038,6 +2039,7 @@ static int Lua_Player_Set_Elevation(lua_State *L)
 	player_data *player = get_player_data(player_index);
 	player->variables.elevation = INTEGER_TO_FIXED((int)(elevation/AngleConvert));
 	instantiate_physics_variables(get_physics_constants_for_model(static_world->physics_model, 0), &player->variables, player_index, false, false);
+	resync_virtual_aim();
 	return 0;
 }
 

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -3057,7 +3057,7 @@ InfoTree input_preferences_tree()
 	root.put_attr("modifiers", input_preferences->modifiers);
 	root.put_attr("sens_horizontal", input_preferences->sens_horizontal);
 	root.put_attr("sens_vertical", input_preferences->sens_vertical);
-	root.put_attr("mouse_max_speed", input_preferences->mouse_max_speed);
+	root.put_attr("classic_aim_speed_limits", input_preferences->classic_aim_speed_limits);
 	root.put_attr("mouse_accel_type", input_preferences->mouse_accel_type);
 	root.put_attr("mouse_accel_scale", input_preferences->mouse_accel_scale);
 	root.put_attr("raw_mouse_input", input_preferences->raw_mouse_input);
@@ -3343,7 +3343,7 @@ static void default_input_preferences(input_preferences_data *preferences)
 	preferences->mouse_accel_type = _mouse_accel_none;
 	preferences->mouse_accel_scale = 1.f;
 	preferences->raw_mouse_input = true;
-	preferences->mouse_max_speed = .25f;
+	preferences->classic_aim_speed_limits = true;
 
 	preferences->controller_analog = true;
 	preferences->controller_sensitivity = FIXED_ONE;
@@ -3888,9 +3888,13 @@ void parse_input_preferences(InfoTree root, std::string version)
 			input_preferences->sens_vertical /= 4;
 	}
 	
-	if (!version.length() || version < "20170205")
-		input_preferences->mouse_max_speed = .25f;
-	root.read_attr("mouse_max_speed", input_preferences->mouse_max_speed);
+	if (!root.read_attr("classic_aim_speed_limits", input_preferences->classic_aim_speed_limits))
+	{
+		// Assume users with older prefs with "mouse_max_speed" above its default value don't want classic limits
+		float mouse_max_speed;
+		if (root.read_attr("mouse_max_speed", mouse_max_speed) && mouse_max_speed > 0.25)
+			input_preferences->classic_aim_speed_limits = false;
+	}
 
 	// old prefs may have boolean acceleration flag
 	bool accel = false;

--- a/Source_Files/Misc/preferences.h
+++ b/Source_Files/Misc/preferences.h
@@ -200,7 +200,9 @@ struct input_preferences_data
 	int16 mouse_accel_type;
 	float mouse_accel_scale;
 	bool raw_mouse_input;
-	float mouse_max_speed;
+	
+	// Limit absolute-mode {yaw, pitch} deltas per tick to +/- {32, 8} instead of {63, 15}
+	bool classic_aim_speed_limits;
 	
 	bool controller_analog;
 	_fixed controller_sensitivity;

--- a/Source_Files/Misc/vbl.cpp
+++ b/Source_Files/Misc/vbl.cpp
@@ -1187,9 +1187,7 @@ uint32 parse_keymap(void)
       
       // Handle the selected input controller
       if (input_preferences->input_device == _mouse_yaw_pitch) {
-	_fixed delta_yaw, delta_pitch, delta_velocity;
-	test_mouse(input_preferences->input_device, &flags, &delta_yaw, &delta_pitch, &delta_velocity);
-	flags = mask_in_absolute_positioning_information(flags, delta_yaw, delta_pitch, delta_velocity);
+          flags = process_aim_input(flags, pull_mouselook_delta());
       }
         int joyflags = process_joystick_axes(flags, heartbeat_count);
         if (joyflags != flags) {

--- a/Source_Files/RenderMain/Rasterizer_Shader.cpp
+++ b/Source_Files/RenderMain/Rasterizer_Shader.cpp
@@ -25,7 +25,6 @@
 #include "preferences.h"
 #include "fades.h"
 #include "screen.h"
-#include "mouse.h"
 
 #define MAXIMUM_VERTICES_PER_WORLD_POLYGON (MAXIMUM_VERTICES_PER_POLYGON+4)
 
@@ -71,8 +70,8 @@ void Rasterizer_Shader_Class::SetView(view_data& view) {
 	ytan *= view.real_world_to_screen_y / double(view.world_to_screen_y);
 	xtan *= view.real_world_to_screen_x / double(view.world_to_screen_x);
 
-	double yaw = (view.yaw + lostMousePrecisionX()) * 360.0 / float(NUMBER_OF_ANGLES);
-	double pitch = (view.pitch + lostMousePrecisionY()) * 360.0 / float(NUMBER_OF_ANGLES);
+	double yaw = (view.yaw + virtual_aim_delta().yaw / float{FIXED_ONE}) * (360.0 / FULL_CIRCLE);
+	double pitch = (view.pitch + virtual_aim_delta().pitch / float{FIXED_ONE}) * (360.0 / FULL_CIRCLE);
 	pitch = (pitch > 180.0 ? pitch -360.0 : pitch);
 	
 	glMatrixMode(GL_PROJECTION);

--- a/Source_Files/RenderMain/RenderRasterize_Shader.cpp
+++ b/Source_Files/RenderMain/RenderRasterize_Shader.cpp
@@ -156,16 +156,18 @@ void RenderRasterize_Shader::render_tree() {
 			usefog = true;
 		}
 	}
+	const float virtual_yaw = (view->yaw + virtual_aim_delta().yaw / float{FIXED_ONE}) * AngleConvert;
+	const float virtual_pitch = (view->pitch + virtual_aim_delta().pitch / float{FIXED_ONE}) * AngleConvert;
 	s = Shader::get(Shader::S_Landscape);
 	s->enable();
 	s->setFloat(Shader::U_UseFog, usefog ? 1.0 : 0.0);
-	s->setFloat(Shader::U_Yaw, (view->yaw + lostMousePrecisionX()) * AngleConvert);
-	s->setFloat(Shader::U_Pitch, view->mimic_sw_perspective ? 0.0 : (view->pitch + lostMousePrecisionY()) * AngleConvert);
+	s->setFloat(Shader::U_Yaw, virtual_yaw);
+	s->setFloat(Shader::U_Pitch, view->mimic_sw_perspective ? 0.0 : virtual_pitch);
 	s = Shader::get(Shader::S_LandscapeBloom);
 	s->enable();
 	s->setFloat(Shader::U_UseFog, usefog ? 1.0 : 0.0);
-	s->setFloat(Shader::U_Yaw, (view->yaw + lostMousePrecisionX()) * AngleConvert);
-	s->setFloat(Shader::U_Pitch, (view->pitch + lostMousePrecisionY()) * AngleConvert);
+	s->setFloat(Shader::U_Yaw, virtual_yaw);
+	s->setFloat(Shader::U_Pitch, virtual_pitch);
 	Shader::disable();
 
 	RenderRasterizerClass::render_tree(kDiffuse);
@@ -953,7 +955,7 @@ void RenderRasterize_Shader::_render_node_object_helper(render_object_data *obje
 	glPushMatrix();
 	glTranslated(pos.x, pos.y, pos.z);
 
-	double yaw = (view->yaw + lostMousePrecisionX()) * 360.0 / float(NUMBER_OF_ANGLES);
+	double yaw = (view->yaw + virtual_aim_delta().yaw / float{FIXED_ONE}) * (360.0 / FULL_CIRCLE);
 	glRotated(yaw, 0.0, 0.0, 1.0);
 
 	float offset = 0;


### PR DESCRIPTION
This PR peforms a large cleanup centered around `mask_in_absolute_positioning_information()`. Confusion and complexity over angular units is eliminated, and interfaces are generally clearer. See commit description for details.

Of the points Hopper listed [here](https://github.com/Aleph-One-Marathon/alephone/pull/117#issuecomment-440066684), this PR addresses 2 (I think) and 4, but not 1 or 3.

Classic mouse behavior should be completely restored when GUI option `Fake Mouselook Precision` is disabled and non-GUI option `classic_aim_speed_limits` is `true`.