### PR TITLE
Fix virtual aim clamping and missing resyncs

### DIFF
--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -460,6 +460,10 @@ bool new_game(
 	struct player_start_data *player_start_information,
 	struct entry_point *entry_point)
 {
+	assert(!network || number_of_players == NetGetNumberOfPlayers());
+	
+	const short intended_local_player_index = network ? NetGetLocalPlayerIndex() : 0;
+	
 	short player_index, i;
 	bool success= true;
 
@@ -498,29 +502,14 @@ bool new_game(
 		/* non-network game, for playback.. */
 		for (i=0;i<number_of_players;++i)
 		{
+			new_player_flags flags = (i == intended_local_player_index ? new_player_make_local_and_current : 0);
 			player_index= new_player(player_start_information[i].team,
-				player_start_information[i].color, player_start_information[i].identifier);
+				player_start_information[i].color, player_start_information[i].identifier, flags);
 			assert(player_index==i);
 
 			/* Now copy in the name of the player.. */
 			assert(strlen(player_start_information[i].name)<=MAXIMUM_PLAYER_NAME_LENGTH);
 			strncpy(players[i].name, player_start_information[i].name, MAXIMUM_PLAYER_NAME_LENGTH+1);
-		}
-	
-#if !defined(DISABLE_NETWORKING)
-		if(game_is_networked)
-		{
-			/* Make sure we can count. */
-			assert(number_of_players==NetGetNumberOfPlayers());
-			
-			set_local_player_index(NetGetLocalPlayerIndex());
-			set_current_player_index(NetGetLocalPlayerIndex());
-		}
-		else
-#endif // !defined(DISABLE_NETWORKING)
-		{
-			set_local_player_index(0);
-			set_current_player_index(0);
 		}
 
 		/* we need to alert the function that reverts the game of the game setup so that
@@ -1820,6 +1809,8 @@ bool process_map_wad(
 		count= data_length/SIZEOF_player_data;
 		assert(count*SIZEOF_player_data==data_length);
 		unpack_player_data(data,players,count);
+		set_local_player_index(NONE);
+		set_current_player_index(NONE);
 		team_damage_from_player_data();
 		
 		data= (uint8 *)extract_type_from_wad(wad, DYNAMIC_STRUCTURE_TAG, &data_length);

--- a/Source_Files/GameWorld/physics.cpp
+++ b/Source_Files/GameWorld/physics.cpp
@@ -134,6 +134,9 @@ static fixed_yaw_pitch vir_aim_delta = {0, 0};
 void initialize_player_physics_variables(
 	short player_index)
 {
+	if (player_index == local_player_index)
+		resync_virtual_aim();
+	
 	struct player_data *player= get_player_data(player_index);
 	struct monster_data *monster= get_monster_data(player->monster_index);
 	struct object_data *object= get_object_data(monster->object_index);

--- a/Source_Files/GameWorld/physics.cpp
+++ b/Source_Files/GameWorld/physics.cpp
@@ -785,10 +785,29 @@ static void physics_update(
 		variables->external_velocity.k+= constants->climbing_acceleration;
 	}
 
-	/* change the playerÕs elevation based on his vertical angular velocity; if weÕre recentering and
-		have recentered clear the recentering bit */
+	// Apply vertical angular velocity
 	variables->elevation+= variables->vertical_angular_velocity;
+	
+	// Clamp virtual pitch to the effective limits of the low-precision physical pitch
+	// (this won't enlarge the virtual pitch delta)
+	if (player_is_local)
+	{
+		const fixed_angle min_pitch = FIXED_INTEGERAL_PART(-constants->maximum_elevation) * FIXED_ONE;
+		const fixed_angle max_pitch = FIXED_INTEGERAL_PART(constants->maximum_elevation) * FIXED_ONE;
+		const fixed_angle unclamped_physical_pitch = FIXED_INTEGERAL_PART(variables->elevation) * FIXED_ONE;
+		const fixed_angle unclamped_virtual_pitch = unclamped_physical_pitch + vir_aim_delta.pitch;
+		const fixed_angle clamped_physical_pitch = A1_PIN(unclamped_physical_pitch, min_pitch, max_pitch);
+		const fixed_angle clamped_virtual_pitch = A1_PIN(unclamped_virtual_pitch, min_pitch, max_pitch);
+		const fixed_angle new_delta = clamped_virtual_pitch - clamped_physical_pitch;
+		assert(std::abs(new_delta) <= std::abs(vir_aim_delta.pitch));
+		vir_aim_delta.pitch = new_delta;
+	}
+	
+	// Clamp high-precision physical pitch to physics model limits
+	// (note that the low-precision pitch can slightly violate a non-integral lower bound due to rounding toward -inf)
 	variables->elevation= PIN(variables->elevation, -constants->maximum_elevation, constants->maximum_elevation);
+	
+	// If we're explicitly recentering and have reached or passed 0 pitch, stop at 0
 	if ((variables->flags&_RECENTERING_BIT) && !(action_flags&_absolute_pitch_mode))
 	{
 		if ((variables->elevation<=0&&(action_flags&_looking_down))||(variables->elevation>=0&&(action_flags&_looking_up)))
@@ -796,15 +815,6 @@ static void physics_update(
 			variables->elevation= variables->vertical_angular_velocity= 0;
 			variables->flags&= (uint16)~_RECENTERING_BIT;
 		}
-	}
-	
-	// Also clamp virtual pitch to +/- constants->maximum_elevation
-	if (player_is_local)
-	{
-		const fixed_angle old_v_pitch = variables->elevation + vir_aim_delta.pitch;
-		const fixed_angle new_v_pitch = A1_PIN(old_v_pitch, -constants->maximum_elevation, constants->maximum_elevation);
-		vir_aim_delta.pitch = new_v_pitch - variables->elevation;
-		assert(std::abs(vir_aim_delta.pitch) <= FIXED_ONE/2);
 	}
 
 	/* change the playerÕs heading based on his angular velocities */

--- a/Source_Files/GameWorld/physics.cpp
+++ b/Source_Files/GameWorld/physics.cpp
@@ -541,7 +541,7 @@ static void physics_update(
 	_fixed delta_z;
 	_fixed delta; /* used as a scratch ‘change’ variable */
 	
-	const bool player_is_local = (player - &players[0] == local_player_index);
+	const bool player_is_local = (player == local_player);
 
 	if (PLAYER_IS_DEAD(player)) /* dead players immediately loose all bodily control */
 	{

--- a/Source_Files/GameWorld/player.cpp
+++ b/Source_Files/GameWorld/player.cpp
@@ -413,7 +413,8 @@ void allocate_player_memory(
 short new_player(
 	short team,
 	short color,
-	short identifier)
+	short identifier,
+	new_player_flags flags)
 {
 	short player_index, loop;
 	struct player_data *player;
@@ -425,6 +426,10 @@ short new_player(
 	player= get_player_data(player_index);
 
 	/* and initialize it */
+	if (flags & new_player_make_local)
+		set_local_player_index(player_index);
+	if (flags & new_player_make_current)
+		set_current_player_index(player_index);
 	obj_clear(*player);
 	player->teleporting_destination= NO_TELEPORTATION_DESTINATION;
 	player->interface_flags= 0; // Doesn't matter-> give_player_initial_items will take care of it.
@@ -500,6 +505,8 @@ void initialize_players(
 	
 	/* no players */
 	dynamic_world->player_count= 0;
+	set_local_player_index(NONE);
+	set_current_player_index(NONE);
 	
 	/* reset the action flag queues and zero the player slots */
 	for (i=0;i<MAXIMUM_NUMBER_OF_PLAYERS;++i)
@@ -961,14 +968,14 @@ void set_local_player_index(
 	short player_index)
 {
 	local_player_index= player_index;
-	local_player= get_player_data(player_index);
+	local_player = player_index == NONE ? nullptr : get_player_data(player_index);
 }
 
 void set_current_player_index(
 	short player_index)
 {
 	current_player_index= player_index;
-	current_player= get_player_data(player_index);
+	current_player = player_index == NONE ? nullptr : get_player_data(player_index);
 }
 
 /* We just teleported in as it were-> recreate all the players..  */

--- a/Source_Files/GameWorld/player.h
+++ b/Source_Files/GameWorld/player.h
@@ -480,7 +480,14 @@ void allocate_player_memory(void);
 void set_local_player_index(short player_index);
 void set_current_player_index(short player_index);
 
-short new_player(short team, short color, short player_identifier);
+// Flags for new_player()
+using new_player_flags = uint32;
+constexpr new_player_flags
+	new_player_make_local = 1u << 0,
+	new_player_make_current = 1u << 1,
+	new_player_make_local_and_current = new_player_make_local | new_player_make_current;
+
+short new_player(short team, short color, short player_identifier, new_player_flags flags);
 void delete_player(short player_number);
 
 void recreate_players_for_new_level(void);

--- a/Source_Files/Misc/interface.cpp
+++ b/Source_Files/Misc/interface.cpp
@@ -631,8 +631,10 @@ void match_starts_with_existing_players(player_start_data* ioStartArray, short* 
 }
 
 // This should be safe to use whether starting or resuming, and whether single- or multiplayer.
-static void synchronize_players_with_starts(const player_start_data* inStartArray, short inStartCount)
+static void synchronize_players_with_starts(const player_start_data* inStartArray, short inStartCount, short inLocalPlayerIndex)
 {
+        assert(inLocalPlayerIndex >= 0 && inLocalPlayerIndex < inStartCount);
+        
         // s will walk through all the starts
         int s = 0;
         
@@ -662,10 +664,18 @@ static void synchronize_players_with_starts(const player_start_data* inStartArra
                 }
         }
         
+        // Designate the local player if they already exist
+        if (inLocalPlayerIndex < s)
+        {
+            set_local_player_index(inLocalPlayerIndex);
+            set_current_player_index(inLocalPlayerIndex);
+        }
+        
         // If there are any starts left, we need new players for them
         for( ; s < inStartCount; s++)
         {
-                int theIndex = new_player(inStartArray[s].team, inStartArray[s].color, inStartArray[s].identifier);
+                new_player_flags flags = (s == inLocalPlayerIndex ? new_player_make_local_and_current : 0);
+                int theIndex = new_player(inStartArray[s].team, inStartArray[s].color, inStartArray[s].identifier, flags);
                 assert(theIndex == s);
                 player_data* thePlayer = get_player_data(theIndex);
                 strncpy(thePlayer->name, inStartArray[s].name, MAXIMUM_PLAYER_NAME_LENGTH+1);
@@ -698,8 +708,6 @@ static bool make_restored_game_relevant(bool inNetgame, const player_start_data*
         // Note we always take the random seed directly from the dynamic_world, no need to screw around
         // with copying it from game_information or the like.
         set_random_seed(dynamic_world->random_seed);
-        
-        synchronize_players_with_starts(inStartArray, inStartCount);
         
         short theLocalPlayerIndex;
         
@@ -740,9 +748,9 @@ static bool make_restored_game_relevant(bool inNetgame, const player_start_data*
         }
         
         assert(theLocalPlayerIndex != NONE);
-        set_local_player_index(theLocalPlayerIndex);
-        set_current_player_index(theLocalPlayerIndex);
 
+        synchronize_players_with_starts(inStartArray, inStartCount, theLocalPlayerIndex);
+        
         bool success = entering_map(true /*restoring game*/);
 
         reset_motion_sensor(theLocalPlayerIndex);


### PR DESCRIPTION
This PR solves the stuttering at the pitch limits and adds resyncs for teleporting, reviving, and level loading. It also incidentally fixes `recreate_player()` [reading](https://github.com/Aleph-One-Marathon/alephone/blob/10a3f669d94a4f44122af276c531432045f2b0e2/Source_Files/GameWorld/player.cpp#L1705) `current_player_index` before it's been initialized.