### PR TITLE
Simple C++11 updates to the code base

### DIFF
--- a/Source_Files/CSeries/byte_swapping.h
+++ b/Source_Files/CSeries/byte_swapping.h
@@ -21,7 +21,7 @@
 #ifndef _BYTE_SWAPPING_
 #define _BYTE_SWAPPING_
 
-typedef short _bs_field;
+using _bs_field = short;
 
 enum {
 	_2byte	= -2,

--- a/Source_Files/CSeries/csalerts.h
+++ b/Source_Files/CSeries/csalerts.h
@@ -43,10 +43,10 @@ extern void alert_user(
 	short resid,
 	short item,
 	int error);
-static inline void alert_user_fatal(short resid, short item, int error) NORETURN;
-static inline void alert_out_of_memory(int error = -1) NORETURN;
-static inline void alert_bad_extra_file(int error = -1) NORETURN;
-static inline void alert_corrupted_map(int error = -1) NORETURN;
+inline void alert_user_fatal(short resid, short item, int error) NORETURN;
+inline void alert_out_of_memory(int error = -1) NORETURN;
+inline void alert_bad_extra_file(int error = -1) NORETURN;
+inline void alert_corrupted_map(int error = -1) NORETURN;
 
 extern bool alert_choose_scenario(char *chosen_dir);
 

--- a/Source_Files/CSeries/csdialogs.h
+++ b/Source_Files/CSeries/csdialogs.h
@@ -37,7 +37,7 @@ Feb 27, 2002 (Br'fin (Jeremy Parsons)):
 
 class dialog;
 
-typedef	dialog*	DialogPtr;
+using DialogPtr = dialog*;
 
 #define	CONTROL_INACTIVE	0
 #define	CONTROL_ACTIVE		1

--- a/Source_Files/CSeries/cseries.h
+++ b/Source_Files/CSeries/cseries.h
@@ -49,6 +49,14 @@
 #undef ALEPHONE_LITTLE_ENDIAN
 #endif
 
+constexpr bool PlatformIsLittleEndian() noexcept {
+#ifdef ALEPHONE_LITTLE_ENDIAN
+	return true;
+#else
+	return false;
+#endif
+}
+
 
 /*
  *  Data types with specific bit width

--- a/Source_Files/CSeries/cseries.h
+++ b/Source_Files/CSeries/cseries.h
@@ -71,21 +71,21 @@ struct Rect {
 	int16 bottom, right;
 };
 
-const int noErr = 0;
+constexpr int noErr = 0;
 #endif
 
-constexpr Rect MakeRect(int16 top, int16 left, int16 bottom, int16 right)
+constexpr Rect MakeRect(int16 top, int16 left, int16 bottom, int16 right) noexcept
 	{ return {top, left, bottom, right}; }
 
-constexpr Rect MakeRect(SDL_Rect r)
+constexpr Rect MakeRect(SDL_Rect r) noexcept
 	{ return {int16(r.y), int16(r.x), int16(r.y + r.h), int16(r.x + r.w)}; }
 
 struct RGBColor {
 	uint16 red, green, blue;
 };
 
-const int kFontIDMonaco = 4;
-const int kFontIDCourier = 22;
+constexpr int kFontIDMonaco = 4;
+constexpr int kFontIDCourier = 22;
 
 /*
  *  Include CSeries headers

--- a/Source_Files/CSeries/csfonts.h
+++ b/Source_Files/CSeries/csfonts.h
@@ -27,12 +27,12 @@
 #include "cstypes.h"
 #include <string>
 
-const int styleNormal = 0;
-const int styleBold = 1;
-const int styleItalic = 2;
-const int styleUnderline = 4;
+constexpr int styleNormal = 0;
+constexpr int styleBold = 1;
+constexpr int styleItalic = 2;
+constexpr int styleUnderline = 4;
 // const int styleOutline = 8; -- can't be used with TTF
-const int styleShadow = 16;
+constexpr int styleShadow = 16;
 
 struct TextSpec {
 	int16 font;

--- a/Source_Files/CSeries/csmacros.h
+++ b/Source_Files/CSeries/csmacros.h
@@ -34,7 +34,11 @@ Aug 27, 2000 (Loren Petrich):
 #include "FilmProfile.h" // TERRIBLE
 
 #undef MAX
-#define MAX(a,b) ((a)>=(b) ? (a) : (b))
+template<typename T>
+constexpr T Max(T a, T b) noexcept {
+	return a >= b ? a : b;
+}
+#define MAX(a,b) (Max((a), (b)))
 #undef MIN
 #define MIN(a,b) ((a)<=(b) ? (a) : (b))
 

--- a/Source_Files/CSeries/csmacros.h
+++ b/Source_Files/CSeries/csmacros.h
@@ -74,7 +74,7 @@ SWAP(T& a, T& b)
 #define RECTANGLE_WIDTH(rectptr) ((rectptr)->right-(rectptr)->left)
 #define RECTANGLE_HEIGHT(rectptr) ((rectptr)->bottom-(rectptr)->top)
 
-static inline int NextPowerOfTwo(int n)
+inline int NextPowerOfTwo(int n)
 {
 	int p = 1;
 	while(p < n) {p <<= 1;}

--- a/Source_Files/CSeries/csmacros.h
+++ b/Source_Files/CSeries/csmacros.h
@@ -34,11 +34,7 @@ Aug 27, 2000 (Loren Petrich):
 #include "FilmProfile.h" // TERRIBLE
 
 #undef MAX
-template<typename T>
-constexpr T Max(T a, T b) noexcept {
-	return a >= b ? a : b;
-}
-#define MAX(a,b) (Max((a), (b)))
+#define MAX(a,b) ((a)>=(b) ? (a) : (b))
 #undef MIN
 #define MIN(a,b) ((a)<=(b) ? (a) : (b))
 

--- a/Source_Files/CSeries/cspixels.h
+++ b/Source_Files/CSeries/cspixels.h
@@ -25,9 +25,9 @@
 // Need this here
 #include "cstypes.h"
 
-typedef uint8 pixel8;
-typedef uint16 pixel16;
-typedef uint32 pixel32;
+using pixel8 = uint8;
+using pixel16 = uint16;
+using pixel32 = uint32;
 
 #define PIXEL8_MAXIMUM_COLORS 256
 #define PIXEL16_MAXIMUM_COMPONENT 31
@@ -41,11 +41,26 @@ typedef uint32 pixel32;
 		0x00 through 0x1F (in the 16-bit case)
 		0x00 through 0xFF (in the 32-bit case)
  */
-
-#define RGBCOLOR_TO_PIXEL16(r,g,b) (((r)>>1&0x7C00) | ((g)>>6&0x03E0) | ((b)>>11&0x001F))
-#define RED16(p) ((p)>>10&0x1F)
-#define GREEN16(p) ((p)>>5&0x1F)
-#define BLUE16(p) ((p)&0x1F)
+template<pixel16 shiftAmount>
+constexpr pixel16 ExtractColorComponent(pixel16 p) noexcept {
+	return ((p >> shiftAmount) & 0x1f);
+}
+constexpr pixel16 Red16(pixel16 p) noexcept {
+	return ExtractColorComponent<10>(p);
+}
+constexpr pixel16 Green16(pixel16 p) noexcept {
+	return ExtractColorComponent<5>(p);
+}
+constexpr pixel16 Blue16(pixel16 p) noexcept {
+	return ExtractColorComponent<0>(p);
+}
+constexpr pixel16 ToPixel16(uint16 r, uint16 g, uint16 b) noexcept {
+	return (((r)>>1&0x7C00) | ((g)>>6&0x03E0) | ((b)>>11&0x001F));
+}
+#define RGBCOLOR_TO_PIXEL16(r,g,b) (ToPixel16(r,g,b))
+#define RED16(p) (Red16(p))
+#define GREEN16(p) (Green16(p))
+#define BLUE16(p) (Blue16(p))
 
 #define RGBCOLOR_TO_PIXEL32(r,g,b) (((r)<<8&0x00FF0000) | ((g)&0x00000FF00) | ((b)>>8&0x000000FF))
 #define RED32(p) ((p)>>16&0xFF)

--- a/Source_Files/CSeries/cspixels.h
+++ b/Source_Files/CSeries/cspixels.h
@@ -66,17 +66,17 @@ template<pixel32 shiftAmount>
 constexpr pixel32 ExtractColorComponent(pixel32 p) noexcept {
 	return ((p >> shiftAmount) & 0xFF);
 }
-constexpr pixel16 Red32(pixel32 p) noexcept {
+constexpr pixel32 Red32(pixel32 p) noexcept {
 	return ExtractColorComponent<16>(p);
 }
-constexpr pixel16 Green32(pixel32 p) noexcept {
+constexpr pixel32 Green32(pixel32 p) noexcept {
 	return ExtractColorComponent<8>(p);
 }
-constexpr pixel16 Blue32(pixel32 p) noexcept {
+constexpr pixel32 Blue32(pixel32 p) noexcept {
 	return ExtractColorComponent<0>(p);
 }
-constexpr pixe32 ToPixel32(uint32 r, uint32 g, uint32 b) noexcept {
-	return (((r)<<8&0x00FF0000) | ((g)&0x00000FF00) | ((b)>>8&0x000000FF))
+constexpr pixel32 ToPixel32(uint32 r, uint32 g, uint32 b) noexcept {
+	return (((r)<<8&0x00FF0000) | ((g)&0x00000FF00) | ((b)>>8&0x000000FF));
 }
 #define RGBCOLOR_TO_PIXEL32(r,g,b) (ToPixel32(r,g,b))
 #define RED32(p) (Red32(p))

--- a/Source_Files/CSeries/cspixels.h
+++ b/Source_Files/CSeries/cspixels.h
@@ -62,9 +62,25 @@ constexpr pixel16 ToPixel16(uint16 r, uint16 g, uint16 b) noexcept {
 #define GREEN16(p) (Green16(p))
 #define BLUE16(p) (Blue16(p))
 
-#define RGBCOLOR_TO_PIXEL32(r,g,b) (((r)<<8&0x00FF0000) | ((g)&0x00000FF00) | ((b)>>8&0x000000FF))
-#define RED32(p) ((p)>>16&0xFF)
-#define GREEN32(p) ((p)>>8&0xFF)
-#define BLUE32(p) ((p)&0xFF)
+template<pixel32 shiftAmount>
+constexpr pixel32 ExtractColorComponent(pixel32 p) noexcept {
+	return ((p >> shiftAmount) & 0xFF);
+}
+constexpr pixel16 Red32(pixel32 p) noexcept {
+	return ExtractColorComponent<16>(p);
+}
+constexpr pixel16 Green32(pixel32 p) noexcept {
+	return ExtractColorComponent<8>(p);
+}
+constexpr pixel16 Blue32(pixel32 p) noexcept {
+	return ExtractColorComponent<0>(p);
+}
+constexpr pixe32 ToPixel32(uint32 r, uint32 g, uint32 b) noexcept {
+	return (((r)<<8&0x00FF0000) | ((g)&0x00000FF00) | ((b)>>8&0x000000FF))
+}
+#define RGBCOLOR_TO_PIXEL32(r,g,b) (ToPixel32(r,g,b))
+#define RED32(p) (Red32(p))
+#define GREEN32(p) (Green32(p))
+#define BLUE32(p) (Blue32(p))
 
 #endif

--- a/Source_Files/CSeries/cstypes.h
+++ b/Source_Files/CSeries/cstypes.h
@@ -69,7 +69,8 @@ using _fixed = int32;
 constexpr _fixed FixedFractionalBits = 16;
 template<typename T>
 constexpr _fixed ToFixed(T i) noexcept {
-	static_assert(std::is_integral<T>::value, "Must provide an integer for conversion to a integer");
+	// For sanity checking if desired
+	//static_assert(std::is_integral<T>::value, "Must provide an integer for conversion to a integer");
 	return static_cast<_fixed>(i) << FixedFractionalBits;
 }
 constexpr _fixed FixedIntegralPart(_fixed f) noexcept {

--- a/Source_Files/CSeries/cstypes.h
+++ b/Source_Files/CSeries/cstypes.h
@@ -37,12 +37,12 @@ enum {
 // Integer types with specific bit size
 #include <SDL_types.h>
 #include <time.h>	// for time_t
-using Uint8 = uint8;
-using Sint8 = int8;
-using Uint16 = uint16;
-using Sint16 = int16;
-using Uint32 = uint32;
-using Sint32 = int32;
+using uint8 = Uint8;
+using int8 = Sint8;
+using uint16 = Uint16;
+using int16 = Sint16;
+using uint32 = Uint32;
+using int32 = Sint32;
 using TimeType = time_t;
 
 // Minimum and maximum values for these types

--- a/Source_Files/CSeries/cstypes.h
+++ b/Source_Files/CSeries/cstypes.h
@@ -37,13 +37,13 @@ enum {
 // Integer types with specific bit size
 #include <SDL_types.h>
 #include <time.h>	// for time_t
-typedef Uint8 uint8;
-typedef Sint8 int8;
-typedef Uint16 uint16;
-typedef Sint16 int16;
-typedef Uint32 uint32;
-typedef Sint32 int32;
-typedef time_t TimeType;
+using Uint8 = uint8;
+using Sint8 = int8;
+using Uint16 = uint16;
+using Sint16 = int16;
+using Uint32 = uint32;
+using Sint32 = int32;
+using TimeType = time_t;
 
 // Minimum and maximum values for these types
 #ifndef INT16_MAX
@@ -64,7 +64,7 @@ typedef time_t TimeType;
 
 // Fixed point (16.16) type
 // LP: changed to _fixed to get around MSVC namespace conflict
-typedef int32 _fixed;
+using _fixed = int32;
 
 #define FIXED_FRACTIONAL_BITS 16
 #define INTEGER_TO_FIXED(i) ((_fixed)(i)<<FIXED_FRACTIONAL_BITS)
@@ -74,8 +74,8 @@ typedef int32 _fixed;
 #define FIXED_ONE_HALF	(1L<<(FIXED_FRACTIONAL_BITS-1))
 
 // Binary powers
-const int MEG = 0x100000;
-const int KILO = 0x400L;
+constexpr int MEG = 0x100000;
+constexpr int KILO = 0x400L;
 
 // Construct four-character-code
 #define FOUR_CHARS_TO_INT(a,b,c,d) (((uint32)(a) << 24) | ((uint32)(b) << 16) | ((uint32)(c) << 8) | (uint32)(d))

--- a/Source_Files/CSeries/cstypes.h
+++ b/Source_Files/CSeries/cstypes.h
@@ -66,9 +66,19 @@ using TimeType = time_t;
 // LP: changed to _fixed to get around MSVC namespace conflict
 using _fixed = int32;
 
-#define FIXED_FRACTIONAL_BITS 16
-#define INTEGER_TO_FIXED(i) ((_fixed)(i)<<FIXED_FRACTIONAL_BITS)
-#define FIXED_INTEGERAL_PART(f) ((f)>>FIXED_FRACTIONAL_BITS)
+constexpr _fixed FixedFractionalBits = 16;
+template<typename T>
+constexpr _fixed ToFixed(T i) noexcept {
+	static_assert(std::is_integral<T>::value, "Must provide an integer for conversion to a integer");
+	return static_cast<_fixed>(i) << FixedFractionalBits;
+}
+constexpr _fixed FixedIntegralPart(_fixed f) noexcept {
+	return f >> FixedFractionalBits;
+}
+
+#define FIXED_FRACTIONAL_BITS FixedFractionalBits
+#define INTEGER_TO_FIXED(i) (ToFixed<decltype(i)>(i))
+#define FIXED_INTEGERAL_PART(f) (FixedIntegralPart(f))
 
 #define FIXED_ONE		(1L<<FIXED_FRACTIONAL_BITS)
 #define FIXED_ONE_HALF	(1L<<(FIXED_FRACTIONAL_BITS-1))

--- a/Source_Files/CSeries/cstypes.h
+++ b/Source_Files/CSeries/cstypes.h
@@ -92,7 +92,7 @@ constexpr int KILO = 0x400L;
 #define FOUR_CHARS_TO_INT(a,b,c,d) (((uint32)(a) << 24) | ((uint32)(b) << 16) | ((uint32)(c) << 8) | (uint32)(d))
 
 // Hmmm, this should be removed one day...
-typedef uint8 byte;
+using byte = uint8;
 
 // Make it compile on systems without OpenGL
 #ifndef HAVE_OPENGL

--- a/Source_Files/FFmpeg/Movie.cpp
+++ b/Source_Files/FFmpeg/Movie.cpp
@@ -48,8 +48,6 @@
 #include "Mixer.h"
 #include "preferences.h"
 
-Movie* Movie::m_instance = NULL;
-
 #ifndef HAVE_FFMPEG
 
 struct libav_vars {

--- a/Source_Files/FFmpeg/Movie.h
+++ b/Source_Files/FFmpeg/Movie.h
@@ -32,7 +32,13 @@
 class Movie
 {
 public:
-	static Movie *instance() { if (!m_instance) m_instance = new Movie(); return m_instance; }
+	static Movie *instance() { 
+		static Movie *m_instance = nullptr;
+		if (!m_instance) {
+			m_instance = new Movie();
+		}
+		return m_instance;
+	}
 	
 	void PromptForRecording();
 	void StartRecording(std::string path);
@@ -47,7 +53,6 @@ public:
 	void AddFrame(FrameType ftype = FRAME_NORMAL);
 
 private:
-  static class Movie *m_instance;
   
   std::string moviefile;
   SDL_Rect view_rect;

--- a/Source_Files/Files/AStream.h
+++ b/Source_Files/Files/AStream.h
@@ -44,13 +44,13 @@
 namespace AStream
 {
 	enum _Aiostate { _M_aiostate_end = 1L << 16 };
-	static const short _S_badbit = 0x01;
-	static const short _S_failbit = 0x02;
+	constexpr short _S_badbit = 0x01;
+	constexpr short _S_failbit = 0x02;
 
-	typedef _Aiostate iostate;
-	static const iostate badbit = iostate(_S_badbit);
-	static const iostate failbit = iostate(_S_failbit);
-	static const iostate goodbit = iostate(0);
+	using iostate = _Aiostate;
+	const iostate badbit = iostate(_S_badbit);
+	const iostate failbit = iostate(_S_failbit);
+	const iostate goodbit = iostate(0);
 
 	class failure : public std::exception
 	{

--- a/Source_Files/Files/Packing.h
+++ b/Source_Files/Files/Packing.h
@@ -90,7 +90,7 @@ extern void ValueToStream(uint8* &Stream, uint32 Value);
 extern void ValueToStream(uint8* &Stream, int32 Value);
 
 #ifndef PACKING_INTERNAL
-template<class T> inline static void StreamToList(uint8* &Stream, T* List, size_t Count)
+template<class T> inline void StreamToList(uint8* &Stream, T* List, size_t Count)
 {
     T* ValuePtr = List;
     for (size_t k=0; k<Count; k++)
@@ -98,20 +98,20 @@ template<class T> inline static void StreamToList(uint8* &Stream, T* List, size_
 }
 
 
-template<class T> inline static void ListToStream(uint8* &Stream, T* List, size_t Count)
+template<class T> inline void ListToStream(uint8* &Stream, T* List, size_t Count)
 {
     T* ValuePtr = List;
     for (size_t k=0; k<Count; k++)
         ValueToStream(Stream,*(ValuePtr++));
 }
 
-inline static void StreamToBytes(uint8* &Stream, void* Bytes, size_t Count)
+inline void StreamToBytes(uint8* &Stream, void* Bytes, size_t Count)
 {
     memcpy(Bytes,Stream,Count);
     Stream += Count;
 }
 
-inline static void BytesToStream(uint8* &Stream, const void* Bytes, size_t Count)
+inline void BytesToStream(uint8* &Stream, const void* Bytes, size_t Count)
 {
     memcpy(Stream,Bytes,Count);
     Stream += Count;

--- a/Source_Files/Files/WadImageCache.cpp
+++ b/Source_Files/Files/WadImageCache.cpp
@@ -39,18 +39,17 @@
 #include "sdl_resize.h"
 #include "Logging.h"
 
-WadImageCache* WadImageCache::m_instance = 0;
 WadImageCache* WadImageCache::instance() {
+	static WadImageCache* m_instance = nullptr;
 	if (!m_instance) {
 		m_instance = new WadImageCache;
 	}
-	
 	return m_instance;
 }
 
 SDL_Surface *WadImageCache::image_from_desc(WadImageDescriptor& desc)
 {
-	SDL_Surface *surface = NULL;
+	SDL_Surface *surface = nullptr;
 	OpenedFile wad_file;
 	if (open_wad_file_for_reading(desc.file, wad_file))
 	{
@@ -90,7 +89,7 @@ SDL_Surface *WadImageCache::image_from_name(std::string& name) const
 	
 	OpenedFile of;
 	if (!file.Open(of))
-		return NULL;
+		return nullptr;
 	
 #ifdef HAVE_SDL_IMAGE
 	SDL_Surface *img = IMG_Load_RW(of.GetRWops(), 0);
@@ -115,7 +114,7 @@ SDL_Surface *WadImageCache::resize_image(SDL_Surface *original, int width, int h
 			return SDL_Resize(original, width, height, false, 1);
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 std::string WadImageCache::image_to_new_name(SDL_Surface *image, int32 *filesize) const
@@ -134,7 +133,7 @@ std::string WadImageCache::image_to_new_name(SDL_Surface *image, int32 *filesize
 	
 	int ret;
 //#if defined(HAVE_PNG) && defined(HAVE_SDL_IMAGE)
-//	ret = aoIMG_SavePNG(TempFile.GetPath(), image, IMG_COMPRESS_DEFAULT, NULL, 0);
+//	ret = aoIMG_SavePNG(TempFile.GetPath(), image, IMG_COMPRESS_DEFAULT, nullptr, 0);
 #ifdef HAVE_SDL_IMAGE
 	ret = IMG_SavePNG(image, TempFile.GetPath());
 #else
@@ -221,7 +220,7 @@ void WadImageCache::cache_image(WadImageDescriptor& desc, int width, int height,
 		return;
 	}
 	
-	SDL_Surface *resized_image = NULL;
+	SDL_Surface *resized_image = nullptr;
 	if (image)
 	{
 		resized_image = resize_image(image, width, height);
@@ -281,7 +280,7 @@ SDL_Surface *WadImageCache::retrieve_image(WadImageDescriptor& desc, int width, 
 {
 	std::string name = retrieve_name(desc, width, height, true);
 	if (name.empty())
-		return NULL;
+		return nullptr;
 	
 	return image_from_name(name);
 }

--- a/Source_Files/Files/WadImageCache.h
+++ b/Source_Files/Files/WadImageCache.h
@@ -60,10 +60,10 @@ struct WadImageDescriptor {
 
 class WadImageCache {
 public:
-	typedef boost::tuple<WadImageDescriptor, int, int> cache_key_t;
-	typedef std::pair<std::string, size_t> cache_value_t;
-	typedef std::pair<cache_key_t, cache_value_t> cache_pair_t;
-	typedef std::list<cache_pair_t>::iterator cache_iter_t;
+	using cache_key_t = boost::tuple<WadImageDescriptor, int, int>;
+	using cache_value_t = std::pair<std::string, size_t>;
+	using cache_pair_t = std::pair<cache_key_t, cache_value_t>;
+	using cache_iter_t = std::list<cache_pair_t>::iterator;
 
 	static WadImageCache* instance();
 	
@@ -81,7 +81,7 @@ public:
 	// a different size). Updates LRU info if already cached.
 	// If "surface" is provided, uses that for caching instead of
 	// reading wadfile directly.
-	void cache_image(WadImageDescriptor& desc, int width, int height, SDL_Surface *surface = NULL);
+	void cache_image(WadImageDescriptor& desc, int width, int height, SDL_Surface *surface = nullptr);
 	
 	// Deletes cache data for this image. If width and height are zero,
 	// removes any cached sizes for image.
@@ -95,7 +95,7 @@ public:
 	// If return value is not NULL, surface must be freed by caller.
 	// If "surface" is provided, uses that for caching instead of
 	// reading wad file directly.
-	SDL_Surface *get_image(WadImageDescriptor& desc, int width, int height, SDL_Surface *surface = NULL);
+	SDL_Surface *get_image(WadImageDescriptor& desc, int width, int height, SDL_Surface *surface = nullptr);
 
 	void save_cache();
 	void set_cache_autosave(bool enabled) { m_autosave = enabled; }
@@ -111,13 +111,12 @@ private:
 	SDL_Surface *image_from_name(std::string& name) const;
 	void delete_storage_for_name(std::string& name) const;
 	SDL_Surface *resize_image(SDL_Surface *original, int width, int height) const;
-	std::string image_to_new_name(SDL_Surface *image, int32 *filesize = NULL) const;
+	std::string image_to_new_name(SDL_Surface *image, int32 *filesize = nullptr) const;
 	std::string add_to_cache(cache_key_t key, SDL_Surface *surface);
 	bool apply_cache_limit();
 	std::string retrieve_name(WadImageDescriptor& desc, int width, int height, bool mark_accessed = true);
 	void autosave_cache() { if (m_autosave) save_cache(); }
 	
-	static WadImageCache* m_instance;
 	std::list<cache_pair_t> m_used;
 	std::map<cache_key_t, cache_iter_t> m_cacheinfo;
 	size_t m_cachesize;

--- a/Source_Files/Files/game_wad.h
+++ b/Source_Files/Files/game_wad.h
@@ -44,8 +44,8 @@ struct wad_data *build_meta_game_wad(const std::string& metadata, const std::str
 bool export_level(FileSpecifier& File);
 
 /* -------------- New functions */
-void pause_game(void);
-void resume_game(void);
+void pause_game();
+void resume_game();
 void get_current_saved_game_name(FileSpecifier& File);
 // ZZZ: split this out from new_game; it sets a default filespec in the revert-game info
 void set_saved_game_name_to_default();
@@ -58,7 +58,7 @@ bool match_checksum_with_map(short vRefNum, long dirID, uint32 checksum,
 void set_map_file(FileSpecifier& File);
 
 //CP Addition: get_map_file returns the FileDesc pointer to the current map
-FileSpecifier& get_map_file(void);
+FileSpecifier& get_map_file();
 
 void level_has_embedded_physics_lua(int Level, bool& HasPhysics, bool& HasLua);
 
@@ -68,6 +68,6 @@ void get_savegame_filedesc(FileSpecifier& File);
 
 void add_finishing_touches_to_save_file(FileSpecifier& File);
 
-const int SAVE_GAME_METADATA_INDEX = 1000;
+constexpr int SAVE_GAME_METADATA_INDEX = 1000;
 
 #endif

--- a/Source_Files/Files/wad.h
+++ b/Source_Files/Files/wad.h
@@ -56,7 +56,7 @@ class FileSpecifier;
 class OpenedFile;
 
 /* ------------- typedefs */
-typedef uint32 WadDataType;
+using WadDataType = uint32;
 
 /* ------------- file structures */
 struct wad_header { /* 128 bytes */
@@ -72,20 +72,24 @@ struct wad_header { /* 128 bytes */
 	uint32 parent_checksum;	/* If non-zero, this is the checksum of our parent, and we are simply modifications! */
 	int16 unused[20];
 };
-const int SIZEOF_wad_header = 128;	// don't trust sizeof()
+constexpr int SIZEOF_wad_header = 128;	// don't trust sizeof()
+//static_assert(sizeof(wad_header) == SIZEOF_wad_header, "wad_header is not of the correct size!"); 
 
 struct old_directory_entry { /* 8 bytes */
 	int32 offset_to_start; /* From start of file */
 	int32 length; /* Of total level */
 };
-const int SIZEOF_old_directory_entry = 8;
+constexpr int SIZEOF_old_directory_entry = 8;
+//static_assert(sizeof(old_directory_entry) == SIZEOF_old_directory_entry, "old_directory_entry is not of the correct size!");
 
 struct directory_entry { /* >=10 bytes */
 	int32 offset_to_start; /* From start of file */
 	int32 length; /* Of total level */
 	int16 index; /* For inplace modification of the wadfile! */
 };
-const int SIZEOF_directory_entry = 10;
+constexpr int SIZEOF_directory_entry = 10;
+// disabled because optimization does alignment but we are ignoring it
+//static_assert(sizeof(directory_entry) == SIZEOF_directory_entry, "directory_entry is not of the correct size!");
 
 struct old_entry_header { /* 12 bytes */
 	WadDataType tag;
@@ -96,7 +100,8 @@ struct old_entry_header { /* 12 bytes */
 	
 	/* Data follows */
 };
-const int SIZEOF_old_entry_header = 12;
+constexpr int SIZEOF_old_entry_header = 12;
+//static_assert(sizeof(old_entry_header) == SIZEOF_old_entry_header, "old_entry_header is not of the correct size!");
 
 struct entry_header { /* 16 bytes */
 	WadDataType tag;
@@ -108,7 +113,9 @@ struct entry_header { /* 16 bytes */
 	
 	/* Data follows */
 };
-const int SIZEOF_entry_header = 16;
+constexpr int SIZEOF_entry_header = 16;
+//static_assert(sizeof(entry_header) == SIZEOF_entry_header, "entry_header is not of the correct size!");
+
 
 /* ---------- Memory Data structures ------------ */
 struct tag_data {

--- a/Source_Files/Files/wad_prefs.h
+++ b/Source_Files/Files/wad_prefs.h
@@ -34,8 +34,8 @@ Aug 21, 2000 (Loren Petrich):
 /*  preferences pointer.. */
 bool w_open_preferences_file(char *PrefName, Typecode Type);
 
-typedef void (*prefs_initializer)(void *prefs);
-typedef bool (*prefs_validater)(void *prefs);
+using prefs_initializer = void (*)(void *prefs);
+using prefs_validater = bool (*)(void *prefs);
 
 void *w_get_data_from_preferences(
 	WadDataType tag,					/* Tag to read */
@@ -43,15 +43,15 @@ void *w_get_data_from_preferences(
 	prefs_initializer initialize,	/* Call if I have to allocate it.. */
 	prefs_validater validate);	/* Verify function-> fixes if bad and returns true */
 	
-void w_write_preferences_file(void);
+void w_write_preferences_file();
 
 /* ------ local structures */
 /* This is the structure used internally */
 struct preferences_info {
-	preferences_info() : wad(NULL) {}
+	preferences_info() : wad(nullptr) {}
 
 	FileSpecifier PrefsFile;
-	struct wad_data *wad;
+	wad_data *wad;
 };
 
 #endif

--- a/Source_Files/GameWorld/media_definitions.h
+++ b/Source_Files/GameWorld/media_definitions.h
@@ -54,7 +54,7 @@ struct media_definition
 /* ---------- globals */
 
 // LP addition: added JjaroGoo support (copy of sewage)
-static struct media_definition media_definitions[NUMBER_OF_MEDIA_TYPES]=
+struct media_definition media_definitions[NUMBER_OF_MEDIA_TYPES]=
 {
 	/* _media_water */
 	{

--- a/Source_Files/GameWorld/weapons.h
+++ b/Source_Files/GameWorld/weapons.h
@@ -142,9 +142,9 @@ struct player_weapon_data {
 };
 
 // For external access:
-const int SIZEOF_weapon_definition = 134;
+constexpr int SIZEOF_weapon_definition = 134;
 
-const int SIZEOF_player_weapon_data = 472;
+constexpr int SIZEOF_player_weapon_data = 472;
 
 /* ----------------- prototypes */
 /* called once at startup */

--- a/Source_Files/GameWorld/world.h
+++ b/Source_Files/GameWorld/world.h
@@ -185,7 +185,7 @@ void build_trig_tables(void);
 
 // LP change: inlined this for speed, and used the NORMALIZE_ANGLE macro;
 // looks as if the code had been worked on by more than one programmer.
-static inline angle normalize_angle(angle theta)
+inline angle normalize_angle(angle theta)
 {
 	return NORMALIZE_ANGLE(theta);
 }
@@ -226,12 +226,12 @@ void overflow_short_to_long_2d(world_point2d& WVec, uint16& flags, long_vector2d
 world_point2d *transform_overflow_point2d(world_point2d *point, world_point2d *origin, angle theta, uint16 *flags);
 
 // Simple copy-overs
-static inline void long_to_short_2d(long_vector2d& LVec, world_vector2d&WVec)
+inline void long_to_short_2d(long_vector2d& LVec, world_vector2d&WVec)
 {
 	WVec.i = static_cast<short>(LVec.i);
 	WVec.j = static_cast<short>(LVec.j);
 }
-static inline void short_to_long_2d(world_vector2d&WVec, long_vector2d& LVec)
+inline void short_to_long_2d(world_vector2d&WVec, long_vector2d& LVec)
 {
 	LVec.i = WVec.i;
 	LVec.j = WVec.j;

--- a/Source_Files/Lua/lua_templates.h
+++ b/Source_Files/Lua/lua_templates.h
@@ -40,7 +40,7 @@ extern "C"
 #include <map>
 #include <new>
 
-static inline int luaL_typerror(lua_State* L, int narg, const char* tname)
+inline int luaL_typerror(lua_State* L, int narg, const char* tname)
 {
 	const char *msg = lua_pushfstring(L, "%s expected, got %s",
 					  tname, luaL_typename(L, narg));

--- a/Source_Files/Misc/ActionQueues.h
+++ b/Source_Files/Misc/ActionQueues.h
@@ -62,7 +62,10 @@ public:
     void		setZombiesControllable(bool inZombiesControllable);
     
     ~ActionQueues();
-    
+	// Delete these until we have a valid implementation
+	ActionQueues(const ActionQueues&) = delete;
+	ActionQueues& operator=(const ActionQueues&) = delete;
+   	 
 protected:
     struct action_queue {
 	    unsigned int read_index, write_index;
@@ -75,11 +78,6 @@ protected:
     action_queue*	mQueueHeaders;
     uint32*		mFlagsBuffer;
     bool		mZombiesControllable;
-
-// Hide these until they have valid implementation
-private:
-    ActionQueues(ActionQueues&);
-    ActionQueues& operator =(ActionQueues&);
 };
 
 class ModifiableActionQueues : public ActionQueues {

--- a/Source_Files/Misc/CircularByteBuffer.h
+++ b/Source_Files/Misc/CircularByteBuffer.h
@@ -34,7 +34,7 @@
 
 #include "CircularQueue.h"
 
-typedef CircularQueue<char> CircularByteBufferBase;
+using CircularByteBufferBase = CircularQueue<char>;
 
 class CircularByteBuffer : public CircularByteBufferBase
 {

--- a/Source_Files/Misc/CircularQueue.h
+++ b/Source_Files/Misc/CircularQueue.h
@@ -41,12 +41,12 @@
 template<typename T>
 class CircularQueue {
 public:
-        CircularQueue() : mData(NULL) { reset(0); }
+        CircularQueue() : mData(nullptr) { reset(0); }
 
-        explicit CircularQueue(unsigned int inSize) : mData(NULL) { reset(inSize); }
+        explicit CircularQueue(unsigned int inSize) : mData(nullptr) { reset(inSize); }
 
 	// The queue being copied had best not change while we're copying...
-        CircularQueue(const CircularQueue<T>& o) : mData(NULL) {
+        CircularQueue(const CircularQueue<T>& o) : mData(nullptr) {
 		*this = o;
 	}
 		
@@ -71,9 +71,9 @@ public:
 
                 mReadIndex = mWriteIndex = 0;
 
-                if(theStorageCount != mQueueSize || mData == NULL) {
+                if(theStorageCount != mQueueSize || mData == nullptr) {
                         mQueueSize = theStorageCount;
-                        if(mData != NULL)
+                        if(mData != nullptr)
                                 delete [] mData;
                         mData = new T[mQueueSize];
                 }
@@ -93,7 +93,7 @@ public:
 
         void            enqueue(const T& inData) { mData[getWriteIndex()] = inData;  advanceWriteIndex(); }
 
-        virtual ~CircularQueue() { if(mData != NULL) delete [] mData; }
+        virtual ~CircularQueue() { if(mData != nullptr) delete [] mData; }
 
 protected:
         unsigned int	getReadIndex(unsigned int inOffset = 0) const

--- a/Source_Files/Misc/Console.cpp
+++ b/Source_Files/Misc/Console.cpp
@@ -46,8 +46,6 @@ using namespace std;
 
 extern bool game_is_networked;
 
-Console *Console::m_instance = NULL;
-
 Console::Console() : m_active(false), m_carnage_messages_exist(false), m_use_lua_console(true)
 {
 	m_command_iter = m_prev_commands.end();
@@ -56,6 +54,7 @@ Console::Console() : m_active(false), m_carnage_messages_exist(false), m_use_lua
 }
 
 Console *Console::instance() {
+	static Console* m_instance = nullptr;
 	if (!m_instance) {
 		m_instance = new Console;
 	}

--- a/Source_Files/Misc/Console.h
+++ b/Source_Files/Misc/Console.h
@@ -39,7 +39,7 @@ public:
 
 	virtual void parse_and_execute(const std::string& command_string);
 private:
-	typedef std::map<std::string, boost::function<void(const std::string&)> > command_map;
+	using command_map = std::map<std::string, boost::function<void(const std::string&)> >;
 	command_map m_commands;
 };
 
@@ -90,7 +90,6 @@ public:
 
 private:
 	Console();
-	static Console* m_instance;
 
 	boost::function<void (std::string)> m_callback;
 	std::string m_buffer;

--- a/Source_Files/Misc/Logging.h
+++ b/Source_Files/Misc/Logging.h
@@ -83,25 +83,26 @@ extern const char* logDomain;
 
 // (COMMENTS FOR logError() FAMILY)
 // Ease-of-use macros wrap around logMessage.
-#define logFatal(...)    (GetCurrentLogger()->logMessage(logDomain, logFatalLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logError(...)    (GetCurrentLogger()->logMessage(logDomain, logErrorLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logWarning(...)  (GetCurrentLogger()->logMessage(logDomain, logWarningLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logAnomaly(...)  (GetCurrentLogger()->logMessage(logDomain, logAnomalyLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logNote(...)     (GetCurrentLogger()->logMessage(logDomain, logNoteLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logSummary(...)  (GetCurrentLogger()->logMessage(logDomain, logSummaryLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logTrace(...)    (GetCurrentLogger()->logMessage(logDomain, logTraceLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logDump(...)     (GetCurrentLogger()->logMessage(logDomain, logDumpLevel, __FILE__, __LINE__, __VA_ARGS__))
+#define __FILE_HERE__ __FILE__, __LINE__
+#define logFatal(...)    (GetCurrentLogger()->logMessage(logDomain, logFatalLevel, __FILE_HERE__, __VA_ARGS__))
+#define logError(...)    (GetCurrentLogger()->logMessage(logDomain, logErrorLevel, __FILE_HERE__, __VA_ARGS__))
+#define logWarning(...)  (GetCurrentLogger()->logMessage(logDomain, logWarningLevel, __FILE_HERE__, __VA_ARGS__))
+#define logAnomaly(...)  (GetCurrentLogger()->logMessage(logDomain, logAnomalyLevel, __FILE_HERE__, __VA_ARGS__))
+#define logNote(...)     (GetCurrentLogger()->logMessage(logDomain, logNoteLevel, __FILE_HERE__, __VA_ARGS__))
+#define logSummary(...)  (GetCurrentLogger()->logMessage(logDomain, logSummaryLevel, __FILE_HERE__, __VA_ARGS__))
+#define logTrace(...)    (GetCurrentLogger()->logMessage(logDomain, logTraceLevel, __FILE_HERE__, __VA_ARGS__))
+#define logDump(...)     (GetCurrentLogger()->logMessage(logDomain, logDumpLevel, __FILE_HERE__, __VA_ARGS__))
 
 // NB! use logError() and co. only in the main thread.  Elsewhere, use logErrorNMT() and co.
 // (the NMT versions may have more complex - or missing - implementations to make them safer)
-#define logFatalNMT(...)    (GetCurrentLogger()->logMessageNMT(logDomain, logFatalLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logErrorNMT(...)    (GetCurrentLogger()->logMessageNMT(logDomain, logErrorLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logWarningNMT(...)  (GetCurrentLogger()->logMessageNMT(logDomain, logWarningLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logAnomalyNMT(...)  (GetCurrentLogger()->logMessageNMT(logDomain, logAnomalyLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logNoteNMT(...)     (GetCurrentLogger()->logMessageNMT(logDomain, logNoteLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logSummaryNMT(...)  (GetCurrentLogger()->logMessageNMT(logDomain, logSummaryLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logTraceNMT(...)    (GetCurrentLogger()->logMessageNMT(logDomain, logTraceLevel, __FILE__, __LINE__, __VA_ARGS__))
-#define logDumpNMT(...)     (GetCurrentLogger()->logMessageNMT(logDomain, logDumpLevel, __FILE__, __LINE__, __VA_ARGS__))
+#define logFatalNMT(...)    (GetCurrentLogger()->logMessageNMT(logDomain, logFatalLevel, __FILE_HERE__, __VA_ARGS__))
+#define logErrorNMT(...)    (GetCurrentLogger()->logMessageNMT(logDomain, logErrorLevel, __FILE_HERE__, __VA_ARGS__))
+#define logWarningNMT(...)  (GetCurrentLogger()->logMessageNMT(logDomain, logWarningLevel, __FILE_HERE__, __VA_ARGS__))
+#define logAnomalyNMT(...)  (GetCurrentLogger()->logMessageNMT(logDomain, logAnomalyLevel, __FILE_HERE__, __VA_ARGS__))
+#define logNoteNMT(...)     (GetCurrentLogger()->logMessageNMT(logDomain, logNoteLevel, __FILE_HERE__, __VA_ARGS__))
+#define logSummaryNMT(...)  (GetCurrentLogger()->logMessageNMT(logDomain, logSummaryLevel, __FILE_HERE__, __VA_ARGS__))
+#define logTraceNMT(...)    (GetCurrentLogger()->logMessageNMT(logDomain, logTraceLevel, __FILE_HERE__, __VA_ARGS__))
+#define logDumpNMT(...)     (GetCurrentLogger()->logMessageNMT(logDomain, logDumpLevel, __FILE_HERE__, __VA_ARGS__))
 
 // (COMMENTS FOR logContext() FAMILY)
 // Enter a (runtime) logging subcontext; expires at end of block.  Use only within functions!!
@@ -112,8 +113,8 @@ extern const char* logDomain;
 // We need to use makeUniqueIdentifier so that __LINE__ gets expanded before concatenation.
 #define makeUniqueIdentifier(a, b) a ## b
 
-#define logContext(...)	LogContext makeUniqueIdentifier(_theLogContext,__LINE__)(false, __FILE__, __LINE__, __VA_ARGS__)
-#define logContextNMT(...)	LogContext makeUniqueIdentifier(_theLogContext,__LINE__)(true, __FILE__, __LINE__, __VA_ARGS__)
+#define logContext(...)	LogContext makeUniqueIdentifier(_theLogContext,__LINE__)(false, __FILE_HERE__, __VA_ARGS__)
+#define logContextNMT(...)	LogContext makeUniqueIdentifier(_theLogContext,__LINE__)(true, __FILE_HERE__, __VA_ARGS__)
 
 
 // Class intended for stack-based use for entering/leaving a logging subcontext

--- a/Source_Files/Misc/PlayerImage_sdl.h
+++ b/Source_Files/Misc/PlayerImage_sdl.h
@@ -50,10 +50,10 @@ public:
         mLegsValid(false),
         mTorsoValid(false),
         
-        mLegsSurface(NULL),
-        mTorsoSurface(NULL),
-        mLegsData(NULL),
-        mTorsoData(NULL)
+        mLegsSurface(nullptr),
+        mTorsoSurface(nullptr),
+        mLegsData(nullptr),
+        mTorsoData(nullptr)
         
         { objectCreated(); }
     

--- a/Source_Files/Misc/Scenario.cpp
+++ b/Source_Files/Misc/Scenario.cpp
@@ -28,11 +28,12 @@
 #include "Scenario.h"
 #include "InfoTree.h"
 
-Scenario *Scenario::m_instance;
-
 Scenario *Scenario::instance()
 {
-	if (!m_instance) m_instance = new Scenario();
+	static Scenario *m_instance = nullptr;
+	if (!m_instance) {
+		m_instance = new Scenario();
+	}
 	return m_instance;
 }
 

--- a/Source_Files/Misc/Scenario.h
+++ b/Source_Files/Misc/Scenario.h
@@ -57,8 +57,6 @@ private:
 	string m_id;
 	
 	vector<string> m_compatibleVersions;
-	
-	static Scenario *m_instance;
 };
 
 class InfoTree;

--- a/Source_Files/Misc/Statistics.cpp
+++ b/Source_Files/Misc/Statistics.cpp
@@ -30,8 +30,6 @@
 #include <sstream>
 #include <boost/bind.hpp>
 
-StatsManager* StatsManager::instance_ = 0;
-
 class ScopedMutex
 {
 public:

--- a/Source_Files/Misc/Statistics.h
+++ b/Source_Files/Misc/Statistics.h
@@ -36,7 +36,10 @@
 class StatsManager {
 public:
 	static StatsManager* instance() { 
-		if (!instance_) instance_  = new StatsManager();
+		static StatsManager* instance_ = nullptr;
+		if (!instance_) {
+			instance_  = new StatsManager();
+		}
 		return instance_;
 	}
 
@@ -55,7 +58,6 @@ private:
 	};
 
 	StatsManager();
-	static StatsManager* instance_;
 
 	void CheckForDone(dialog* d);
 

--- a/Source_Files/Misc/preferences_widgets_sdl.h
+++ b/Source_Files/Misc/preferences_widgets_sdl.h
@@ -109,13 +109,13 @@ private:
 // Environment selection button
 // ZZZ: added callback stuff - callback is made if user clicks on an entry in the selection dialog.
 class w_env_select;
-typedef void (*selection_made_callback_t)(w_env_select* inWidget);
+using selection_made_callback_t = void(*)(w_env_select* inWidget);
 
 class w_env_select : public w_select_button {
 public:
 w_env_select(const char *path, const char *m, Typecode t, dialog *d)
-	: w_select_button(item_name, select_item_callback, NULL, true),
-		parent(d), menu_title(m), type(t), mCallback(NULL)
+	: w_select_button(item_name, select_item_callback, nullptr, true),
+		parent(d), menu_title(m), type(t), mCallback(nullptr)
 	{
 		set_arg(this);
 		set_path(path);
@@ -169,7 +169,7 @@ public:
 	~w_crosshair_display();
 
 	void draw(SDL_Surface *s) const;
-	bool is_selectable(void) const { return false; }
+	bool is_selectable() const { return false; }
 
 	bool placeable_implemented() { return true; }
 

--- a/Source_Files/Misc/sdl_network.h
+++ b/Source_Files/Misc/sdl_network.h
@@ -43,8 +43,9 @@
 // Note that the SDL network microphone code is the one sending "big" packets these days.
 #define ddpMaxData 1500
 
-typedef char NetEntityName[32];
-typedef IPaddress NetAddrBlock;
+
+using NetEntityName = char[32];
+using NetAddrBlock = IPaddress;
 
 /* ---------- DDPFrame and PacketBuffer (DDP) */
 

--- a/Source_Files/Misc/vbl_definitions.h
+++ b/Source_Files/Misc/vbl_definitions.h
@@ -49,7 +49,7 @@ struct recording_header
 	struct player_start_data starts[MAXIMUM_NUMBER_OF_PLAYERS];
 	struct game_data game_information;
 };
-const int SIZEOF_recording_header = 352;
+constexpr int SIZEOF_recording_header = 352;
 
 struct replay_private_data {
 	bool valid;
@@ -80,7 +80,7 @@ extern struct replay_private_data replay;
 ActionQueue *get_player_recording_queue(short player_index);
 #endif
 
-typedef void *timer_task_proc;
+using timer_task_proc = void*;
 
 timer_task_proc install_timer_task(short tasks_per_second, bool (*func)(void));
 void remove_timer_task(timer_task_proc proc);

--- a/Source_Files/Network/ConnectPool.cpp
+++ b/Source_Files/Network/ConnectPool.cpp
@@ -24,7 +24,6 @@
 #include "ConnectPool.h"
 #include <utility>
 
-ConnectPool* ConnectPool::m_instance = 0;
 
 NonblockingConnect::NonblockingConnect(const std::string& address, uint16 port)
 	: m_address(address), m_port(port), m_thread(0), m_ipSpecified(false)

--- a/Source_Files/Network/ConnectPool.h
+++ b/Source_Files/Network/ConnectPool.h
@@ -78,7 +78,13 @@ private:
 class ConnectPool
 {
 public:
-	static ConnectPool *instance() { if (!m_instance) m_instance = new ConnectPool(); return m_instance; }
+	static ConnectPool *instance() { 
+		static ConnectPool* m_instance = nullptr;
+		if (!m_instance) {
+			m_instance = new ConnectPool(); 
+		}
+		return m_instance; 
+	}
 	NonblockingConnect* connect(const std::string& address, uint16 port);
 	NonblockingConnect* connect(const IPaddress& ip);
 	void abandon(NonblockingConnect*);
@@ -90,8 +96,6 @@ private:
 	enum { kPoolSize = 20 };
 	// second is false if we are in use!
 	std::pair<NonblockingConnect *, bool> m_pool[kPoolSize];
-
-	static ConnectPool* m_instance;
 };
 
 #endif

--- a/Source_Files/Network/HTTP.h
+++ b/Source_Files/Network/HTTP.h
@@ -31,7 +31,7 @@ public:
 	typedef std::map<std::string, std::string> parameter_map;
 	static void Init();
 
-	HTTPClient() { }
+	HTTPClient() = default;
 	
 	bool Get(const std::string& url);
 	bool Post(const std::string& url, const parameter_map& parameters);

--- a/Source_Files/Network/Update.cpp
+++ b/Source_Files/Network/Update.cpp
@@ -28,7 +28,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include "alephversion.h"
 
-Update *Update::m_instance = 0;
 
 Update::Update() : m_status(NoUpdateAvailable), m_thread(0)
 {

--- a/Source_Files/Network/Update.h
+++ b/Source_Files/Network/Update.h
@@ -31,7 +31,13 @@
 class Update
 {
 public:
-	static Update *instance() { if (!m_instance) m_instance = new Update(); return m_instance; }
+	static Update *instance() { 
+		static Update *m_instance = nullptr;
+		if (!m_instance) {
+			m_instance = new Update();
+		}
+		return m_instance;
+	}
 
 	enum Status
 	{
@@ -45,7 +51,6 @@ public:
 	std::string NewDisplayVersion() { assert(m_status == UpdateAvailable); return m_new_display_version; }
 
 private:
-	static Update *m_instance;
 	Update();
 	~Update();
 

--- a/Source_Files/Network/network_capabilities.h
+++ b/Source_Files/Network/network_capabilities.h
@@ -30,7 +30,7 @@
 
 using std::string;
 
-typedef std::map<string, uint32> capabilities_t;
+using capabilities_t = std::map<string, uint32>;
 
 class Capabilities : public capabilities_t
 {

--- a/Source_Files/Network/network_capabilities.h
+++ b/Source_Files/Network/network_capabilities.h
@@ -37,16 +37,16 @@ class Capabilities : public capabilities_t
  public:
   enum { kMaxKeySize = 1024 };
 
-  static const int kGameworldVersion = 3;
-  static const int kGameworldM1Version = 2;
-  static const int kStarVersion = 6;
-  static const int kRingVersion = 2;
-  static const int kLuaVersion = 2;
-  static const int kSpeexVersion = 1;
-  static const int kGatherableVersion = 1;
-  static const int kZippedDataVersion = 1; // map, lua, physics
-  static const int kNetworkStatsVersion = 1; // latency, jitter, errors
-  static const int kRugbyVersion = 1; // sane score limit
+  static constexpr int kGameworldVersion = 3;
+  static constexpr int kGameworldM1Version = 2;
+  static constexpr int kStarVersion = 6;
+  static constexpr int kRingVersion = 2;
+  static constexpr int kLuaVersion = 2;
+  static constexpr int kSpeexVersion = 1;
+  static constexpr int kGatherableVersion = 1;
+  static constexpr int kZippedDataVersion = 1; // map, lua, physics
+  static constexpr int kNetworkStatsVersion = 1; // latency, jitter, errors
+  static constexpr int kRugbyVersion = 1; // sane score limit
 
   static const string kGameworld;    // the PRNG, physics, etc.
   static const string kGameworldM1;  // like gameworld, but for Marathon 1 compatibility

--- a/Source_Files/RenderMain/ImageLoader.h
+++ b/Source_Files/RenderMain/ImageLoader.h
@@ -49,32 +49,32 @@ class ImageDescriptor
 	
 public:
 	
-	bool IsPresent() const {return (Pixels != NULL); }
-	bool IsPremultiplied() const { return (IsPresent() ? PremultipliedAlpha : false); }
+	bool IsPresent() const noexcept {return (Pixels != nullptr); }
+	bool IsPremultiplied() const noexcept { return (IsPresent() ? PremultipliedAlpha : false); }
 
 	bool LoadFromFile(FileSpecifier& File, int ImgMode, int flags, int actual_width = 0, int actual_height = 0, int maxSize = 0);
 
 	// Size of level 0 image
-	int GetWidth() const {return Width;}
-	int GetHeight() const {return Height;}
-	int GetNumPixels() const {return Width*Height;}
+	int GetWidth() const noexcept {return Width;}
+	int GetHeight() const noexcept {return Height;}
+	int GetNumPixels() const noexcept {return Width*Height;}
 
-	int GetMipMapCount() const { return MipMapCount; }
-	int GetTotalBytes() const { return Size; }
-	int GetBufferSize() const { return Size; }
-	int GetFormat() const { return Format; }
+	int GetMipMapCount() const noexcept { return MipMapCount; }
+	int GetTotalBytes() const noexcept { return Size; }
+	int GetBufferSize() const noexcept { return Size; }
+	int GetFormat() const noexcept { return Format; }
 
-	double GetVScale() const { return VScale; }
-	double GetUScale() const { return UScale; }
+	double GetVScale() const noexcept { return VScale; }
+	double GetUScale() const noexcept { return UScale; }
 
 	// Pixel accessors
 	uint32& GetPixel(int Horiz, int Vert) {return Pixels[Width*(Vert%Height) + (Horiz%Width)];}
-	uint32 *GetPixelBasePtr() {return Pixels;}
-	const uint32 *GetBuffer() const { return Pixels; }
-	uint32 *GetBuffer() { return Pixels; }
+	uint32 *GetPixelBasePtr() noexcept {return Pixels;}
+	const uint32 *GetBuffer() const noexcept { return Pixels; }
+	uint32 *GetBuffer() noexcept { return Pixels; }
 
 	uint32 *GetMipMapPtr(int Level);
-	const uint32 *GetMipMapPtr(int Level) const;
+	const uint32 *GetMipMapPtr(int Level) const ;
 	int GetMipMapSize(int level) const;
 	
 	// Reallocation
@@ -93,11 +93,11 @@ public:
 
 	// Clearing
 	void Clear()
-		{Width = Height = Size = 0; delete []Pixels; Pixels = NULL;}
+		{Width = Height = Size = 0; delete []Pixels; Pixels = nullptr;}
 
 	ImageDescriptor(const ImageDescriptor &CopyFrom);
 	
-ImageDescriptor(): Width(0), Height(0), VScale(1.0), UScale(1.0), Pixels(NULL), Size(0), PremultipliedAlpha(false) {}
+	ImageDescriptor(): Width(0), Height(0), VScale(1.0), UScale(1.0), Pixels(nullptr), Size(0), PremultipliedAlpha(false) {}
 
 	// asumes RGBA8
 	ImageDescriptor(int width, int height, uint32 *pixels);
@@ -113,7 +113,7 @@ ImageDescriptor(): Width(0), Height(0), VScale(1.0), UScale(1.0), Pixels(NULL), 
 	~ImageDescriptor()
 	{
 		delete []Pixels;
-		Pixels = NULL;
+		Pixels = nullptr;
 	}
 			
 private:
@@ -128,12 +128,12 @@ template <typename T>
 class copy_on_edit
 {
 public:
-	copy_on_edit() : _original(NULL), _copy(NULL) { };
+	copy_on_edit() : _original(nullptr), _copy(nullptr) { };
 
 	void set(const T* original) {
 		if (_copy) {
 			delete _copy;
-			_copy = NULL;
+			_copy = nullptr;
 		}
 		_original = original;
 	}
@@ -141,7 +141,7 @@ public:
 	void set(T* original) {
 		if (_copy) {
 			delete _copy;
-			_copy= NULL;
+			_copy= nullptr;
 		}
 		_original = original;
 	}
@@ -170,7 +170,7 @@ public:
 		if (_copy) {
 			delete _copy;
 		}
-		_original = NULL;
+		_original = nullptr;
 		_copy = copy;
         return _copy;
 	}
@@ -178,7 +178,7 @@ public:
 	~copy_on_edit() {
 		if (_copy) {
 			delete _copy;
-			_copy = NULL;
+			_copy = nullptr;
 		}
 	}
 
@@ -187,7 +187,7 @@ private:
 	T* _copy;
 };
 
-typedef copy_on_edit<ImageDescriptor> ImageDescriptorManager;
+using ImageDescriptionManager = copy_on_edit<ImageDescriptor>;
 		
 
 // What to load: image colors (must be loaded first)

--- a/Source_Files/RenderMain/ImageLoader.h
+++ b/Source_Files/RenderMain/ImageLoader.h
@@ -187,7 +187,7 @@ private:
 	T* _copy;
 };
 
-using ImageDescriptionManager = copy_on_edit<ImageDescriptor>;
+using ImageDescriptorManager = copy_on_edit<ImageDescriptor>;
 		
 
 // What to load: image colors (must be loaded first)

--- a/Source_Files/RenderMain/OGL_Setup.h
+++ b/Source_Files/RenderMain/OGL_Setup.h
@@ -119,7 +119,7 @@ extern bool npotTextures;
 #ifdef HAVE_OPENGL
 
 /* Using the EXT_framebuffer_sRGB spec as reference */
-static inline float sRGB_frob(GLfloat f) {
+inline float sRGB_frob(GLfloat f) {
 	if (Using_sRGB) {
 		return (f <= 0.04045f ? f * (1.f/12.92f) : std::pow((f + 0.055) * (1.0/1.055), 2.4));
 	} else {

--- a/Source_Files/RenderMain/OGL_Texture_Def.h
+++ b/Source_Files/RenderMain/OGL_Texture_Def.h
@@ -79,7 +79,7 @@ inline bool IsSilhouetteTable(short CLUT)
 
 
 // If the color-table value has this value, it means all color tables:
-const int ALL_CLUTS = -1;
+constexpr int ALL_CLUTS = -1;
 
 
 // Here are the texture-opacity types.

--- a/Source_Files/RenderMain/OGL_Texture_Def.h
+++ b/Source_Files/RenderMain/OGL_Texture_Def.h
@@ -64,13 +64,13 @@ enum {
 
 
 // Check for infravision or silhouette special CLUTs
-static inline bool IsInfravisionTable(short CLUT)
+inline bool IsInfravisionTable(short CLUT)
 {
     return (CLUT == INFRAVISION_BITMAP_SET ||
             (CLUT >= INFRAVISION_BITMAP_CLUTSPECIFIC &&
              CLUT <  INFRAVISION_BITMAP_CLUTSPECIFIC + MAXIMUM_CLUTS_PER_COLLECTION));
 }
-static inline bool IsSilhouetteTable(short CLUT)
+inline bool IsSilhouetteTable(short CLUT)
 {
     return (CLUT == SILHOUETTE_BITMAP_SET ||
             (CLUT >= SILHOUETTE_BITMAP_CLUTSPECIFIC &&

--- a/Source_Files/RenderMain/OGL_Textures.h
+++ b/Source_Files/RenderMain/OGL_Textures.h
@@ -116,7 +116,7 @@ short ModifyCLUT(short TransferMode, short CLUT);
 
 
 // Intended to be the no-texture default argument
-const int BadTextureType = 32767;
+constexpr int BadTextureType = 32767;
 
 /*
 	Texture-manager object: contains all the handling of textures;
@@ -263,7 +263,9 @@ public:
 
 // Five-to-eight translation:
 // takes a 5-bit color value and expands it to 8 bytes
-inline byte FiveToEight(byte x) {return (x << 3) | ((x >> 2) & 0x07);}
+constexpr byte FiveToEight(byte x) noexcept {
+	return (x << 3) | ((x >> 2) & 0x07);
+}
 
 // 16-bit-to-32-bit with opacity = 1;
 // ARGB 1555 to RGBA 8888

--- a/Source_Files/RenderMain/RenderVisTree.h
+++ b/Source_Files/RenderMain/RenderVisTree.h
@@ -44,12 +44,12 @@ Oct 13, 2000
 
 
 // Made pointers more general
-typedef byte *POINTER_DATA;
+using POINTER_DATA = byte*;
 #define POINTER_CAST(x) ((POINTER_DATA)(x))
 
 
 // LP addition: typecast for cross-products, since these can be large
-typedef double CROSSPROD_TYPE;
+using CROSSPROD_TYPE = double;
 
 
 // Macros

--- a/Source_Files/RenderMain/collection_definition.h
+++ b/Source_Files/RenderMain/collection_definition.h
@@ -92,7 +92,7 @@ struct collection_definition
 	std::vector<low_level_shape_definition> low_level_shapes;
 	std::vector<std::vector<uint8> > bitmaps;
 };
-const int SIZEOF_collection_definition = 544;
+constexpr int SIZEOF_collection_definition = 544;
 
 /* ---------- high level shape definition */
 
@@ -125,7 +125,7 @@ struct high_level_shape_definition // Starting with number_of_views, this is a s
 	   low-level indices follow (it's not simply number_of_view * frames_per_view) */
 	int16 low_level_shape_indexes[1];
 };
-const int SIZEOF_high_level_shape_definition = 90;
+constexpr int SIZEOF_high_level_shape_definition = 90;
 
 /* --------- low-level shape definition */
 
@@ -152,7 +152,7 @@ struct low_level_shape_definition
 	
 	int16 unused[4];
 };
-const int SIZEOF_low_level_shape_definition = 36;
+constexpr int SIZEOF_low_level_shape_definition = 36;
 
 /* ---------- colors */
 
@@ -168,6 +168,6 @@ struct rgb_color_value
 	
 	uint16 red, green, blue;
 };
-const int SIZEOF_rgb_color_value = 8;
+constexpr int SIZEOF_rgb_color_value = 8;
 
 #endif

--- a/Source_Files/RenderMain/shape_definitions.h
+++ b/Source_Files/RenderMain/shape_definitions.h
@@ -46,10 +46,10 @@ struct collection_header /* 32 bytes on disk */
 	collection_definition *collection;
 	byte *shading_tables;
 };
-const int SIZEOF_collection_header = 32;
+constexpr int SIZEOF_collection_header = 32;
 
 /* ---------- globals */
 
-static struct collection_header collection_headers[MAXIMUM_COLLECTIONS];
+struct collection_header collection_headers[MAXIMUM_COLLECTIONS];
 
 #endif

--- a/Source_Files/RenderMain/shape_descriptors.h
+++ b/Source_Files/RenderMain/shape_descriptors.h
@@ -36,15 +36,17 @@ Feb 3, 2000 (Loren Petrich):
 
 /* ---------- types */
 
-typedef uint16 shape_descriptor; /* [clut.3] [collection.5] [shape.8] */
+using shape_descriptor = uint16; /* [clut.3] [collection.5] [shape.8] */
 
 #define DESCRIPTOR_SHAPE_BITS 8
 #define DESCRIPTOR_COLLECTION_BITS 5
 #define DESCRIPTOR_CLUT_BITS 3
-
-#define MAXIMUM_COLLECTIONS (1<<DESCRIPTOR_COLLECTION_BITS)
-#define MAXIMUM_SHAPES_PER_COLLECTION (1<<DESCRIPTOR_SHAPE_BITS)
-#define MAXIMUM_CLUTS_PER_COLLECTION (1<<DESCRIPTOR_CLUT_BITS)
+constexpr shape_descriptor MaximumCollections = 1 << DESCRIPTOR_SHAPE_BITS;
+constexpr shape_descriptor MaximumShapesPerCollection = 1 << DESCRIPTOR_COLLECTION_BITS;
+constexpr shape_descriptor MaximumClutsPerCollection = 1 << DESCRIPTOR_CLUT_BITS;
+#define MAXIMUM_COLLECTIONS (MaximumCollections)
+#define MAXIMUM_SHAPES_PER_COLLECTION (MaximumShapesPerCollection)
+#define MAXIMUM_CLUTS_PER_COLLECTION (MaximumClutsPerCollection)
 
 /* ---------- collections */
 
@@ -87,13 +89,30 @@ enum /* collection numbers */
 };
 
 /* ---------- macros */
-
-#define GET_DESCRIPTOR_SHAPE(d) ((d)&(uint16)(MAXIMUM_SHAPES_PER_COLLECTION-1))
-#define GET_DESCRIPTOR_COLLECTION(d) (((d)>>DESCRIPTOR_SHAPE_BITS)&(uint16)((1<<(DESCRIPTOR_COLLECTION_BITS+DESCRIPTOR_CLUT_BITS))-1))
-#define BUILD_DESCRIPTOR(collection,shape) (((collection)<<DESCRIPTOR_SHAPE_BITS)|(shape))
+constexpr uint16 ShapeDescriptor_GetDescriptorShape(uint16 d) noexcept {
+	return d & (MaximumShapesPerCollection - 1);
+}
+constexpr uint16 ShapeDescriptor_GetDescriptorCollection(uint16 d) noexcept {
+	return ((d) >> DESCRIPTOR_SHAPE_BITS) & uint16(((1<< (DESCRIPTOR_COLLECTION_BITS + DESCRIPTOR_CLUT_BITS)) - 1));
+}
+constexpr uint16 ShapeDescriptor_BuildDescriptor(uint16 collection, uint16 shape) noexcept {
+	return (collection << DESCRIPTOR_SHAPE_BITS) | shape;
+}
+constexpr uint16 ShapeDescriptor_GetCollectionClut(uint16 collection) noexcept {
+	return ((collection) >> DESCRIPTOR_COLLECTION_BITS) & uint16(MAXIMUM_CLUTS_PER_COLLECTION - 1);
+}
+constexpr uint16 ShapeDescriptor_GetCollection(uint16 collection) noexcept {
+	return ((collection) & (MaximumCollections - 1));
+}
+constexpr uint16 ShapeDescriptor_BuildCollection(uint16 collection, uint16 clut) noexcept {
+	return collection | uint16(clut << DESCRIPTOR_COLLECTION_BITS);
+}
+#define GET_DESCRIPTOR_SHAPE(d) (ShapeDescriptor_GetDescriptorShape((d)))
+#define GET_DESCRIPTOR_COLLECTION(d) (ShapeDescriptor_GetDescriptorCollection((d)))
+#define BUILD_DESCRIPTOR(collection,shape) (ShapeDescriptor_BuildCollection((collection), (shape)))
 
 #define BUILD_COLLECTION(collection,clut) ((collection)|(uint16)((clut)<<DESCRIPTOR_COLLECTION_BITS))
-#define GET_COLLECTION_CLUT(collection) (((collection)>>DESCRIPTOR_COLLECTION_BITS)&(uint16)(MAXIMUM_CLUTS_PER_COLLECTION-1))
-#define GET_COLLECTION(collection) ((collection)&(MAXIMUM_COLLECTIONS-1))
+#define GET_COLLECTION_CLUT(collection) (ShapeDescriptor_GetCollectionClut((collection)))
+#define GET_COLLECTION(collection) (ShapeDescriptor_GetCollection((collection)))
 
 #endif

--- a/Source_Files/RenderMain/textures.h
+++ b/Source_Files/RenderMain/textures.h
@@ -47,7 +47,7 @@ struct bitmap_definition
 	
 	pixel8 *row_addresses[1];
 };
-const int SIZEOF_bitmap_definition = 30;
+constexpr int SIZEOF_bitmap_definition = 30;
 
 /* ---------- prototypes/TEXTURES.C */
 

--- a/Source_Files/RenderMain/vec3.h
+++ b/Source_Files/RenderMain/vec3.h
@@ -18,7 +18,7 @@ const GLfloat kThreshhold = FLT_MIN * 10.0;
 struct vec4 {
 	GLfloat _d[4];
 
-	vec4() {}
+	vec4() = default;
 	vec4(const GLfloat& x, const GLfloat& y, const GLfloat& z, const GLfloat& w) {
 		_d[0] = x; _d[1] = y; _d[2] = z; _d[3] = w;		
 	}
@@ -31,7 +31,7 @@ struct vec4 {
 
 struct vec3 : public vec4 {
 	
-	vec3() {}
+	vec3() = default;
 	vec3(const GLfloat& x, const GLfloat& y, const GLfloat& z) : vec4(x, y, z, 0.0) {}
 	vec3(const GLfloat* f) : vec4(f[0], f[1], f[2], 0.0) {}
 	
@@ -76,7 +76,7 @@ struct vec3 : public vec4 {
 
 struct vertex3 : public vec4 {
 
-	vertex3() {}
+	vertex3() = default;
 	vertex3(const GLfloat& x, const GLfloat& y, const GLfloat& z) : vec4(x, y, z, 1.0) {}
 	vertex3(const GLfloat* f) : vec4(f[0], f[1], f[2], 1.0) {}
 
@@ -87,7 +87,7 @@ struct vertex3 : public vec4 {
 
 struct vertex2 : public vec4 {
 	
-	vertex2() {}
+	vertex2() = default;
 	vertex2(const vec4& v) : vec4(v) {}
 	vertex2(const GLfloat& x, const GLfloat& y) : vec4(x, y, 0.0, 1.0) {}
 	vertex2(const GLfloat* f) : vec4(f[0], f[1], 0.0, 1.0) {}

--- a/Source_Files/RenderOther/HUDRenderer.h
+++ b/Source_Files/RenderOther/HUDRenderer.h
@@ -49,8 +49,10 @@
 #define DELAY_TICKS_BETWEEN_OXYGEN_REDRAW (2*TICKS_PER_SECOND)
 #define RECORDING_LIGHT_FLASHING_DELAY (TICKS_PER_SECOND)
 
-#define MICROPHONE_STOP_CLICK_SOUND ((short) 1250)
-#define MICROPHONE_START_CLICK_SOUND ((short) 1280)
+constexpr short MicrophoneStopClickSound = 1250;
+constexpr short MicrophoneStartClickSound = 1280;
+#define MICROPHONE_STOP_CLICK_SOUND (MicrophoneStopClickSound)
+#define MICROPHONE_START_CLICK_SOUND (MicrophoneStartClickSound)
 
 #define TOP_OF_BAR_HEIGHT 4
 

--- a/Source_Files/RenderOther/HUDRenderer_OGL.h
+++ b/Source_Files/RenderOther/HUDRenderer_OGL.h
@@ -33,8 +33,8 @@
 class HUD_OGL_Class : public HUD_Class
 {
 public:
-	HUD_OGL_Class() {}
-	~HUD_OGL_Class() {}
+	HUD_OGL_Class() = default;
+	~HUD_OGL_Class() = default;
 
 protected:
 	void update_motion_sensor(short time_elapsed);

--- a/Source_Files/RenderOther/HUDRenderer_SW.h
+++ b/Source_Files/RenderOther/HUDRenderer_SW.h
@@ -37,8 +37,8 @@
 class HUD_SW_Class : public HUD_Class
 {
 public:
-	HUD_SW_Class() {}
-	~HUD_SW_Class() {}
+	HUD_SW_Class() = default;
+	~HUD_SW_Class() = default;
 
 protected:
 	void update_motion_sensor(short time_elapsed);

--- a/Source_Files/RenderOther/Image_Blitter.h
+++ b/Source_Files/RenderOther/Image_Blitter.h
@@ -34,10 +34,10 @@ struct Image_Rect
 	
 	Image_Rect() = default;
 	
-	explicit constexpr Image_Rect(float x, float y, float w, float h)
+	explicit constexpr Image_Rect(float x, float y, float w, float h) noexcept 
 		: x(x), y(y), w(w), h(h) {}
 	
-	/*implicit*/ constexpr Image_Rect(SDL_Rect r)
+	/*implicit*/ constexpr Image_Rect(SDL_Rect r) noexcept 
 		: x(r.x), y(r.y), w(r.w), h(r.h) {}
 };
 

--- a/Source_Files/RenderOther/OGL_LoadScreen.cpp
+++ b/Source_Files/RenderOther/OGL_LoadScreen.cpp
@@ -29,10 +29,10 @@
 
 extern bool OGL_SwapBuffers();
 
-OGL_LoadScreen *OGL_LoadScreen::instance_;
 
 OGL_LoadScreen *OGL_LoadScreen::instance()
 {
+	static OGL_LoadScreen *instance_ = nullptr;
 	if (!instance_) 
 		instance_ = new OGL_LoadScreen();
 	

--- a/Source_Files/RenderOther/OGL_LoadScreen.h
+++ b/Source_Files/RenderOther/OGL_LoadScreen.h
@@ -72,7 +72,6 @@ OGL_LoadScreen() : x(0), y(0), w(0), h(0), use(false), useProgress(false), perce
 
 	short percent;
 
-	static OGL_LoadScreen *instance_;
 
 	GLuint texture_ref;
 };

--- a/Source_Files/RenderOther/OverheadMapRenderer.h
+++ b/Source_Files/RenderOther/OverheadMapRenderer.h
@@ -110,7 +110,7 @@ struct entity_definition
 	short front, rear, rear_theta;
 };
 
-const int NUMBER_OF_ANNOTATION_SIZES = OVERHEAD_MAP_MAXIMUM_SCALE-OVERHEAD_MAP_MINIMUM_SCALE+1;
+constexpr int NUMBER_OF_ANNOTATION_SIZES = OVERHEAD_MAP_MAXIMUM_SCALE-OVERHEAD_MAP_MINIMUM_SCALE+1;
 struct annotation_definition
 {
 	rgb_color color;
@@ -118,7 +118,7 @@ struct annotation_definition
 };
 
 // For some reason, only one annotation color was ever implemented
-const int NUMBER_OF_ANNOTATION_DEFINITIONS = 1;
+constexpr int NUMBER_OF_ANNOTATION_DEFINITIONS = 1;
 
 // Collection of the data used to do the map name
 struct map_name_definition
@@ -321,7 +321,7 @@ public:
 	void Render(overhead_map_data& Control);
 	
 	// Constructor (idiot-proofer)
-	OverheadMapClass(): ConfigPtr(NULL) {}
+	OverheadMapClass(): ConfigPtr(nullptr) {}
 
 	// Destructor
 	virtual ~OverheadMapClass() {}

--- a/Source_Files/RenderOther/computer_interface.h
+++ b/Source_Files/RenderOther/computer_interface.h
@@ -86,7 +86,7 @@ struct static_preprocessed_terminal_data {
 	int16 grouping_count;
 	int16 font_changes_count;
 };
-const int SIZEOF_static_preprocessed_terminal_data = 10;
+constexpr int SIZEOF_static_preprocessed_terminal_data = 10;
 
 struct view_terminal_data {
 	short top, left, bottom, right;
@@ -94,7 +94,7 @@ struct view_terminal_data {
 };
 
 // External-data size of current terminal state
-const int SIZEOF_player_terminal_data = 20;
+constexpr int SIZEOF_player_terminal_data = 20;
 
 /* ------------ prototypes */
 void initialize_terminal_manager(void);

--- a/Source_Files/RenderOther/screen_drawing.h
+++ b/Source_Files/RenderOther/screen_drawing.h
@@ -179,32 +179,32 @@ void _set_port_to_HUD();
 
 struct world_point2d;
 
-static inline int draw_text(SDL_Surface *s, const char *text, size_t length, int x, int y, uint32 pixel, const font_info *font, uint16 style, bool utf8 = false)
+inline int draw_text(SDL_Surface *s, const char *text, size_t length, int x, int y, uint32 pixel, const font_info *font, uint16 style, bool utf8 = false)
 {
 	return font ? font->draw_text(s, text, length, x, y, pixel, style, utf8) : 0;
 }
 
-static inline int draw_text(SDL_Surface *s, const char *text, int x, int y, uint32 pixel, const font_info *font, uint16 style, bool utf8 = false)
+inline int draw_text(SDL_Surface *s, const char *text, int x, int y, uint32 pixel, const font_info *font, uint16 style, bool utf8 = false)
 {
 	return font ? font->draw_text(s, text, strlen(text), x, y, pixel, style, utf8) : 0;
 }
 
-static inline int8 char_width(uint8 c, const font_info *font, uint16 style)
+inline int8 char_width(uint8 c, const font_info *font, uint16 style)
 {
 	return font ? font->char_width(c, style) : 0;
 }
 
-static inline uint16 text_width(const char *text, const font_info *font, uint16 style, bool utf8 = false)
+inline uint16 text_width(const char *text, const font_info *font, uint16 style, bool utf8 = false)
 {
 	return font ? font->text_width(text, style, utf8) : 0;
 }
 
-static inline uint16 text_width(const char *text, size_t length, const font_info *font, uint16 style, bool utf8 = false)
+inline uint16 text_width(const char *text, size_t length, const font_info *font, uint16 style, bool utf8 = false)
 {
 	return font ? font->text_width(text, length, style, utf8) : 0;
 }
 
-static inline int trunc_text(const char *text, int max_width, const font_info *font, uint16 style)
+inline int trunc_text(const char *text, int max_width, const font_info *font, uint16 style)
 {
 	return font ? font->trunc_text(text, max_width, style) : 0;
 }

--- a/Source_Files/RenderOther/screen_shared.h
+++ b/Source_Files/RenderOther/screen_shared.h
@@ -142,34 +142,34 @@ static void set_terminal_status(bool status);
 /* SB */
 namespace icon {
 	
-  static inline char nextc(const char*& p, size_t& rem) {
+  inline char nextc(const char*& p, size_t& rem) {
     if(rem == 0) throw "end of string";
     --rem;
     return *(p++);
   }
 	
   // we can't use ctype for this because of locales and hexadecimal
-  static inline bool isadigit(char p) {
+  inline bool isadigit(char p) {
     if(p >= '0' && p <= '9') return true;
     else if(p >= 'A' && p <= 'F') return true;
     else if(p >= 'a' && p <= 'f') return true;
     else return false;
   }
 	
-  static inline unsigned char digit(char p) {
+  inline unsigned char digit(char p) {
     if(p >= '0' && p <= '9') return p - '0';
     else if(p >= 'A' && p <= 'F') return p - 'A' + 0xA;
     else if(p >= 'a' && p <= 'f') return p - 'a' + 0xA;
     else throw "invalid digit";
   }
 	
-  static inline unsigned char readuc(const char*& p, size_t& rem) {
+  inline unsigned char readuc(const char*& p, size_t& rem) {
     char a = nextc(p, rem), b;
     b = nextc(p, rem);
     return (digit(a) << 4) | digit(b);
   }
 	
-  static bool parseicon(const char* p, size_t rem,
+  bool parseicon(const char* p, size_t rem,
 			unsigned char palette[1024], int& numcolors,
 			unsigned char graphic[256]) {
     char chars[256];

--- a/Source_Files/Sound/BasicIFFDecoder.h
+++ b/Source_Files/Sound/BasicIFFDecoder.h
@@ -45,7 +45,7 @@ public:
 	int32 Frames() { return length / bytes_per_frame; }
 
 	BasicIFFDecoder();
-	~BasicIFFDecoder() { }
+	~BasicIFFDecoder() = default;
 
 private:
 	bool sixteen_bit;

--- a/Source_Files/Sound/Decoder.h
+++ b/Source_Files/Sound/Decoder.h
@@ -35,6 +35,7 @@ public:
 	virtual void Rewind() = 0;
 	virtual void Close() = 0;
 
+	// TODO figure out if these abstract methods can be safely const noexcept
 	virtual bool IsSixteenBit() = 0;
 	virtual bool IsStereo() = 0;
 	virtual bool IsSigned() = 0;

--- a/Source_Files/Sound/FFmpegDecoder.h
+++ b/Source_Files/Sound/FFmpegDecoder.h
@@ -41,11 +41,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return 2 * (IsStereo() ? 2 : 1); }
 	float Rate() { return rate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	int32 Frames();
 

--- a/Source_Files/Sound/MADDecoder.h
+++ b/Source_Files/Sound/MADDecoder.h
@@ -42,11 +42,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return bytes_per_frame; }
 	float Rate() { return rate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	MADDecoder();
 	~MADDecoder();

--- a/Source_Files/Sound/Mixer.cpp
+++ b/Source_Files/Sound/Mixer.cpp
@@ -22,8 +22,6 @@
 #include "Mixer.h"
 #include "interface.h" // for strERRORS
 
-Mixer* Mixer::m_instance = 0;
-
 extern bool option_nosound;
 
 void Mixer::Start(uint16 rate, bool sixteen_bit, bool stereo, int num_channels, int volume, uint16 samples)

--- a/Source_Files/Sound/Mixer.h
+++ b/Source_Files/Sound/Mixer.h
@@ -36,7 +36,12 @@ extern bool game_is_networked;
 class Mixer
 {
 public:
-	static Mixer *instance() { if (!m_instance) m_instance = new Mixer(); return m_instance; }
+	static Mixer *instance() { 
+		static Mixer *m_instance = nullptr;
+		if (!m_instance) 
+			m_instance = new Mixer(); 
+		return m_instance; 
+	}
 	void Start(uint16 rate, bool sixteen_bit, bool stereo, int num_channels, int volume, uint16 samples);
 	void Stop();
 
@@ -73,7 +78,6 @@ public:
 private:
         Mixer() : sNetworkAudioBufferDesc(0) { };
 	
-	static Mixer *m_instance;
 	
 	struct Channel {
 		SoundInfo info;

--- a/Source_Files/Sound/Music.cpp
+++ b/Source_Files/Sound/Music.cpp
@@ -23,8 +23,6 @@
 #include "Mixer.h"
 #include "XML_LevelScript.h"
 
-Music* Music::m_instance = 0;
-
 Music::Music() : 
 	music_initialized(false), 
 	music_intro(false), 

--- a/Source_Files/Sound/Music.h
+++ b/Source_Files/Sound/Music.h
@@ -35,7 +35,10 @@ class Music
 {
 public:
 	static Music *instance() { 
-		if (!m_instance) m_instance = new Music(); return m_instance; 
+		static Music *m_instance = nullptr;
+		if (!m_instance) 
+			m_instance = new Music(); 
+		return m_instance; 
 	}
 
 	bool SetupIntroMusic(FileSpecifier &File);
@@ -70,7 +73,6 @@ public:
 private:
 	Music();
 	bool Load(FileSpecifier &file);
-	static Music *m_instance;
 
 	FileSpecifier* GetLevelMusic();
 	void LoadLevelMusic();

--- a/Source_Files/Sound/ReplacementSounds.cpp
+++ b/Source_Files/Sound/ReplacementSounds.cpp
@@ -25,8 +25,6 @@
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 
-SoundReplacements *SoundReplacements::m_instance = 0;
-
 boost::shared_ptr<SoundData> ExternalSoundHeader::LoadExternal(FileSpecifier& File)
 {
 	boost::shared_ptr<SoundData> p;

--- a/Source_Files/Sound/ReplacementSounds.h
+++ b/Source_Files/Sound/ReplacementSounds.h
@@ -47,6 +47,7 @@ class SoundReplacements
 {
 public:
 	static inline SoundReplacements* instance() { 
+		static SoundReplacements *m_instance = nullptr;
 		if (!m_instance) m_instance = new SoundReplacements;
 		return m_instance;
 	}
@@ -57,9 +58,8 @@ public:
 
 private:
 	SoundReplacements() { }
-	static SoundReplacements *m_instance;
 
-	typedef std::pair<short, short> key;
+	using key = std::pair<short, short>;
 
 	boost::unordered_map<key, SoundOptions> m_hash;
 };

--- a/Source_Files/Sound/SndfileDecoder.h
+++ b/Source_Files/Sound/SndfileDecoder.h
@@ -42,11 +42,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return 2 * (IsStereo() ? 2 : 1); }
 	float Rate() { return (float) sfinfo.samplerate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	int32 Frames() { return sfinfo.frames; }
 

--- a/Source_Files/Sound/SoundFile.h
+++ b/Source_Files/Sound/SoundFile.h
@@ -32,7 +32,7 @@ SOUND_DEFINITIONS.H
 #include <boost/shared_array.hpp>
 #include <boost/shared_ptr.hpp>
 
-typedef std::vector<uint8> SoundData;
+using SoundData = std::vector<uint8>;
 
 class SoundInfo 
 {
@@ -62,7 +62,7 @@ class SoundHeader : public SoundInfo
 {
 public:
 	SoundHeader();
-	virtual ~SoundHeader() { };
+	virtual ~SoundHeader() = default;
 
 	bool Load(BIStreamBE& stream);
 	boost::shared_ptr<SoundData> LoadData(BIStreamBE& stream);
@@ -73,16 +73,16 @@ public:
 	bool Load(LoadedResource& rsrc); // finds system 7 header in rsrc
 	boost::shared_ptr<SoundData> LoadData(LoadedResource& rsrc);
 
-	int32 Length() const
+	int32 Length() const noexcept
 		{ return length; };
 	
-	void Clear() { length = 0; }
+	void Clear() noexcept { length = 0; }
 
 private:
-	static const uint8 stdSH = 0x00; // standard sound header
-	static const uint8 extSH = 0xFF; // extended sound header
-	static const uint8 cmpSH = 0xFE; // compressed sound header
-	static const uint16 bufferCmd = 0x8051;
+	static constexpr uint8 stdSH = 0x00; // standard sound header
+	static constexpr uint8 extSH = 0xFF; // extended sound header
+	static constexpr uint8 cmpSH = 0xFE; // compressed sound header
+	static constexpr uint16 bufferCmd = 0x8051;
 
 	bool UnpackStandardSystem7Header(BIStreamBE &header);
 	bool UnpackExtendedSystem7Header(BIStreamBE &header);
@@ -99,10 +99,11 @@ public:
 	boost::shared_ptr<SoundData> LoadData(OpenedFile& SoundFile, short permutation);
 	void Unload() { sounds.clear(); }
 
-	static const int MAXIMUM_PERMUTATIONS_PER_SOUND = 5;
+	static constexpr int MAXIMUM_PERMUTATIONS_PER_SOUND = 5;
 
 private:
-	static int HeaderSize() { return 64; }
+	// TODO see if this can be marked as constexpr
+	static int HeaderSize() noexcept { return 64; }
 	
 public: // for now
 	int16 sound_code;
@@ -180,7 +181,7 @@ private:
 	int16 source_count;
 	int16 sound_count;
 
-	static const int v1Unused = 124;
+	static constexpr int v1Unused = 124;
 
 	std::vector< std::vector<SoundDefinition> > sound_definitions;
 

--- a/Source_Files/Sound/SoundManager.cpp
+++ b/Source_Files/Sound/SoundManager.cpp
@@ -129,8 +129,6 @@ void SoundMemoryManager::Update(short index)
 	m_entries[index].last_played = machine_tick_count();
 }
 
-SoundManager *SoundManager::m_instance = 0;
-
 static void Shutdown()
 {
 	SoundManager::instance()->Shutdown();

--- a/Source_Files/Sound/SoundManager.h
+++ b/Source_Files/Sound/SoundManager.h
@@ -41,6 +41,7 @@ class SoundManager
 {
 public:
 	static inline SoundManager* instance() { 
+		static SoundManager *m_instance = nullptr;
 		if (!m_instance) m_instance = new SoundManager; 
 		return m_instance; 
 	}
@@ -164,7 +165,6 @@ private:
 	void TrackStereoSounds();
 	void UpdateAmbientSoundSources();
 
-	static SoundManager *m_instance;
 
 	bool initialized;
 	bool active;
@@ -179,35 +179,35 @@ private:
 	SoundMemoryManager* sounds;
 
 	// buffer sizes
-	static const int MINIMUM_SOUND_BUFFER_SIZE = 300*KILO;
-	static const int MORE_SOUND_BUFFER_SIZE = 600*KILO;
-	static const int AMBIENT_SOUND_BUFFER_SIZE = 1*MEG;
-	static const int MAXIMUM_SOUND_BUFFER_SIZE = 1*MEG;
+	static constexpr int MINIMUM_SOUND_BUFFER_SIZE = 300*KILO;
+	static constexpr int MORE_SOUND_BUFFER_SIZE = 600*KILO;
+	static constexpr int AMBIENT_SOUND_BUFFER_SIZE = 1*MEG;
+	static constexpr int MAXIMUM_SOUND_BUFFER_SIZE = 1*MEG;
 
 	// channels
-	static const int MAXIMUM_SOUND_CHANNELS = 32;
-	static const int MAXIMUM_AMBIENT_SOUND_CHANNELS = 4;
-	static const int MAXIMUM_PROCESSED_AMBIENT_SOUNDS = 5;
+	static constexpr int MAXIMUM_SOUND_CHANNELS = 32;
+	static constexpr int MAXIMUM_AMBIENT_SOUND_CHANNELS = 4;
+	static constexpr int MAXIMUM_PROCESSED_AMBIENT_SOUNDS = 5;
 
 	// volumes
 	// MAXIMUM_SOUND_VOLUME is 256, NUMBER_OF_SOUND_VOLUME_LEVELS is 8
-	static const int MAXIMUM_OUTPUT_SOUND_VOLUME = 2 * MAXIMUM_SOUND_VOLUME;
-	static const int SOUND_VOLUME_DELTA = MAXIMUM_OUTPUT_SOUND_VOLUME / NUMBER_OF_SOUND_VOLUME_LEVELS;
-	static const int MAXIMUM_AMBIENT_SOUND_VOLUME = 3 * MAXIMUM_SOUND_VOLUME / 2;
-	static const int DEFAULT_SOUND_LEVEL= NUMBER_OF_SOUND_VOLUME_LEVELS/3;
-	static const int DEFAULT_MUSIC_LEVEL = NUMBER_OF_SOUND_VOLUME_LEVELS/2;
-	static const int DEFAULT_VOLUME_WHILE_SPEAKING = MAXIMUM_SOUND_VOLUME / 8;
+	static constexpr int MAXIMUM_OUTPUT_SOUND_VOLUME = 2 * MAXIMUM_SOUND_VOLUME;
+	static constexpr int SOUND_VOLUME_DELTA = MAXIMUM_OUTPUT_SOUND_VOLUME / NUMBER_OF_SOUND_VOLUME_LEVELS;
+	static constexpr int MAXIMUM_AMBIENT_SOUND_VOLUME = 3 * MAXIMUM_SOUND_VOLUME / 2;
+	static constexpr int DEFAULT_SOUND_LEVEL= NUMBER_OF_SOUND_VOLUME_LEVELS/3;
+	static constexpr int DEFAULT_MUSIC_LEVEL = NUMBER_OF_SOUND_VOLUME_LEVELS/2;
+	static constexpr int DEFAULT_VOLUME_WHILE_SPEAKING = MAXIMUM_SOUND_VOLUME / 8;
 
 	// pitch
-	static const int MINIMUM_SOUND_PITCH= 1;
-	static const int MAXIMUM_SOUND_PITCH= 256*FIXED_ONE;
+	static constexpr int MINIMUM_SOUND_PITCH= 1;
+	static constexpr int MAXIMUM_SOUND_PITCH= 256*FIXED_ONE;
 
 	// best channel
-	static const int ABORT_AMPLITUDE_THRESHHOLD= (MAXIMUM_SOUND_VOLUME/6);
-	static const int MINIMUM_RESTART_TICKS= MACHINE_TICKS_PER_SECOND/12;
+	static constexpr int ABORT_AMPLITUDE_THRESHHOLD= (MAXIMUM_SOUND_VOLUME/6);
+	static constexpr int MINIMUM_RESTART_TICKS= MACHINE_TICKS_PER_SECOND/12;
 
 	// channel flags
-	static const int _sound_is_local = 0x0001;
+	static constexpr int _sound_is_local = 0x0001;
 };
 
 /* ---------- types */

--- a/Source_Files/Sound/VorbisDecoder.h
+++ b/Source_Files/Sound/VorbisDecoder.h
@@ -42,11 +42,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return 2 * (IsStereo() ? 2 : 1); }
 	float Rate() { return rate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	VorbisDecoder();
 	~VorbisDecoder();

--- a/Source_Files/Sound/sound_definitions.h
+++ b/Source_Files/Sound/sound_definitions.h
@@ -112,7 +112,7 @@ struct sound_file_header
 	
 	// immediately followed by source_count*sound_count sound_definition structures
 };
-const int SIZEOF_sound_file_header = 260;
+constexpr int SIZEOF_sound_file_header = 260;
 
 struct sound_definition
 {

--- a/Source_Files/TCPMess/CommunicationsChannel.h
+++ b/Source_Files/TCPMess/CommunicationsChannel.h
@@ -98,7 +98,7 @@ public:
 
 	bool		isMessageAvailable();
 
-	// Call does not return unless (1) times out (NULL); (2) disconnected (NULL); or
+	// Call does not return unless (1) times out (nullptr); (2) disconnected (nullptr); or
 	// (3) some message received (pointer to inflated message object).
 	// Caller is responsible for deleting the returned object!
 	// Timeouts are in milliseconds.  'Overall' timeouts limit the amount of time
@@ -121,7 +121,7 @@ public:
 	{
 		std::unique_ptr<Message> receivedMessage(receiveSpecificMessage(inType, inOverallTimeout, inInactivityTimeout));
 		tMessage* result = dynamic_cast<tMessage*>(receivedMessage.get());
-		if(result != NULL)
+		if(result != nullptr)
 			receivedMessage.release();
 		return result;
 	}
@@ -146,7 +146,7 @@ public:
 				Uint32 inInactivityTimeout = kSSRAnyDataTimeout)
 	{
 		tMessage* result = receiveSpecificMessage<tMessage>(inOverallTimeout, inInactivityTimeout);
-		if (result == NULL)
+		if (result == nullptr)
 			throw FailedToReceiveSpecificMessageException();
 		return result;
 	}
@@ -250,7 +250,7 @@ class CommunicationsChannelFactory
 {
 public:
 	CommunicationsChannelFactory(Uint16 inPort);
-	bool	isFunctional() const { return mSocket != NULL; }
+	bool	isFunctional() const { return mSocket != nullptr; }
 	CommunicationsChannel* newIncomingConnection();
 	~CommunicationsChannelFactory();
 	

--- a/Source_Files/TCPMess/Message.h
+++ b/Source_Files/TCPMess/Message.h
@@ -31,7 +31,7 @@
 #include <string.h>	// memcpy
 #include "SDL.h"
 
-typedef Uint16 MessageTypeID;
+using MessageTypeID = Uint16;
 
 class UninflatedMessage;
 
@@ -63,10 +63,10 @@ public:
 	// If bytes are provided, this object takes ownership of them (does not copy).
 	// If no bytes are provided, this object creates a buffer of size inLength.
 	//    Clients should write into the pointer returned by buffer().
-	UninflatedMessage(MessageTypeID inType, size_t inLength, Uint8* inBytes = NULL)
+	UninflatedMessage(MessageTypeID inType, size_t inLength, Uint8* inBytes = nullptr)
 		: mType(inType), mLength(inLength), mBuffer(inBytes)
 	{
-		if(mBuffer == NULL)
+		if(mBuffer == nullptr)
 			mBuffer = new Uint8[mLength];
 	}
 
@@ -130,8 +130,8 @@ private:
 class BigChunkOfDataMessage : public Message
 {
 public:
-	BigChunkOfDataMessage(MessageTypeID inType, const Uint8* inBuffer = NULL, size_t inLength = 0);
-	BigChunkOfDataMessage(const BigChunkOfDataMessage& other) : mLength(0), mBuffer(NULL)
+	BigChunkOfDataMessage(MessageTypeID inType, const Uint8* inBuffer = nullptr, size_t inLength = 0);
+	BigChunkOfDataMessage(const BigChunkOfDataMessage& other) : mLength(0), mBuffer(nullptr)
 	{
 		mType = other.type();
 		copyBufferFrom(other.buffer(), other.length());

--- a/Source_Files/TCPMess/MessageDispatcher.h
+++ b/Source_Files/TCPMess/MessageDispatcher.h
@@ -38,11 +38,11 @@
 class MessageDispatcher : public MessageHandler
 {
 public:
-	MessageDispatcher() : mDefaultHandler(NULL) {}
+	MessageDispatcher() : mDefaultHandler(nullptr) {}
 	
 	void setHandlerForType(MessageHandler* inHandler, MessageTypeID inType)
 	{
-		if(inHandler == NULL)
+		if(inHandler == nullptr)
 			clearHandlerForType(inType);
 		else
 			mMap[inType] = inHandler;
@@ -62,7 +62,7 @@ public:
 	MessageHandler* handlerForTypeNoDefault(MessageTypeID inType)
 	{
 		MessageDispatcherMap::iterator i = mMap.find(inType);
-		return (i != mMap.end()) ? i->second : NULL;
+		return (i != mMap.end()) ? i->second : nullptr;
 	}
 
 	void clearHandlerForType(MessageTypeID inType)
@@ -84,13 +84,13 @@ public:
 	{
 		MessageHandler* theHandler = handlerForType(inMessage->type());
 
-		if(theHandler != NULL)
+		if(theHandler != nullptr)
 			theHandler->handle(inMessage, inChannel);
 	}
 
 private:
-	typedef std::map<MessageTypeID, MessageHandler*> MessageDispatcherMap;
-	
+	using MessageDispatcherMap = std::map<MessageTypeID, MessageHandler*>;
+
 	MessageDispatcherMap	mMap;
 	MessageHandler*		mDefaultHandler;
 };

--- a/Source_Files/TCPMess/MessageHandler.h
+++ b/Source_Files/TCPMess/MessageHandler.h
@@ -57,7 +57,7 @@ public:
 
 	void handle(Message* inMessage, CommunicationsChannel* inChannel)
 	{
-		if(mFunction != NULL)
+		if(mFunction != nullptr)
 			mFunction(dynamic_cast<tMessage*>(inMessage), dynamic_cast<tChannel*>(inChannel));
 	}
 
@@ -84,7 +84,7 @@ public:
 
 	void handle(Message* inMessage, CommunicationsChannel* inChannel)
 	{
-		if(mObject != NULL && mMethod != NULL)
+		if(mObject != nullptr && mMethod != nullptr)
 			(mObject->*(mMethod))(dynamic_cast<tMessage*>(inMessage), dynamic_cast<tChannel*>(inChannel));
 	}
 

--- a/Source_Files/TCPMess/MessageHandler.h
+++ b/Source_Files/TCPMess/MessageHandler.h
@@ -97,7 +97,7 @@ private:
 
 
 template<typename tTargetClass, typename tMessage, typename tChannel>
-static inline MessageHandlerMethod<tTargetClass, tMessage, tChannel>*
+inline MessageHandlerMethod<tTargetClass, tMessage, tChannel>*
 newMessageHandlerMethod(
 			tTargetClass* targetObject,
 			void (tTargetClass::*targetMethod)(tMessage* inMessage, tChannel* inChannel)

--- a/Source_Files/TCPMess/MessageInflater.h
+++ b/Source_Files/TCPMess/MessageInflater.h
@@ -44,7 +44,7 @@ public:
 	~MessageInflater();
 
 private:
-	typedef std::map<MessageTypeID, Message*> MessageInflaterMap;
+	using MessageInflaterMap = std::map<MessageTypeID, Message*>;
 	MessageInflaterMap	mMap;
 };
 

--- a/Source_Files/XML/InfoTree.h
+++ b/Source_Files/XML/InfoTree.h
@@ -40,13 +40,13 @@
 class InfoTree : public boost::property_tree::ptree
 {
 public:
-	typedef boost::property_tree::xml_parser_error parse_error;
-	typedef boost::property_tree::ini_parser_error ini_error;
-	typedef boost::property_tree::ptree_bad_path path_error;
-	typedef boost::property_tree::ptree_bad_data data_error;
-	typedef boost::property_tree::ptree_error unexpected_error;
+	using parse_error = boost::property_tree::xml_parser_error;
+	using ini_error = boost::property_tree::ini_parser_error;
+	using path_error = boost::property_tree::ptree_bad_path;
+	using data_error = boost::property_tree::ptree_bad_data;
+	using unexpected_error = boost::property_tree::ptree_error;
 	
-	InfoTree() {}
+	InfoTree() = default;
 	explicit InfoTree(const data_type &data) : boost::property_tree::ptree(data) {}
 	InfoTree(const boost::property_tree::ptree &rhs) : boost::property_tree::ptree(rhs) {}
 	
@@ -117,7 +117,7 @@ public:
 	void put_cstr(std::string path, std::string cstr);
 	void put_attr_cstr(std::string path, std::string cstr);
 	
-	typedef boost::any_range<const InfoTree, boost::forward_traversal_tag, const InfoTree, std::ptrdiff_t> const_child_range;
+	using const_child_range = boost::any_range<const InfoTree, boost::forward_traversal_tag, const InfoTree, std::ptrdiff_t>;
 	const_child_range children_named(std::string key) const;
 };
 

--- a/Source_Files/XML/Plugins.cpp
+++ b/Source_Files/XML/Plugins.cpp
@@ -86,8 +86,8 @@ bool Plugin::valid() const {
 	return !overridden;
 }
 
-Plugins* Plugins::m_instance = 0;
 Plugins* Plugins::instance() {
+	static Plugins *m_instance = nullptr;
 	if (!m_instance) {
 		m_instance = new Plugins;
 	}

--- a/Source_Files/XML/Plugins.h
+++ b/Source_Files/XML/Plugins.h
@@ -67,7 +67,7 @@ class Plugins {
 	friend class PluginLoader;
 public:
 	static Plugins* instance();
-	typedef std::vector<Plugin>::iterator iterator;
+	using iterator = std::vector<Plugin>::iterator;
 	
 	enum GameMode { kMode_Menu, kMode_Solo, kMode_Net };
 	
@@ -93,7 +93,6 @@ private:
 	void add(Plugin plugin) { m_plugins.push_back(plugin); }
 	void validate();
 
-	static Plugins* m_instance;
 	std::vector<Plugin> m_plugins;
 	bool m_validated;
 	GameMode m_mode;

--- a/Source_Files/XML/QuickSave.cpp
+++ b/Source_Files/XML/QuickSave.cpp
@@ -89,15 +89,14 @@ public:
 
 private:
     QuickSaveImageCache() {};
-    static QuickSaveImageCache* m_instance;
     static const int k_max_items = 100;
     
     std::list<cache_pair_t> m_used;
     std::map<std::string, cache_iter_t> m_images;
 };
 
-QuickSaveImageCache* QuickSaveImageCache::m_instance = 0;
 QuickSaveImageCache* QuickSaveImageCache::instance() {
+	static QuickSaveImageCache *m_instance = nullptr;
     if (!m_instance) {
         m_instance = new QuickSaveImageCache;
     }
@@ -773,8 +772,8 @@ bool QuickSaveLoader::ParseDirectory(FileSpecifier& dir)
 }
 
 
-QuickSaves* QuickSaves::m_instance = 0;
 QuickSaves* QuickSaves::instance() {
+	static QuickSaves *m_instance = nullptr;
     if (!m_instance) {
         m_instance = new QuickSaves;
     }

--- a/Source_Files/XML/QuickSave.h
+++ b/Source_Files/XML/QuickSave.h
@@ -60,7 +60,6 @@ private:
     QuickSaves() { }
     void add(QuickSave save) { m_saves.push_back(save); }
     
-    static QuickSaves* m_instance;
     std::vector<QuickSave> m_saves;
 };
 


### PR DESCRIPTION
Take advantage of C++11 (and perhaps C++14 if I wasn't careful) features including:

- constexpr functions and variables where it makes sense
- replacing typedefs with using declarations where it makes sense
- Replacing static inline with just inline (static inline causes ODR problems and can lead to wasted space)
- Cleaning up the singleton pattern used in many classes to stash the singleton in the instance method itself instead of the class itself. It locks out any friend class from messing with the instance pointer itself.
- Abstracting the platform endianness in a constexpr function to cut down on the don't repeat yourself violations found in the Sound subsystem. 

I'm assuming this update is safe since constexpr is already being used in some places. This is more of a structural change to allow the compiler to do more work for us. 