### PR TITLE
Prevent friends of singleton classes from being able to modify the singleton instance address

### DIFF
--- a/Source_Files/FFmpeg/Movie.cpp
+++ b/Source_Files/FFmpeg/Movie.cpp
@@ -48,8 +48,6 @@
 #include "Mixer.h"
 #include "preferences.h"
 
-Movie* Movie::m_instance = NULL;
-
 #ifndef HAVE_FFMPEG
 
 struct libav_vars {

--- a/Source_Files/FFmpeg/Movie.h
+++ b/Source_Files/FFmpeg/Movie.h
@@ -32,7 +32,12 @@
 class Movie
 {
 public:
-	static Movie *instance() { if (!m_instance) m_instance = new Movie(); return m_instance; }
+	static Movie *instance() { 
+		static Movie *m_instance = nullptr;
+		if (!m_instance
+				) m_instance = new Movie(); 
+		return m_instance; 
+	}
 	
 	void PromptForRecording();
 	void StartRecording(std::string path);
@@ -47,7 +52,6 @@ public:
 	void AddFrame(FrameType ftype = FRAME_NORMAL);
 
 private:
-  static class Movie *m_instance;
   
   std::string moviefile;
   SDL_Rect view_rect;

--- a/Source_Files/Files/WadImageCache.cpp
+++ b/Source_Files/Files/WadImageCache.cpp
@@ -39,8 +39,8 @@
 #include "sdl_resize.h"
 #include "Logging.h"
 
-WadImageCache* WadImageCache::m_instance = 0;
 WadImageCache* WadImageCache::instance() {
+	static WadImageCache *m_instance = nullptr;
 	if (!m_instance) {
 		m_instance = new WadImageCache;
 	}

--- a/Source_Files/Files/WadImageCache.h
+++ b/Source_Files/Files/WadImageCache.h
@@ -117,7 +117,6 @@ private:
 	std::string retrieve_name(WadImageDescriptor& desc, int width, int height, bool mark_accessed = true);
 	void autosave_cache() { if (m_autosave) save_cache(); }
 	
-	static WadImageCache* m_instance;
 	std::list<cache_pair_t> m_used;
 	std::map<cache_key_t, cache_iter_t> m_cacheinfo;
 	size_t m_cachesize;

--- a/Source_Files/Misc/Console.cpp
+++ b/Source_Files/Misc/Console.cpp
@@ -46,8 +46,6 @@ using namespace std;
 
 extern bool game_is_networked;
 
-Console *Console::m_instance = NULL;
-
 Console::Console() : m_active(false), m_carnage_messages_exist(false), m_use_lua_console(true)
 {
 	m_command_iter = m_prev_commands.end();
@@ -56,6 +54,7 @@ Console::Console() : m_active(false), m_carnage_messages_exist(false), m_use_lua
 }
 
 Console *Console::instance() {
+	static Console *m_instance = nullptr;
 	if (!m_instance) {
 		m_instance = new Console;
 	}

--- a/Source_Files/Misc/Console.h
+++ b/Source_Files/Misc/Console.h
@@ -90,7 +90,6 @@ public:
 
 private:
 	Console();
-	static Console* m_instance;
 
 	boost::function<void (std::string)> m_callback;
 	std::string m_buffer;

--- a/Source_Files/Misc/Scenario.cpp
+++ b/Source_Files/Misc/Scenario.cpp
@@ -28,10 +28,9 @@
 #include "Scenario.h"
 #include "InfoTree.h"
 
-Scenario *Scenario::m_instance;
-
 Scenario *Scenario::instance()
 {
+	static Scenario *m_instance = nullptr;
 	if (!m_instance) m_instance = new Scenario();
 	return m_instance;
 }

--- a/Source_Files/Misc/Scenario.h
+++ b/Source_Files/Misc/Scenario.h
@@ -57,8 +57,6 @@ private:
 	string m_id;
 	
 	vector<string> m_compatibleVersions;
-	
-	static Scenario *m_instance;
 };
 
 class InfoTree;

--- a/Source_Files/Misc/Statistics.cpp
+++ b/Source_Files/Misc/Statistics.cpp
@@ -30,8 +30,6 @@
 #include <sstream>
 #include <boost/bind.hpp>
 
-StatsManager* StatsManager::instance_ = 0;
-
 class ScopedMutex
 {
 public:

--- a/Source_Files/Misc/Statistics.h
+++ b/Source_Files/Misc/Statistics.h
@@ -36,7 +36,9 @@
 class StatsManager {
 public:
 	static StatsManager* instance() { 
-		if (!instance_) instance_  = new StatsManager();
+		static StatsManager *instance_ = nullptr;
+		if (!instance_) 
+			instance_  = new StatsManager();
 		return instance_;
 	}
 
@@ -55,7 +57,6 @@ private:
 	};
 
 	StatsManager();
-	static StatsManager* instance_;
 
 	void CheckForDone(dialog* d);
 

--- a/Source_Files/Network/ConnectPool.cpp
+++ b/Source_Files/Network/ConnectPool.cpp
@@ -24,7 +24,6 @@
 #include "ConnectPool.h"
 #include <utility>
 
-ConnectPool* ConnectPool::m_instance = 0;
 
 NonblockingConnect::NonblockingConnect(const std::string& address, uint16 port)
 	: m_address(address), m_port(port), m_thread(0), m_ipSpecified(false)

--- a/Source_Files/Network/ConnectPool.h
+++ b/Source_Files/Network/ConnectPool.h
@@ -78,7 +78,13 @@ private:
 class ConnectPool
 {
 public:
-	static ConnectPool *instance() { if (!m_instance) m_instance = new ConnectPool(); return m_instance; }
+	static ConnectPool *instance() { 
+		static ConnectPool *m_instance = nullptr;
+		if (!m_instance) {
+			m_instance = new ConnectPool(); 
+		}
+		return m_instance; 
+	}
 	NonblockingConnect* connect(const std::string& address, uint16 port);
 	NonblockingConnect* connect(const IPaddress& ip);
 	void abandon(NonblockingConnect*);
@@ -91,7 +97,6 @@ private:
 	// second is false if we are in use!
 	std::pair<NonblockingConnect *, bool> m_pool[kPoolSize];
 
-	static ConnectPool* m_instance;
 };
 
 #endif

--- a/Source_Files/Network/Update.cpp
+++ b/Source_Files/Network/Update.cpp
@@ -28,7 +28,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include "alephversion.h"
 
-Update *Update::m_instance = 0;
 
 Update::Update() : m_status(NoUpdateAvailable), m_thread(0)
 {

--- a/Source_Files/Network/Update.h
+++ b/Source_Files/Network/Update.h
@@ -31,7 +31,12 @@
 class Update
 {
 public:
-	static Update *instance() { if (!m_instance) m_instance = new Update(); return m_instance; }
+	static Update *instance() { 
+		static Update *m_instance = nullptr;
+		if (!m_instance) 
+			m_instance = new Update(); 
+		return m_instance; 
+	}
 
 	enum Status
 	{
@@ -45,7 +50,6 @@ public:
 	std::string NewDisplayVersion() { assert(m_status == UpdateAvailable); return m_new_display_version; }
 
 private:
-	static Update *m_instance;
 	Update();
 	~Update();
 

--- a/Source_Files/Network/network.cpp
+++ b/Source_Files/Network/network.cpp
@@ -1111,9 +1111,9 @@ void ChatCallbacks::SendChatMessage(const std::string& message)
 	}
 }
 
-InGameChatCallbacks *InGameChatCallbacks::m_instance = NULL;
 
 InGameChatCallbacks *InGameChatCallbacks::instance() {
+	static InGameChatCallbacks *m_instance = nullptr;
   if (!m_instance) {
     m_instance = new InGameChatCallbacks();
   }

--- a/Source_Files/Network/network.h
+++ b/Source_Files/Network/network.h
@@ -151,7 +151,6 @@ class InGameChatCallbacks : public ChatCallbacks
 
  private:
   InGameChatCallbacks() { }
-  static InGameChatCallbacks *m_instance;
 };
 
 

--- a/Source_Files/RenderMain/SW_Texture_Extras.cpp
+++ b/Source_Files/RenderMain/SW_Texture_Extras.cpp
@@ -27,8 +27,6 @@ SW_TEXTURE_EXTRAS.CPP
 #include "InfoTree.h"
 #include "screen.h"
 
-SW_Texture_Extras *SW_Texture_Extras::m_instance;
-
 extern short bit_depth;
 void SW_Texture::build_opac_table()
 {

--- a/Source_Files/RenderMain/SW_Texture_Extras.h
+++ b/Source_Files/RenderMain/SW_Texture_Extras.h
@@ -62,7 +62,12 @@ private:
 class SW_Texture_Extras
 {
 public:
-	static SW_Texture_Extras *instance() { if (!m_instance) m_instance = new SW_Texture_Extras(); return m_instance; }
+	static SW_Texture_Extras *instance() { 
+		static SW_Texture_Extras *m_instance = nullptr;
+		if (!m_instance) 
+			m_instance = new SW_Texture_Extras(); 
+		return m_instance; 
+	}
 
 	SW_Texture *GetTexture(shape_descriptor ShapeDesc);
 	SW_Texture *AddTexture(shape_descriptor ShapeDesc);
@@ -72,7 +77,6 @@ public:
 
 private:
 	SW_Texture_Extras() { }
-	static SW_Texture_Extras *m_instance;
 
 	std::vector<SW_Texture> texture_list[NUMBER_OF_COLLECTIONS];
 };

--- a/Source_Files/RenderOther/OGL_LoadScreen.cpp
+++ b/Source_Files/RenderOther/OGL_LoadScreen.cpp
@@ -29,10 +29,9 @@
 
 extern bool OGL_SwapBuffers();
 
-OGL_LoadScreen *OGL_LoadScreen::instance_;
-
 OGL_LoadScreen *OGL_LoadScreen::instance()
 {
+	static OGL_LoadScreen *instance_ = nullptr;
 	if (!instance_) 
 		instance_ = new OGL_LoadScreen();
 	

--- a/Source_Files/RenderOther/OGL_LoadScreen.h
+++ b/Source_Files/RenderOther/OGL_LoadScreen.h
@@ -72,7 +72,6 @@ OGL_LoadScreen() : x(0), y(0), w(0), h(0), use(false), useProgress(false), perce
 
 	short percent;
 
-	static OGL_LoadScreen *instance_;
 
 	GLuint texture_ref;
 };

--- a/Source_Files/Sound/Mixer.cpp
+++ b/Source_Files/Sound/Mixer.cpp
@@ -22,8 +22,6 @@
 #include "Mixer.h"
 #include "interface.h" // for strERRORS
 
-Mixer* Mixer::m_instance = 0;
-
 extern bool option_nosound;
 
 void Mixer::Start(uint16 rate, bool sixteen_bit, bool stereo, int num_channels, int volume, uint16 samples)

--- a/Source_Files/Sound/Mixer.h
+++ b/Source_Files/Sound/Mixer.h
@@ -36,7 +36,12 @@ extern bool game_is_networked;
 class Mixer
 {
 public:
-	static Mixer *instance() { if (!m_instance) m_instance = new Mixer(); return m_instance; }
+	static Mixer *instance() { 
+		static Mixer *m_instance = nullptr;
+		if (!m_instance) 
+			m_instance = new Mixer(); 
+		return m_instance; 
+	}
 	void Start(uint16 rate, bool sixteen_bit, bool stereo, int num_channels, int volume, uint16 samples);
 	void Stop();
 
@@ -73,7 +78,6 @@ public:
 private:
         Mixer() : sNetworkAudioBufferDesc(0) { };
 	
-	static Mixer *m_instance;
 	
 	struct Channel {
 		SoundInfo info;

--- a/Source_Files/Sound/Music.cpp
+++ b/Source_Files/Sound/Music.cpp
@@ -23,8 +23,6 @@
 #include "Mixer.h"
 #include "XML_LevelScript.h"
 
-Music* Music::m_instance = 0;
-
 Music::Music() : 
 	music_initialized(false), 
 	music_intro(false), 

--- a/Source_Files/Sound/Music.h
+++ b/Source_Files/Sound/Music.h
@@ -35,7 +35,10 @@ class Music
 {
 public:
 	static Music *instance() { 
-		if (!m_instance) m_instance = new Music(); return m_instance; 
+		static Music *m_instance = nullptr;
+		if (!m_instance) 
+			m_instance = new Music(); 
+		return m_instance; 
 	}
 
 	bool SetupIntroMusic(FileSpecifier &File);
@@ -70,7 +73,6 @@ public:
 private:
 	Music();
 	bool Load(FileSpecifier &file);
-	static Music *m_instance;
 
 	FileSpecifier* GetLevelMusic();
 	void LoadLevelMusic();

--- a/Source_Files/Sound/ReplacementSounds.cpp
+++ b/Source_Files/Sound/ReplacementSounds.cpp
@@ -25,8 +25,6 @@
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 
-SoundReplacements *SoundReplacements::m_instance = 0;
-
 boost::shared_ptr<SoundData> ExternalSoundHeader::LoadExternal(FileSpecifier& File)
 {
 	boost::shared_ptr<SoundData> p;

--- a/Source_Files/Sound/ReplacementSounds.h
+++ b/Source_Files/Sound/ReplacementSounds.h
@@ -47,6 +47,7 @@ class SoundReplacements
 {
 public:
 	static inline SoundReplacements* instance() { 
+		static SoundReplacements *m_instance = nullptr;
 		if (!m_instance) m_instance = new SoundReplacements;
 		return m_instance;
 	}
@@ -57,7 +58,6 @@ public:
 
 private:
 	SoundReplacements() { }
-	static SoundReplacements *m_instance;
 
 	typedef std::pair<short, short> key;
 

--- a/Source_Files/Sound/SoundManager.cpp
+++ b/Source_Files/Sound/SoundManager.cpp
@@ -129,7 +129,6 @@ void SoundMemoryManager::Update(short index)
 	m_entries[index].last_played = machine_tick_count();
 }
 
-SoundManager *SoundManager::m_instance = 0;
 
 static void Shutdown()
 {

--- a/Source_Files/Sound/SoundManager.h
+++ b/Source_Files/Sound/SoundManager.h
@@ -41,6 +41,7 @@ class SoundManager
 {
 public:
 	static inline SoundManager* instance() { 
+		static SoundManager *m_instance = 0;
 		if (!m_instance) m_instance = new SoundManager; 
 		return m_instance; 
 	}
@@ -163,8 +164,6 @@ private:
 
 	void TrackStereoSounds();
 	void UpdateAmbientSoundSources();
-
-	static SoundManager *m_instance;
 
 	bool initialized;
 	bool active;

--- a/Source_Files/XML/Plugins.cpp
+++ b/Source_Files/XML/Plugins.cpp
@@ -86,8 +86,8 @@ bool Plugin::valid() const {
 	return !overridden;
 }
 
-Plugins* Plugins::m_instance = 0;
 Plugins* Plugins::instance() {
+	static Plugins* m_instance = nullptr;
 	if (!m_instance) {
 		m_instance = new Plugins;
 	}

--- a/Source_Files/XML/Plugins.h
+++ b/Source_Files/XML/Plugins.h
@@ -93,7 +93,6 @@ private:
 	void add(Plugin plugin) { m_plugins.push_back(plugin); }
 	void validate();
 
-	static Plugins* m_instance;
 	std::vector<Plugin> m_plugins;
 	bool m_validated;
 	GameMode m_mode;

--- a/Source_Files/XML/QuickSave.cpp
+++ b/Source_Files/XML/QuickSave.cpp
@@ -89,15 +89,14 @@ public:
 
 private:
     QuickSaveImageCache() {};
-    static QuickSaveImageCache* m_instance;
     static const int k_max_items = 100;
     
     std::list<cache_pair_t> m_used;
     std::map<std::string, cache_iter_t> m_images;
 };
 
-QuickSaveImageCache* QuickSaveImageCache::m_instance = 0;
 QuickSaveImageCache* QuickSaveImageCache::instance() {
+    static QuickSaveImageCache* m_instance = nullptr;
     if (!m_instance) {
         m_instance = new QuickSaveImageCache;
     }
@@ -773,8 +772,8 @@ bool QuickSaveLoader::ParseDirectory(FileSpecifier& dir)
 }
 
 
-QuickSaves* QuickSaves::m_instance = 0;
 QuickSaves* QuickSaves::instance() {
+	static QuickSaves* m_instance = nullptr;
     if (!m_instance) {
         m_instance = new QuickSaves;
     }

--- a/Source_Files/XML/QuickSave.h
+++ b/Source_Files/XML/QuickSave.h
@@ -60,7 +60,6 @@ private:
     QuickSaves() { }
     void add(QuickSave save) { m_saves.push_back(save); }
     
-    static QuickSaves* m_instance;
     std::vector<QuickSave> m_saves;
 };
 


### PR DESCRIPTION
Stash the singleton instance pointer in the instance method itself instead of the class.  This change will prevent a whole set of problems from ever happening. If another class becomes a friend of one of these singleton classes then it could directly (or indirectly) modify the instance pointer (not the contents but the address itself) and cause hard to diagnose crashes. By tucking the instance pointer into the instance method, there is no way for this to happen. 

