### PR TITLE
Preserve texture matrix when drawing sprite layer.

### DIFF
--- a/Source_Files/RenderMain/RenderRasterize_Shader.cpp
+++ b/Source_Files/RenderMain/RenderRasterize_Shader.cpp
@@ -1055,7 +1055,10 @@ extern GLdouble Screen_2_Clip[16];
 void RenderRasterize_Shader::render_viewer_sprite_layer(RenderStep renderStep)
 {
         if (!view->show_weapons_in_hand) return;
-
+    
+        glMatrixMode(GL_TEXTURE);
+        glPushMatrix();
+    
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadMatrixd(Screen_2_Clip);
@@ -1132,6 +1135,9 @@ void RenderRasterize_Shader::render_viewer_sprite_layer(RenderStep renderStep)
         glPopMatrix();
 
         glMatrixMode(GL_PROJECTION);
+        glPopMatrix();
+
+        glMatrixMode(GL_TEXTURE);
         glPopMatrix();
         
         glMatrixMode(GL_MODELVIEW);

--- a/Source_Files/RenderMain/RenderRasterize_Shader.cpp
+++ b/Source_Files/RenderMain/RenderRasterize_Shader.cpp
@@ -1132,6 +1132,8 @@ void RenderRasterize_Shader::render_viewer_sprite_layer(RenderStep renderStep)
                 render_viewer_sprite(rect, renderStep);
         }
 
+        Shader::disable();
+    
         glPopMatrix();
 
         glMatrixMode(GL_PROJECTION);
@@ -1139,7 +1141,7 @@ void RenderRasterize_Shader::render_viewer_sprite_layer(RenderStep renderStep)
 
         glMatrixMode(GL_TEXTURE);
         glPopMatrix();
-        
+    
         glMatrixMode(GL_MODELVIEW);
 }
 


### PR DESCRIPTION
OpenGL state sometimes gets hosed when switching weapons. This helps the case where Bloom and replacement textures are enabled.

The alternative:
![img_1899](https://user-images.githubusercontent.com/25617921/50947152-80194100-1462-11e9-914d-17725b7b1eb4.jpg)
