### PR TITLE
Replace most uses of the endianness macros with a constexpr function

### DIFF
--- a/Source_Files/CSeries/cseries.h
+++ b/Source_Files/CSeries/cseries.h
@@ -50,6 +50,13 @@
 #endif
 
 
+constexpr bool PlatformIsLittleEndian() noexcept {
+#ifdef ALEPHONE_LITTLE_ENDIAN
+	return true;
+#else
+	return false;
+#endif // end ALEPHONE_LITTLE_ENDIAN
+}
 /*
  *  Data types with specific bit width
  */

--- a/Source_Files/Misc/interface.cpp
+++ b/Source_Files/Misc/interface.cpp
@@ -3236,11 +3236,11 @@ void show_movie(short index)
 		SDL_Surface *gl_surface = NULL;
 		if (OGL_IsActive())
 		{
-#ifdef ALEPHONE_LITTLE_ENDIAN
-			gl_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, dst_rect.w, dst_rect.h, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0x00000000);
-#else
-			gl_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, dst_rect.w, dst_rect.h, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x00000000);
-#endif
+			if (PlatformIsLittleEndian()) {
+				gl_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, dst_rect.w, dst_rect.h, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0x00000000);
+			} else {
+				gl_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, dst_rect.w, dst_rect.h, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x00000000);
+			}
 			SMPEG_setdisplay(movie, gl_surface, NULL, show_movie_frame);
 			SMPEG_scaleXY(movie, dst_rect.w, dst_rect.h);
 			show_movie_mutex = SDL_CreateMutex();

--- a/Source_Files/Network/network_microphone_sdl_alsa.cpp
+++ b/Source_Files/Network/network_microphone_sdl_alsa.cpp
@@ -65,11 +65,21 @@ open_network_microphone() {
 	}
 
 	snd_pcm_format_t format;
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	format = SND_PCM_FORMAT_S16_LE;
-#else
-	format = SND_PCM_FORMAT_S16_BE;
-#endif
+	// In C++17, we could use if constexpr to do the same thing as the original
+	// ifdef preprocessor statement like so:
+	// if constexpr(PlatformIsLittleEndian()) {
+	// 	format = SND_PCM_FORMAT_S16_LE; 
+	// } else {
+	// 	format = SND_PCM_FORMAT_S16_BE;
+	// }
+	//
+	// Until that point, the following will be equivalent but we are depending
+	// on the optimizer to do the right thing.
+	if (PlatformIsLittleEndian()) {
+		format = SND_PCM_FORMAT_S16_LE ;
+	} else {
+		format = SND_PCM_FORMAT_S16_BE;
+	}
 
 	if ((err = snd_pcm_hw_params_set_format(capture_handle, hw_params, format)) < 0) {
 		fprintf(stderr, "snd_pcm_hw_params_set_format\n");

--- a/Source_Files/RenderMain/ImageLoader_SDL.cpp
+++ b/Source_Files/RenderMain/ImageLoader_SDL.cpp
@@ -98,11 +98,15 @@ bool ImageDescriptor::LoadFromFile(FileSpecifier& File, int ImgMode, int flags, 
 	}
 
 	// Convert to 32-bit OpenGL-friendly RGBA surface
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	SDL_Surface *rgba = SDL_CreateRGBSurface(SDL_SWSURFACE, Width, Height, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
-#else
-	SDL_Surface *rgba = SDL_CreateRGBSurface(SDL_SWSURFACE, Width, Height, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
-#endif
+	SDL_Surface *rgba = nullptr;
+	if (PlatformIsLittleEndian()) {
+		// this can be improved greatly in C++17 with constexpr but we are
+		// currently relying on the compiler to do the right thing and choose
+		// the correct path
+		rgba = SDL_CreateRGBSurface(SDL_SWSURFACE, Width, Height, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+	} else {
+		rgba = SDL_CreateRGBSurface(SDL_SWSURFACE, Width, Height, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+	}
 	if (rgba == NULL) {
 		SDL_FreeSurface(s);
 		return false;

--- a/Source_Files/RenderMain/OGL_Textures.cpp
+++ b/Source_Files/RenderMain/OGL_Textures.cpp
@@ -433,17 +433,20 @@ static void FindOGLColorTable(int NumSrcBytes, byte *OrigColorTable, uint32 *Col
 			
 			// Convert from ARGB 8888 to RGBA 8888; make opaque
 			uint8 *ColorPtr = (uint8 *)(&Color);
-#ifdef ALEPHONE_LITTLE_ENDIAN
-			ColorPtr[0] = OrigPtr[2];
-			ColorPtr[1] = OrigPtr[1];
-			ColorPtr[2] = OrigPtr[0];
-			ColorPtr[3] = 0xff;
-#else
-			ColorPtr[0] = OrigPtr[1];
-			ColorPtr[1] = OrigPtr[2];
-			ColorPtr[2] = OrigPtr[3];
-			ColorPtr[3] = 0xff;
-#endif
+			if (PlatformIsLittleEndian()) {
+				// the compiler will do the right thing and only emit
+				// code for the correct path. In C++17 we can do constexpr if
+				// to make that requirement explicit.
+				ColorPtr[0] = OrigPtr[2];
+				ColorPtr[1] = OrigPtr[1];
+				ColorPtr[2] = OrigPtr[0];
+				ColorPtr[3] = 0xff;
+			} else {
+				ColorPtr[0] = OrigPtr[1];
+				ColorPtr[1] = OrigPtr[2];
+				ColorPtr[2] = OrigPtr[3];
+				ColorPtr[3] = 0xff;
+			}
 		}
 		break;
 	}

--- a/Source_Files/RenderMain/OGL_Textures.cpp
+++ b/Source_Files/RenderMain/OGL_Textures.cpp
@@ -967,11 +967,7 @@ void TextureManager::FindColorTables()
 
 void TextureManager::PremultiplyColorTables()
 {
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	uint32 alphaMask = 0xff000000;
-#else
-	uint32 alphaMask = 0x000000ff;
-#endif
+	uint32 alphaMask = PlatformIsLittleEndian() ? 0xff000000 : 0x000000ff;
 
 	uint32 *tables[2];
 	tables[0] = NormalColorTable;
@@ -1059,12 +1055,7 @@ uint32 *TextureManager::GetOGLTexture(uint32 *ColorTable)
 		OGLWidthFinish = 0;
 	}
 
-	uint32 rgb_mask;
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	rgb_mask = 0x00ffffff;
-#else
-	rgb_mask = 0xffffff00;
-#endif
+	uint32 rgb_mask = PlatformIsLittleEndian() ? 0x00ffffff : 0xffffff00;
 	
 	for (short h = OGLHeightOffset; h < OGLHeightFinish; h++)
 	{
@@ -1941,11 +1932,7 @@ void FindSilhouetteVersionDXTC1(int NumBytes, unsigned char *buffer)
 	{
 		if (SDL_SwapLE16(pixels[i * 4]) > SDL_SwapLE16(pixels[i * 4 + 1]))
 		{
-#ifdef ALEPHONE_LITTLE_ENDIAN
-			pixels[i * 4 + 1] = 0xffdf;
-#else
-			pixels[i * 4 + 1] = 0xdfff;
-#endif
+			pixels[i * 4 + 1] = PlatformIsLittleEndian() ? 0xffdf : 0xdfff;
 		} 
 		else
 		{
@@ -1962,11 +1949,7 @@ void FindSilhouetteVersionDXTC35(int NumBytes, unsigned char *buffer)
 	for (int i = 0; i < NumBytes / 8; i++)
 	{
 		pixels[i * 8 + 4] = 0xffff;
-#ifdef ALEPHONE_LITTLE_ENDIAN
-		pixels[i * 8 + 5] = 0xffdf;
-#else
-		pixels[i * 8 + 5] = 0xdfff;
-#endif
+		pixels[i * 8 + 5] = PlatformIsLittleEndian() ? 0xffdf : 0xdfff;
 	}
 }
 
@@ -1974,11 +1957,7 @@ void FindSilhouetteVersionRGBA(int NumPixels, uint32 *Pixels)
 {
 	for (int i = 0; i < NumPixels; i++) 
 	{
-#ifdef ALEPHONE_LITTLE_ENDIAN
-		Pixels[i] |= 0x00ffffff;
-#else
-		Pixels[i] |= 0xffffff00;
-#endif
+		Pixels[i] |= PlatformIsLittleEndian() ? 0x00ffffff : 0xffffff00;
 	}
 }
 

--- a/Source_Files/RenderMain/OGL_Textures.h
+++ b/Source_Files/RenderMain/OGL_Textures.h
@@ -269,35 +269,37 @@ inline byte FiveToEight(byte x) {return (x << 3) | ((x >> 2) & 0x07);}
 // ARGB 1555 to RGBA 8888
 inline GLuint Convert_16to32(uint16 InPxl)
 {
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	// Alpha preset
-	GLuint OutPxl = 0xff000000;
-	GLuint Chan;
-	// Red
-	Chan = FiveToEight(InPxl >> 10);
-	OutPxl |= Chan;
-	// Green
-	Chan = FiveToEight(InPxl >> 5);
-	OutPxl |= Chan << 8;
-	// Blue
-	Chan = FiveToEight(InPxl & 0x1F);
-	OutPxl |= Chan << 16;
-#else
-	// Alpha preset
-	GLuint OutPxl = 0x000000ff;
-	GLuint Chan;
-	// Red
-	Chan = FiveToEight(InPxl >> 10);
-	OutPxl |= Chan << 24;
-	// Green
-	Chan = FiveToEight(InPxl >> 5);
-	OutPxl |= Chan << 16;
-	// Blue
-	Chan = FiveToEight(InPxl);
-	OutPxl |= Chan << 8;
-#endif
+	if (PlatformIsLittleEndian()) {
+		// perfect target for constexpr-if in C++17
+		// Alpha preset
+		GLuint OutPxl = 0xff000000;
+		GLuint Chan;
+		// Red
+		Chan = FiveToEight(InPxl >> 10);
+		OutPxl |= Chan;
+		// Green
+		Chan = FiveToEight(InPxl >> 5);
+		OutPxl |= Chan << 8;
+		// Blue
+		Chan = FiveToEight(InPxl & 0x1F);
+		OutPxl |= Chan << 16;
+		return OutPxl;
+	} else {
+		// Alpha preset
+		GLuint OutPxl = 0x000000ff;
+		GLuint Chan;
+		// Red
+		Chan = FiveToEight(InPxl >> 10);
+		OutPxl |= Chan << 24;
+		// Green
+		Chan = FiveToEight(InPxl >> 5);
+		OutPxl |= Chan << 16;
+		// Blue
+		Chan = FiveToEight(InPxl);
+		OutPxl |= Chan << 8;
+		return OutPxl;
+	}
 	
-	return OutPxl;
 }
 
 

--- a/Source_Files/RenderOther/Image_Blitter.cpp
+++ b/Source_Files/RenderOther/Image_Blitter.cpp
@@ -32,11 +32,12 @@ Image_Blitter::Image_Blitter() : m_surface(NULL), m_disp_surface(NULL), m_scaled
 
 bool Image_Blitter::Load(const ImageDescriptor& image)
 {
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	SDL_Surface *s = SDL_CreateRGBSurfaceFrom(const_cast<uint32 *>(image.GetBuffer()), image.GetWidth(), image.GetHeight(), 32, image.GetWidth() * 4, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
-#else
-	SDL_Surface *s = SDL_CreateRGBSurfaceFrom(const_cast<uint32 *>(image.GetBuffer()), image.GetWidth(), image.GetHeight(), 32, image.GetWidth() * 4, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
-#endif
+	SDL_Surface *s = nullptr;
+	if (PlatformIsLittleEndian()) {
+		s = SDL_CreateRGBSurfaceFrom(const_cast<uint32 *>(image.GetBuffer()), image.GetWidth(), image.GetHeight(), 32, image.GetWidth() * 4, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+	} else {
+		s = SDL_CreateRGBSurfaceFrom(const_cast<uint32 *>(image.GetBuffer()), image.GetWidth(), image.GetHeight(), 32, image.GetWidth() * 4, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+	}
 	if (!s)
 		return false;
 	bool ret = Load(*s);
@@ -80,11 +81,11 @@ bool Image_Blitter::Load(const SDL_Surface& s, const SDL_Rect& src)
 	crop_rect.w = m_src.w;
 	crop_rect.h = m_src.h;
 	
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	m_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, m_src.w, m_src.h, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
-#else
-	m_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, m_src.w, m_src.h, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
-#endif
+	if (PlatformIsLittleEndian()) {
+		m_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, m_src.w, m_src.h, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+	} else {
+		m_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, m_src.w, m_src.h, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+	}
 	if (!m_surface)
 		return false;
 	

--- a/Source_Files/RenderOther/OGL_Blitter.cpp
+++ b/Source_Files/RenderOther/OGL_Blitter.cpp
@@ -58,12 +58,12 @@ void OGL_Blitter::_LoadTextures()
 		m_tile_height = std::max(m_tile_height, 128);
 	}
 
-	SDL_Surface *t;
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	t = SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
-#else
-	t = SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
-#endif
+	SDL_Surface *t = nullptr;
+	if (PlatformIsLittleEndian()) {
+		t = SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+	} else {
+		t = SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+	}
 	if (!t)
 		return;
 	

--- a/Source_Files/RenderOther/images.cpp
+++ b/Source_Files/RenderOther/images.cpp
@@ -215,11 +215,11 @@ static int uncompress_rle16(const uint8 *src, int row_bytes, uint8 *dst, int dst
 
 static void copy_component_into_surface(const uint8 *src, uint8 *dst, int count, int component)
 {
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	dst += 2 - component;
-#else
-	dst += component + 1;
-#endif
+	if (PlatformIsLittleEndian()) {
+		dst += 2 - component;
+	} else {
+		dst += component + 1;
+	}
 	while (count--) {
 		*dst = *src++;
 		dst += 4;
@@ -1273,12 +1273,12 @@ static void create_m1_menu_surfaces(void)
     if (m1_menu_unpressed || m1_menu_pressed)
         return;
     
-    SDL_Surface *s;
-#ifdef ALEPHONE_LITTLE_ENDIAN
-    s = SDL_CreateRGBSurface(SDL_SWSURFACE, 640, 480, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0);
-#else
-    s = SDL_CreateRGBSurface(SDL_SWSURFACE, 640, 480, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0);
-#endif
+    SDL_Surface *s = nullptr;
+	if (PlatformIsLittleEndian()) {
+    	s = SDL_CreateRGBSurface(SDL_SWSURFACE, 640, 480, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0);
+	} else {
+    	s = SDL_CreateRGBSurface(SDL_SWSURFACE, 640, 480, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0);
+	}
     if (!s)
         return;
 

--- a/Source_Files/Sound/FFmpegDecoder.h
+++ b/Source_Files/Sound/FFmpegDecoder.h
@@ -41,11 +41,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return 2 * (IsStereo() ? 2 : 1); }
 	float Rate() { return rate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	int32 Frames();
 

--- a/Source_Files/Sound/MADDecoder.h
+++ b/Source_Files/Sound/MADDecoder.h
@@ -42,11 +42,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return bytes_per_frame; }
 	float Rate() { return rate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	MADDecoder();
 	~MADDecoder();

--- a/Source_Files/Sound/Mixer.cpp
+++ b/Source_Files/Sound/Mixer.cpp
@@ -149,11 +149,7 @@ void Mixer::EnsureNetworkAudioPlaying()
 			c->length = sNetworkAudioBufferDesc->mLength;
 			c->loop_length = 0;
 			c->rate = (kNetworkAudioSampleRate << 16) / obtained.freq;
-#ifdef ALEPHONE_LITTLE_ENDIAN
-			c->info.little_endian = true;
-#else
-			c->info.little_endian = false;
-#endif
+			c->info.little_endian = PlatformIsLittleEndian();
 			c->left_volume = 0x100;
 			c->right_volume = 0x100;
 			c->counter = 0;

--- a/Source_Files/Sound/SndfileDecoder.h
+++ b/Source_Files/Sound/SndfileDecoder.h
@@ -42,11 +42,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return 2 * (IsStereo() ? 2 : 1); }
 	float Rate() { return (float) sfinfo.samplerate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	int32 Frames() { return sfinfo.frames; }
 

--- a/Source_Files/Sound/VorbisDecoder.h
+++ b/Source_Files/Sound/VorbisDecoder.h
@@ -42,11 +42,7 @@ public:
 	bool IsSigned() { return true; }
 	int BytesPerFrame() { return 2 * (IsStereo() ? 2 : 1); }
 	float Rate() { return rate; }
-#ifdef ALEPHONE_LITTLE_ENDIAN
-	bool IsLittleEndian() { return true; }
-#else
-	bool IsLittleEndian() { return false; }
-#endif
+	bool IsLittleEndian() { return PlatformIsLittleEndian(); }
 
 	VorbisDecoder();
 	~VorbisDecoder();


### PR DESCRIPTION
By using a constexpr function which wraps the endianness macro generated in cseries.h we migrate the selection of code from the preprocessor to the compiler. These days the compiler is "smart" enough to use the compile time result of PlatformIsLittleEndian to optimize dead code paths away. This makes the code much more readable while not sacrificing performance. The if statements can be converted to constexpr-if statements in C++17 when the time comes. 