### PR TITLE
Hotfix/bug windows build

### DIFF
--- a/Source_Files/RenderMain/OGL_Textures.h
+++ b/Source_Files/RenderMain/OGL_Textures.h
@@ -254,6 +254,9 @@ public:
 	void SetupTextureMatrix();
 	void RestoreTextureMatrix();
 	
+	TextureManager(const TextureManager&) = delete;
+	TextureManager& operator= (const TextureManager&) = delete;
+	
 	TextureManager();
 	~TextureManager();
 };

--- a/Source_Files/RenderMain/RenderRasterize_Shader.h
+++ b/Source_Files/RenderMain/RenderRasterize_Shader.h
@@ -61,8 +61,8 @@ public:
 	virtual void render_tree(void);
         bool renders_viewer_sprites_in_tree() { return true; }
 
-	TextureManager setupWallTexture(const shape_descriptor& Texture, short transferMode, float pulsate, float wobble, float intensity, float offset, RenderStep renderStep);
-	TextureManager setupSpriteTexture(const rectangle_definition& rect, short type, float offset, RenderStep renderStep);
+	std::unique_ptr<TextureManager> setupWallTexture(const shape_descriptor& Texture, short transferMode, float pulsate, float wobble, float intensity, float offset, RenderStep renderStep);
+	std::unique_ptr<TextureManager> setupSpriteTexture(const rectangle_definition& rect, short type, float offset, RenderStep renderStep);
 };
 
 #endif

--- a/Source_Files/RenderOther/screen_shared.h
+++ b/Source_Files/RenderOther/screen_shared.h
@@ -622,7 +622,7 @@ static void DisplayMessages(SDL_Surface *s)
 					icon_drop = 2;
 				break;
 			}
-			bool had_icon;
+			bool had_icon = false;
 			/* Yes, I KNOW this is the same i as above. I know what I'm doing. */
 			for(i = 0; i < MAXIMUM_NUMBER_OF_SCRIPT_HUD_ELEMENTS; ++i) {
 				if(ScriptHUDElements[view][i].text.empty()) continue;


### PR DESCRIPTION
This is a fix for 2 issues I encountered while running Alephone built on windows with VisualStudio. It doesn't occur in the official release for some reason but I thought it would still be a good thing fixing it on master.
For this first one it's a simple unitialized variable leading to a runtime error, not to much to say about it.
The second one is `TextureManager` instances messing things up between them and their child objects and once called by the destructor leads to multiple call to `delete[]` on the same child pointer (already deleted) causing a crash.

See bellow
![2020-08-05 00_17_41-Window](https://user-images.githubusercontent.com/17474079/89357350-8617e800-d6c0-11ea-899f-18d43f94a5c5.png)

As said by the commit, the fix replaces `TextureManager` instances with unique pointer to prevent destructor calls to the same pointer twice.

This has only been tested on Windows.
