### PR TITLE
Support Unicode on Windows

### DIFF
--- a/Source_Files/CSeries/csalerts_sdl.cpp
+++ b/Source_Files/CSeries/csalerts_sdl.cpp
@@ -63,7 +63,7 @@ void system_alert_user(const char* message, short severity)
 	} else {
 		type = MB_ICONERROR|MB_OK;
 	}
-	MessageBox(NULL, message, severity == infoError ? "Warning" : "Error", type);
+	MessageBoxW(NULL, utf8_to_wide(message).c_str(), severity == infoError ? L"Warning" : L"Error", type);
 #else
 	fprintf(stderr, "%s: %s\n", severity == infoError ? "INFO" : "FATAL", message);
 #endif	
@@ -73,20 +73,14 @@ void system_alert_user(const char* message, short severity)
 // callback to set starting location for Win32 "choose scenario" dialog
 static int CALLBACK browse_callback_proc(HWND hwnd, UINT msg, LPARAM lparam, LPARAM lpdata)
 {
-	TCHAR cwd[MAX_PATH];
 	WCHAR wcwd[MAX_PATH];
 	switch (msg)
 	{
 		case BFFM_INITIALIZED:
-			if (GetCurrentDirectory(MAX_PATH, cwd))
+			if (GetCurrentDirectoryW(MAX_PATH, wcwd))
 			{
-#ifdef UNICODE
-				memcpy(wcwd, cwd, sizeof(TCHAR) * MAX_PATH);
-#else
-				MultiByteToWideChar(CP_ACP, 0, cwd, -1, wcwd, MAX_PATH);
-#endif
-				SendMessage(hwnd, BFFM_SETEXPANDED, TRUE, (LPARAM)wcwd);
-				SendMessage(hwnd, BFFM_SETSELECTION, TRUE, (LPARAM)wcwd);
+				SendMessageW(hwnd, BFFM_SETEXPANDED, TRUE, (LPARAM)wcwd);
+				SendMessageW(hwnd, BFFM_SETSELECTIONW, TRUE, (LPARAM)wcwd);
 			}
 	}
 	return 0;
@@ -96,26 +90,22 @@ static int CALLBACK browse_callback_proc(HWND hwnd, UINT msg, LPARAM lparam, LPA
 bool system_alert_choose_scenario(char *chosen_dir)
 {
 #if defined(__WIN32__)
-	BROWSEINFO bi = { 0 };
-	TCHAR path[MAX_PATH];
-	bi.lpszTitle = _T("Select a scenario to play:");
+	BROWSEINFOW bi = { 0 };
+	wchar_t path[MAX_PATH];
+	bi.lpszTitle = L"Select a scenario to play:";
 	bi.pszDisplayName = path;
 	bi.lpfn = browse_callback_proc;
 	bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE | 0x00000200; // no "New Folder" button
-	LPITEMIDLIST pidl = SHBrowseForFolder(&bi);
+	LPITEMIDLIST pidl = SHBrowseForFolderW(&bi);
 	if (pidl)
 	{
-		SHGetPathFromIDList(pidl, path);
-#ifdef UNICODE
-		WideCharToMultiByte(CP_UTF8, 0, path, -1, chosen_dir, 256, NULL, NULL);
-#else
-		strncpy(chosen_dir, path, 255);
-#endif
+		SHGetPathFromIDListW(pidl, path);
+		const int chars_written = WideCharToMultiByte(CP_UTF8, 0, path, -1, chosen_dir, 256, NULL, NULL);
 		LPMALLOC pMalloc = NULL;
 		SHGetMalloc(&pMalloc);
 		pMalloc->Free(pidl);
 		pMalloc->Release();
-		return true;
+		return chars_written > 0;
 	}
 #endif
 	return false;
@@ -128,7 +118,7 @@ extern void system_launch_url_in_browser(const char *url);
 void system_launch_url_in_browser(const char *url)
 {
 #if defined(__WIN32__)
-	ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+	ShellExecuteW(NULL, L"open", utf8_to_wide(url).c_str(), NULL, NULL, SW_SHOWNORMAL);
 #else
 	pid_t pid = fork();
 	if (pid == 0)

--- a/Source_Files/CSeries/csstrings.cpp
+++ b/Source_Files/CSeries/csstrings.cpp
@@ -48,6 +48,12 @@
 #include <map>
 #include <boost/algorithm/string/replace.hpp>
 
+#ifdef __WIN32__
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <wchar.h>
+#endif
+
 using namespace std;
 
 char temporary[256];
@@ -341,6 +347,30 @@ std::string utf8_to_mac_roman(const std::string& input)
 
 	return output;
 }
+
+
+#ifdef __WIN32__
+static std::wstring utf8_to_wide(const char* utf8, int in_length)
+{
+	const int out_length = MultiByteToWideChar(CP_UTF8, 0, utf8, in_length, nullptr, 0); // >= 0
+	std::wstring out(out_length, char{});
+	MultiByteToWideChar(CP_UTF8, 0, utf8, in_length, &out[0], out_length);
+	return out;
+}
+
+static std::string wide_to_utf8(const wchar_t* utf16, int in_length)
+{
+	const int out_length = WideCharToMultiByte(CP_UTF8, 0, utf16, in_length, nullptr, 0, nullptr, nullptr); // >= 0
+	std::string out(out_length, char{});
+	WideCharToMultiByte(CP_UTF8, 0, utf16, in_length, &out[0], out_length, nullptr, nullptr);
+	return out;
+}
+
+std::wstring utf8_to_wide(const char* utf8)         { return utf8_to_wide(utf8, strlen(utf8)); }
+std::wstring utf8_to_wide(const std::string& utf8)  { return utf8_to_wide(utf8.c_str(), utf8.size()); }
+std::string wide_to_utf8(const wchar_t* utf16)      { return wide_to_utf8(utf16, wcslen(utf16)); }
+std::string wide_to_utf8(const std::wstring& utf16) { return wide_to_utf8(utf16.c_str(), utf16.size()); }
+#endif // __WIN32__
 
 
 /*

--- a/Source_Files/CSeries/csstrings.h
+++ b/Source_Files/CSeries/csstrings.h
@@ -73,6 +73,13 @@ extern void mac_roman_to_unicode(const char *input, uint16 *output, int max_len)
 std::string mac_roman_to_utf8(const std::string& input);
 std::string utf8_to_mac_roman(const std::string& input);
 
+#ifdef __WIN32__
+std::wstring utf8_to_wide(const char* utf8);
+std::wstring utf8_to_wide(const std::string& utf8);
+std::string wide_to_utf8(const wchar_t* utf16);
+std::string wide_to_utf8(const std::wstring& utf16);
+#endif
+
 // Substitute special variables like application name or version
 std::string expand_app_variables(const std::string& input);
 void expand_app_variables_inplace(std::string& str);

--- a/Source_Files/Files/FileHandler.cpp
+++ b/Source_Files/Files/FileHandler.cpp
@@ -30,7 +30,6 @@
 
 #include "shell.h"
 #include "interface.h"
-#include "game_errors.h"
 #include "tags.h"
 
 #include <stdio.h>
@@ -383,7 +382,6 @@ bool FileSpecifier::Open(OpenedFile &OFile, bool Writable)
 
 	err = f ? 0 : errno;
 	if (f == NULL) {
-		set_game_error(systemError, err);
 		return false;
 	}
 	if (Writable)
@@ -416,7 +414,6 @@ bool FileSpecifier::Open(OpenedResourceFile &OFile, bool Writable)
 	OFile.f = open_res_file(*this);
 	err = OFile.f ? 0 : errno;
 	if (OFile.f == NULL) {
-		set_game_error(systemError, err);
 		return false;
 	} else
 		return true;

--- a/Source_Files/Files/FileHandler.cpp
+++ b/Source_Files/Files/FileHandler.cpp
@@ -845,7 +845,7 @@ bool FileSpecifier::ReadDirectory(vector<dir_entry> &vec)
 		if (stat(full_path.GetPath(), &st) == 0) {
 			// Ignore files starting with '.' and the directories '.' and '..'
 			if (de->d_name[0] != '.' || (S_ISDIR(st.st_mode) && !(de->d_name[1] == '\0' || de->d_name[1] == '.')))
-				vec.push_back(dir_entry(de->d_name, st.st_size, S_ISDIR(st.st_mode), false, st.st_mtime));
+				vec.push_back(dir_entry(de->d_name, S_ISDIR(st.st_mode), st.st_mtime));
 		}
 		de = readdir(d);
 	}
@@ -1035,7 +1035,7 @@ private:
 
 	void select_entry(const string& inName, bool inIsDirectory)
 	{
-		dir_entry theEntryToFind(inName, NONE /* length - ignored for our purpose */, inIsDirectory);
+		dir_entry theEntryToFind(inName, inIsDirectory);
 		vector<dir_entry>::iterator theEntry = find(entries.begin(), entries.end(), theEntryToFind);
 		if(theEntry != entries.end())
 			set_selection(theEntry - entries.begin());

--- a/Source_Files/Files/FileHandler.h
+++ b/Source_Files/Files/FileHandler.h
@@ -65,6 +65,9 @@ using std::vector;
 #include <boost/iostreams/categories.hpp>
 #include <boost/iostreams/positioning.hpp>
 
+// Returned by .GetError() for unknown errors
+constexpr int unknown_filesystem_error = -1;
+
 /*
 	Abstraction for opened files; it does reading, writing, and closing of such files,
 	without doing anything to the files' specifications

--- a/Source_Files/Files/FileHandler.h
+++ b/Source_Files/Files/FileHandler.h
@@ -208,10 +208,8 @@ private:
 
 // Directory entry, returned by FileSpecifier::ReadDirectory()
 struct dir_entry {
-	dir_entry() : size(0), is_directory(false), is_volume(false) {}
-	dir_entry(const string &n, int32 s, bool is_dir, bool is_vol = false, TimeType d = 0)
-		: name(n), size(s), is_directory(is_dir), is_volume(is_vol), date(d) {}
-	~dir_entry() {}
+	dir_entry() : is_directory(false), date(0) {}
+	dir_entry(const string& n, bool is_dir, TimeType d = 0) : name(n), is_directory(is_dir), date(d) {}
 
 	bool operator<(const dir_entry &other) const
 	{
@@ -226,9 +224,7 @@ struct dir_entry {
 	}
 
 	string name;		// Entry name
-	int32 size;			// File size (only valid if !is_directory)
 	bool is_directory;	// Entry is a directory (plain file otherwise)
-	bool is_volume;		// Entry is a volume (for platforms that have volumes, is_directory must also be set)
 	TimeType date;          // modification date
 };
 

--- a/Source_Files/Files/FileHandler.h
+++ b/Source_Files/Files/FileHandler.h
@@ -266,6 +266,7 @@ public:
 	
 	// Opens a file:
 	bool Open(OpenedFile& OFile, bool Writable=false);
+	bool OpenForWritingText(OpenedFile& OFile); // converts LF to CRLF on Windows
 	
 	// Opens either a MacOS resource fork or some imitation of it:
 	bool Open(OpenedResourceFile& OFile, bool Writable=false);
@@ -337,7 +338,14 @@ public:
 	void SplitPath(DirectorySpecifier &base, string &part) const {string b; SplitPath(b, part); base = b;}
 
 	bool CreateDirectory();
+	
+	// Return directory contents (following symlinks), excluding dot-prefixed files
 	bool ReadDirectory(vector<dir_entry> &vec);
+	vector<dir_entry> ReadDirectory() {vector<dir_entry> vec; ReadDirectory(vec); return vec;}
+	
+	// Return the names of all entries in a ZIP archive
+	bool ReadZIP(vector<string> &vec);
+	vector<string> ReadZIP() {vector<string> vec; ReadZIP(vec); return vec;}
 
 	int GetError() const {return err;}
 

--- a/Source_Files/Files/SDL_rwops_zzip.c
+++ b/Source_Files/Files/SDL_rwops_zzip.c
@@ -45,15 +45,18 @@ static int _zzip_close(SDL_RWops *context)
     return 0;
 }
 
-SDL_RWops *SDL_RWFromZZIP(const char* file, const char* mode)
+SDL_RWops *SDL_RWFromZZIP(const char* file, const zzip_plugin_io_handlers* custom_zzip_io)
 {
     register SDL_RWops* rwops;
     register ZZIP_FILE* zzip_file;
 
-    if (! strchr (mode, 'r'))
-	return SDL_RWFromFile(file, mode);
+#ifdef O_BINARY /*Microsoft extension*/
+    const int o_binary = O_BINARY;
+#else
+    const int o_binary = 0;
+#endif
 
-    zzip_file = zzip_fopen (file, mode);
+    zzip_file = zzip_open_ext_io (file, O_RDONLY|o_binary, 0, NULL, custom_zzip_io);
     if (! zzip_file) return 0;
 
     rwops = SDL_AllocRW ();

--- a/Source_Files/Files/SDL_rwops_zzip.h
+++ b/Source_Files/Files/SDL_rwops_zzip.h
@@ -15,6 +15,7 @@
 #define _SDL_RWops_ZZIP_h
 
 #include <SDL_rwops.h>
+#include <zzip/plugin.h>
 
 #ifndef ZZIP_NO_DECLSPEC
 #define ZZIP_DECLSPEC
@@ -27,7 +28,7 @@ extern "C" {
 #endif
 
 extern ZZIP_DECLSPEC
-SDL_RWops *SDL_RWFromZZIP(const char* file, const char* mode);
+SDL_RWops *SDL_RWFromZZIP(const char* file, const zzip_plugin_io_handlers* custom_zzip_io); /* open mode: "rb" */
 
 #ifdef __cplusplus
 } /* extern C */

--- a/Source_Files/Files/import_definitions.cpp
+++ b/Source_Files/Files/import_definitions.cpp
@@ -94,7 +94,6 @@ bool physics_file_is_m1(void)
     
     // check for M1 physics
     OpenedFile PhysicsFile;
-    short SavedType, SavedError = get_game_error(&SavedType);
     if (PhysicsFileSpec.Open(PhysicsFile))
     {
         uint32 tag = SDL_ReadBE32(PhysicsFile.GetRWops());
@@ -113,7 +112,6 @@ bool physics_file_is_m1(void)
         
         PhysicsFile.Close();
     }
-    set_game_error(SavedType, SavedError);
     return m1_physics;
 }
 

--- a/Source_Files/Files/wad.cpp
+++ b/Source_Files/Files/wad.cpp
@@ -929,14 +929,24 @@ bool create_wadfile(FileSpecifier& File, Typecode Type)
 	return File.Create(Type);
 }
 
+static bool open_wad_file_or_set_error(FileSpecifier& File, OpenedFile& OFile, bool Writable)
+{
+	if (!File.Open(OFile, Writable))
+	{
+		set_game_error(systemError, File.GetError());
+		return false;
+	}
+	return true;
+}
+
 bool open_wad_file_for_reading(FileSpecifier& File, OpenedFile& OFile)
 {
-	return File.Open(OFile);
+	return open_wad_file_or_set_error(File, OFile, false);
 }
 
 bool open_wad_file_for_writing(FileSpecifier& File, OpenedFile& OFile)
 {
-	return File.Open(OFile,true);
+	return open_wad_file_or_set_error(File, OFile, true);
 }
 
 void close_wad_file(OpenedFile& File)

--- a/Source_Files/Lua/lauxlib.h
+++ b/Source_Files/Lua/lauxlib.h
@@ -207,6 +207,19 @@ LUALIB_API void (luaL_openlib) (lua_State *L, const char *libname,
 #endif
 
 
+
+/*
+** Private C/POSIX library wrappers that speak UTF-8 instead of ANSI on Windows
+*/
+#ifdef LUA_LIB
+LUAI_FUNC FILE* luai_fopen(const char* path, const char* mode);
+LUAI_FUNC FILE* luai_popen(const char* command, const char* mode);
+LUAI_FUNC int luai_system(const char* command);
+LUAI_FUNC int luai_remove(const char* path);
+LUAI_FUNC int luai_rename(const char* from, const char* to);
+LUAI_FUNC char* luai_alloc_getenv(const char* name); /* deallocate with free() */
+#endif
+
 #endif
 
 

--- a/Source_Files/Lua/liolib.c
+++ b/Source_Files/Lua/liolib.c
@@ -55,12 +55,12 @@
 
 #if defined(LUA_USE_POPEN)	/* { */
 
-#define lua_popen(L,c,m)	((void)L, fflush(NULL), popen(c,m))
+#define lua_popen(L,c,m)	((void)L, fflush(NULL), luai_popen(c,m))
 #define lua_pclose(L,file)	((void)L, pclose(file))
 
 #elif defined(LUA_WIN)		/* }{ */
 
-#define lua_popen(L,c,m)		((void)L, _popen(c,m))
+#define lua_popen(L,c,m)		((void)L, luai_popen(c,m))
 #define lua_pclose(L,file)		((void)L, _pclose(file))
 
 
@@ -216,7 +216,7 @@ static LStream *newfile (lua_State *L) {
 
 static void opencheck (lua_State *L, const char *fname, const char *mode) {
   LStream *p = newfile(L);
-  p->f = fopen(fname, mode);
+  p->f = luai_fopen(fname, mode);
   if (p->f == NULL)
     luaL_error(L, "cannot open file " LUA_QS " (%s)", fname, strerror(errno));
 }
@@ -228,7 +228,7 @@ static int io_open (lua_State *L) {
   LStream *p = newfile(L);
   const char *md = mode;  /* to traverse/check mode */
   luaL_argcheck(L, lua_checkmode(md), 2, "invalid mode");
-  p->f = fopen(filename, mode);
+  p->f = luai_fopen(filename, mode);
   return (p->f == NULL) ? luaL_fileresult(L, 0, filename) : 1;
 }
 

--- a/Source_Files/Lua/loslib.c
+++ b/Source_Files/Lua/loslib.c
@@ -79,7 +79,7 @@
 
 static int os_execute (lua_State *L) {
   const char *cmd = luaL_optstring(L, 1, NULL);
-  int stat = system(cmd);
+  int stat = luai_system(cmd);
   if (cmd != NULL)
     return luaL_execresult(L, stat);
   else {
@@ -91,14 +91,14 @@ static int os_execute (lua_State *L) {
 
 static int os_remove (lua_State *L) {
   const char *filename = luaL_checkstring(L, 1);
-  return luaL_fileresult(L, remove(filename) == 0, filename);
+  return luaL_fileresult(L, luai_remove(filename) == 0, filename);
 }
 
 
 static int os_rename (lua_State *L) {
   const char *fromname = luaL_checkstring(L, 1);
   const char *toname = luaL_checkstring(L, 2);
-  return luaL_fileresult(L, rename(fromname, toname) == 0, NULL);
+  return luaL_fileresult(L, luai_rename(fromname, toname) == 0, NULL);
 }
 
 
@@ -114,7 +114,9 @@ static int os_tmpname (lua_State *L) {
 
 
 static int os_getenv (lua_State *L) {
-  lua_pushstring(L, getenv(luaL_checkstring(L, 1)));  /* if NULL push nil */
+  char* env = luai_alloc_getenv(luaL_checkstring(L, 1));
+  lua_pushstring(L, env);  /* if NULL push nil */
+  free(env);
   return 1;
 }
 

--- a/Source_Files/Lua/lua_hud_script.cpp
+++ b/Source_Files/Lua/lua_hud_script.cpp
@@ -42,7 +42,6 @@ extern "C"
 
 #include "Logging.h"
 #include "preferences.h"
-#include "game_errors.h"
 #include "Plugins.h"
 
 #include "lua_hud_script.h"
@@ -361,9 +360,6 @@ void LoadHUDLua()
 
 	if (file.size())
 	{
-		// protect Lua errors from harming error checking
-		short SavedType, SavedError = get_game_error(&SavedType);
-
 		FileSpecifier fs (file.c_str());
 		if (directory.size())
 		{
@@ -386,7 +382,6 @@ void LoadHUDLua()
 				}
 			}
 		}
-		set_game_error(SavedType, SavedError);
 	}
 }
 

--- a/Source_Files/Misc/Logging.cpp
+++ b/Source_Files/Misc/Logging.cpp
@@ -228,7 +228,11 @@ InitializeLogging() {
     FileSpecifier fs = log_dir;
     fs += loggingFileName();
 
+#ifdef __WIN32__
+    sOutputFile = _wfopen(utf8_to_wide(fs.GetPath()).c_str(), L"a");
+#else
     sOutputFile = fopen(fs.GetPath(), "a");
+#endif
 
     sCurrentLogger = new TopLevelLogger;
     if(sOutputFile != NULL)

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -107,6 +107,7 @@ May 22, 2003 (Woody Zenfell):
 #ifdef __WIN32__
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h> // for GetUserName()
+#include <lmcons.h>
 #endif
 
 // 8-bit support is still here if you undefine this, but you'll need to fix it
@@ -188,12 +189,10 @@ static std::string get_name_from_system()
 
 #elif defined(__WIN32__)
 
-	char login[17];
-	DWORD len = 17;
-
-	bool hasName = (GetUserName((LPSTR)login, &len) == TRUE);
-	if (hasName && strpbrk(login, "\\/:*?\"<>|") == NULL) // Ignore illegal names
-		return login;
+	wchar_t wname[UNLEN + 1];
+	DWORD wname_n = UNLEN + 1;
+	if (GetUserNameW(wname, &wname_n))
+		return wide_to_utf8(wname);
 
 #else
 //#error get_name_from_system() not implemented for this platform
@@ -3567,7 +3566,8 @@ static void default_player_preferences(player_preferences_data *preferences)
 	obj_clear(*preferences);
 
 	preferences->difficulty_level= 2;
-	strncpy(preferences->name, get_name_from_system().c_str(), PREFERENCES_NAME_LENGTH+1);
+	strncpy(preferences->name, get_name_from_system().c_str(), PREFERENCES_NAME_LENGTH);
+	preferences->name[PREFERENCES_NAME_LENGTH] = '\0';
 	
 	// LP additions for new fields:
 	

--- a/Source_Files/RenderOther/sdl_fonts.cpp
+++ b/Source_Files/RenderOther/sdl_fonts.cpp
@@ -28,7 +28,6 @@
 #include "cseries.h"
 #include "sdl_fonts.h"
 #include "byte_swapping.h"
-#include "game_errors.h"
 #include "resource_manager.h"
 #include "FileHandler.h"
 #include "Logging.h"
@@ -253,16 +252,12 @@ static TTF_Font *load_ttf_font(const std::string& path, uint16 style, int16 size
 	}
 	else
 	{
-		short SavedType, SavedError = get_game_error(&SavedType);
-
 		FileSpecifier fileSpec(path);
 		OpenedFile file;
 		if (fileSpec.Open(file))
 		{
 			font = TTF_OpenFontRW(file.TakeRWops(), 1, size);
 		}
-
-		set_game_error(SavedType, SavedError);
 	}
 
 	if (font)

--- a/Source_Files/Sound/Decoder.cpp
+++ b/Source_Files/Sound/Decoder.cpp
@@ -23,7 +23,6 @@
 
 #include "Decoder.h"
 #include "BasicIFFDecoder.h"
-#include "game_errors.h"
 #include "MADDecoder.h"
 #include "SndfileDecoder.h"
 #include "VorbisDecoder.h"
@@ -34,8 +33,6 @@ using std::unique_ptr;
 
 StreamDecoder *StreamDecoder::Get(FileSpecifier& File)
 {
-	ScopedGameError gameErrorRestorer;
-
 #ifdef HAVE_FFMPEG
 	{
 		unique_ptr<FFmpegDecoder> ffmpegDecoder(new FFmpegDecoder);
@@ -79,8 +76,6 @@ StreamDecoder *StreamDecoder::Get(FileSpecifier& File)
 
 Decoder *Decoder::Get(FileSpecifier &File)
 {
-	ScopedGameError gameErrorRestorer;
-
 #ifdef HAVE_FFMPEG
 	{
 		unique_ptr<FFmpegDecoder> ffmpegDecoder(new FFmpegDecoder);

--- a/Source_Files/XML/InfoTree.cpp
+++ b/Source_Files/XML/InfoTree.cpp
@@ -22,7 +22,6 @@
 
 #include "InfoTree.h"
 #include "cseries.h"
-#include "game_errors.h"
 #include "shell.h"
 #include "TextStrings.h"
 
@@ -49,14 +48,10 @@ InfoTree InfoTree::load_xml(FileSpecifier filename)
 	}
 	else
 	{
-		short err, errtype;
-		err = get_game_error(&errtype);
-		clear_game_error();
-		
 		std::string errstr = "could not open XML file ";
 		errstr += filename.GetPath();
 		errstr += ": system error ";
-		errstr += errtype;
+		errstr += filename.GetError();
 		throw InfoTree::unexpected_error(errstr);
 	}
 	

--- a/Source_Files/XML/InfoTree.cpp
+++ b/Source_Files/XML/InfoTree.cpp
@@ -25,97 +25,91 @@
 #include "shell.h"
 #include "TextStrings.h"
 
+#include <type_traits>
+
 #include <boost/function.hpp>
 #include <boost/version.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include <boost/iostreams/stream.hpp>
+
+namespace pt = boost::property_tree;
+namespace io = boost::iostreams;
+
+class InfoTreeFileStream : public io::stream<opened_file_device>
+{ 
+private:
+	OpenedFile f;
+public:
+	~InfoTreeFileStream() { close(); }
+	explicit InfoTreeFileStream(FileSpecifier path, bool write = false)
+	{ 
+		if (!(write ? path.OpenForWritingText(f) : path.Open(f)))
+		{ 
+			const auto code = std::to_string(path.GetError());
+			const auto mode = write ? "writing" : "reading";
+			const auto msg = std::string("couldn't open '") + path.GetPath() + "' for " + mode + " (error " + code + ")";
+			throw InfoTree::unexpected_error(msg);
+		} 
+		open(f);
+	}
+};
 
 InfoTree InfoTree::load_xml(FileSpecifier filename)
 {
-	// use rwops, in case file is inside a zip archive
-	OpenedFile file;
-	if (filename.Open(file))
-	{
-		int32 data_size;
-		file.GetLength(data_size);
-		std::vector<char> file_data;
-		file_data.resize(data_size);
-		
-		if (file.Read(data_size, &file_data[0]))
-		{
-			std::istringstream strm(std::string(file_data.begin(), file_data.end()));
-			return load_xml(strm);
-		}
-	}
-	else
-	{
-		std::string errstr = "could not open XML file ";
-		errstr += filename.GetPath();
-		errstr += ": system error ";
-		errstr += filename.GetError();
-		throw InfoTree::unexpected_error(errstr);
-	}
-	
-	boost::property_tree::ptree xtree;
-	boost::property_tree::read_xml(filename.GetPath(), xtree);
-	return InfoTree(xtree);
+	InfoTreeFileStream stream(filename);
+	InfoTree xtree;
+	pt::read_xml<pt::ptree>(stream, xtree);
+	return xtree;
 }
 
 InfoTree InfoTree::load_xml(std::istringstream& stream)
 {
-	boost::property_tree::ptree xtree;
-	boost::property_tree::read_xml(stream, xtree);
-	return InfoTree(xtree);
+	InfoTree xtree;
+	pt::read_xml<pt::ptree>(stream, xtree);
+	return xtree;
 }
+
+static void write_indented_xml(std::ostream& dest, const pt::ptree& src)
+{
+	using settings_t = pt::xml_writer_settings< std::conditional<BOOST_VERSION >= 105600, std::string, char>::type >;
+	pt::write_xml<pt::ptree>(dest, src, settings_t(' ', 2));
+} 
 
 void InfoTree::save_xml(FileSpecifier filename) const
 {
-	boost::property_tree::write_xml(filename.GetPath(),
-									boost::property_tree::ptree(*this),
-									std::locale(),
-#if BOOST_VERSION >= 105600
-									boost::property_tree::xml_writer_make_settings<boost::property_tree::ptree::key_type>(' ', 2)
-#else
-									boost::property_tree::xml_writer_make_settings(' ', 2)
-#endif
-									);
+	InfoTreeFileStream stream(filename, /*write:*/ true);
+	write_indented_xml(stream, *this);
 }
 
 void InfoTree::save_xml(std::ostringstream& stream) const
 {
-	boost::property_tree::write_xml(stream,
-									boost::property_tree::ptree(*this),
-#if BOOST_VERSION >= 105600
-									boost::property_tree::xml_writer_make_settings<boost::property_tree::ptree::key_type>(' ', 2)
-#else
-									boost::property_tree::xml_writer_make_settings(' ', 2)
-#endif
-									);
+	write_indented_xml(stream, *this);
 }
 
 InfoTree InfoTree::load_ini(FileSpecifier filename)
 {
-	boost::property_tree::ptree itree;
-	boost::property_tree::read_ini(filename.GetPath(), itree);
-	return InfoTree(itree);
+	InfoTreeFileStream stream(filename);
+	InfoTree itree;
+	pt::read_ini<pt::ptree>(stream, itree);
+	return itree;
 }
 
 InfoTree InfoTree::load_ini(std::istringstream& stream)
 {
-	boost::property_tree::ptree itree;
-	boost::property_tree::read_ini(stream, itree);
-	return InfoTree(itree);
+	InfoTree itree;
+	pt::read_ini<pt::ptree>(stream, itree);
+	return itree;
 }
 
 void InfoTree::save_ini(FileSpecifier filename) const
 {
-	boost::property_tree::write_ini(filename.GetPath(),
-									boost::property_tree::ptree(*this));
+	InfoTreeFileStream stream(filename, /*write:*/ true);
+	pt::write_ini<pt::ptree>(stream, *this);
 }
 
 void InfoTree::save_ini(std::ostringstream& stream) const
 {
-	boost::property_tree::write_ini(stream,
-									boost::property_tree::ptree(*this));
+	pt::write_ini<pt::ptree>(stream, *this);
 }
 
 bool InfoTree::read_fixed(std::string path, _fixed& value, float min, float max) const

--- a/Source_Files/XML/Plugins.cpp
+++ b/Source_Files/XML/Plugins.cpp
@@ -34,10 +34,6 @@
 #include "XML_ParseTreeRoot.h"
 #include "Scenario.h"
 
-#ifdef HAVE_ZZIP
-#include <zzip/lib.h>
-#endif
-
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace algo = boost::algorithm;
@@ -360,27 +356,19 @@ bool PluginLoader::ParseDirectory(FileSpecifier& dir)
 		{
 			ParseDirectory(file);
 		}
-#ifdef HAVE_ZZIP
 		else if (algo::ends_with(it->name, ".zip") || algo::ends_with(it->name, ".ZIP"))
 		{
 			// search it for a Plugin.xml file
-			ZZIP_DIR* zzipdir = zzip_dir_open(file.GetPath(), 0);
-			if (zzipdir)
+			for (const auto& zip_entry : file.ReadZIP())
 			{
-				ZZIP_DIRENT dirent;
-				while (zzip_dir_read(zzipdir, &dirent))
+				if (zip_entry == "Plugin.xml" || algo::ends_with(zip_entry, "/Plugin.xml"))
 				{
-					if (strcmp(dirent.d_name, "Plugin.xml") == 0 || algo::ends_with(dirent.d_name, "/Plugin.xml"))
-					{
-						std::string archive = file.GetPath();
-						FileSpecifier file_name = FileSpecifier(archive.substr(0, archive.find_last_of('.'))) + dirent.d_name;
-						ParsePlugin(file_name);
-					}
+					std::string archive = file.GetPath();
+					FileSpecifier file_name = FileSpecifier(archive.substr(0, archive.find_last_of('.'))) + zip_entry;
+					ParsePlugin(file_name);
 				}
-				zzip_dir_close(zzipdir);
 			}
 		}
-#endif
 	}
 
 	return true;

--- a/Source_Files/XML/QuickSave.cpp
+++ b/Source_Files/XML/QuickSave.cpp
@@ -586,6 +586,10 @@ void create_updated_save(QuickSave& save)
 		err = currentFile.GetError();
 		close_wad_file(currentFile);
 	}
+	else
+	{
+		err = save.save_file.GetError();
+	}
 	
 	// create updated save file
 	int32 offset, meta_wad_length;

--- a/Source_Files/shell.cpp
+++ b/Source_Files/shell.cpp
@@ -176,6 +176,17 @@ static void process_event(const SDL_Event &event);
 // cross-platform static variables
 short vidmasterStringSetID = -1; // can be set with MML
 
+static std::string a1_getenv(const char* name)
+{
+#ifdef __WIN32__
+	wchar_t* wstr = _wgetenv(utf8_to_wide(name).c_str());
+	return wstr ? wide_to_utf8(wstr) : std::string{};
+#else
+	char* str = getenv(name);
+	return str ? str : std::string{};
+#endif
+}
+
 static void usage(const char *prg_name)
 {
 	char msg[] =
@@ -204,7 +215,7 @@ static void usage(const char *prg_name)
 	  "the data directory.\n";
 
 #ifdef __WIN32__
-	MessageBox(NULL, msg, "Usage", MB_OK | MB_ICONINFORMATION);
+	MessageBoxW(NULL, utf8_to_wide(msg).c_str(), L"Usage", MB_OK | MB_ICONINFORMATION);
 #else
 	printf(msg, prg_name);
 #endif
@@ -377,7 +388,7 @@ static int char_is_not_filesafe(int c)
 static void initialize_application(void)
 {
 #if defined(__WIN32__) && defined(__MINGW32__)
-	if (LoadLibrary("exchndl.dll")) option_debug = true;
+	if (LoadLibraryW(L"exchndl.dll")) option_debug = true;
 #endif
 
 #if defined(__WIN32__)
@@ -460,8 +471,8 @@ static void initialize_application(void)
 		data_search_path.push_back(arg_directory);
 	}
 
-	const char *data_env = getenv("ALEPHONE_DATA");
-	if (data_env) {
+	const string data_env = a1_getenv("ALEPHONE_DATA");
+	if (!data_env.empty()) {
 		// Read colon-separated list of directories
 		string path = data_env;
 		string::size_type pos;


### PR DESCRIPTION
This PR fixes all known Unicode-character incompatibilities on Windows (including in Lua scripts) besides text-field input and glyph rendering. In particular, arbitrary Unicode file paths and environment variables now work on Windows. This PR includes minor code cleanups/fixes as well. See commit messages for details.

For the future, maintaining this Unicode compatibility on Windows will particularly require avoidance of ANSI (A-suffixed) WinAPI functions as well as any C, C++, POSIX, Boost, or other 3rd-party library functions that take or return `char` paths unless they are known to speak UTF-8 on Windows (e.g. SDL and FFmpeg) or only ASCII characters are involved.