### PR TITLE
Necessary code modifications in order to build with Visual Studio

### DIFF
--- a/Source_Files/Files/FileHandler.cpp
+++ b/Source_Files/Files/FileHandler.cpp
@@ -24,6 +24,12 @@
  *
  *  Written in 2000 by Christian Bauer
  */
+
+#if defined _MSC_VER 
+ //not #if defined(_WIN32) || defined(_WIN64) because we have strcasecmp in mingw
+#define strcasecmp _stricmp
+#endif
+
 #include "cseries.h"
 #include "FileHandler.h"
 #include "resource_manager.h"
@@ -53,6 +59,9 @@
 #endif
 
 #if defined(__WIN32__)
+#if defined _MSC_VER
+#define R_OK 4
+#endif
 #include <wchar.h>
 #define PATH_SEP '\\'
 #else

--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -727,7 +727,7 @@ bool get_entry_points(vector<entry_point> &vec, int32 type)
 extern void LoadSoloLua();
 extern void LoadReplayNetLua();
 extern void LoadStatsLua();
-extern void RunLuaScript();
+extern bool RunLuaScript();
 
 /* This is called when the game level is changed somehow */
 /* The only thing that has to be valid in the entry point is the level_index */

--- a/Source_Files/Lua/lua_hud_objects.cpp
+++ b/Source_Files/Lua/lua_hud_objects.cpp
@@ -20,6 +20,11 @@ LUA_HUD_OBJECTS.CPP
     Implements Lua HUD objects and globals
 */
 
+
+#if defined (_MSC_VER) && !defined (M_PI)
+#define _USE_MATH_DEFINES
+#endif 
+
 #include "lua_hud_objects.h"
 #include "lua_objects.h"
 #include "lua_map.h"

--- a/Source_Files/ModelView/Model3D.h
+++ b/Source_Files/ModelView/Model3D.h
@@ -22,6 +22,12 @@
 	
 	By Loren Petrich, June 16, 2001
 */
+
+#if defined _MSC_VER
+#define NOMINMAX
+#include <algorithm>
+#endif
+
 #ifndef MODEL_3D
 #define MODEL_3D
 

--- a/Source_Files/Network/Metaserver/metaserver_messages.h
+++ b/Source_Files/Network/Metaserver/metaserver_messages.h
@@ -200,7 +200,10 @@ protected:
 		}
 
 	bool reallyInflateFrom(AIStream& inStream)
-		{ assert(false); }
+	{ 
+		assert(false);
+		return false;
+	}
 
 private:
 	uint16 m_mode;

--- a/Source_Files/Network/Update.cpp
+++ b/Source_Files/Network/Update.cpp
@@ -81,7 +81,8 @@ int Update::Thread()
 	}
 
 	boost::char_separator<char> sep("\r\n");
-	boost::tokenizer<boost::char_separator<char> > tokens(fetcher.Response(), sep);
+	std::string response = fetcher.Response();
+	boost::tokenizer<boost::char_separator<char> > tokens(response, sep);
 	for (boost::tokenizer<boost::char_separator<char> >::iterator it = tokens.begin();
 	     it != tokens.end();
 	     ++it)

--- a/Source_Files/RenderMain/ImageLoader_Shared.cpp
+++ b/Source_Files/RenderMain/ImageLoader_Shared.cpp
@@ -28,6 +28,11 @@
  *          adapted from DevIL (openil.sourceforge.net)
  */
 
+#if defined(_MSC_VER)
+#define NOMINMAX
+#include <algorithm>
+#endif
+
 #include "AStream.h"
 #include "cstypes.h"
 #include "DDS.h"

--- a/Source_Files/RenderMain/Rasterizer_Shader.cpp
+++ b/Source_Files/RenderMain/Rasterizer_Shader.cpp
@@ -6,6 +6,10 @@
  *  http://www.gnu.org/licenses/gpl.html
  */
 
+#if defined (_MSC_VER) && !defined (M_PI)
+#define _USE_MATH_DEFINES
+#endif 
+
 #include "OGL_Headers.h"
 
 #include <iostream>

--- a/Source_Files/RenderOther/sdl_fonts.h
+++ b/Source_Files/RenderOther/sdl_fonts.h
@@ -25,6 +25,11 @@
  *  Written in 2000 by Christian Bauer
  */
 
+#if defined _MSC_VER
+#define NOMINMAX
+#include <algorithm>
+#endif
+
 #ifndef SDL_FONTS_H
 #define SDL_FONTS_H
 

--- a/Source_Files/RenderOther/sdl_resize.cpp
+++ b/Source_Files/RenderOther/sdl_resize.cpp
@@ -8,6 +8,11 @@
  * into the public domain.
  */
 
+#if defined(_MSC_VER)
+#define NOMINMAX
+#include <algorithm>
+#endif
+
 #include <cmath>
 #include <vector>
 

--- a/Source_Files/Sound/BasicIFFDecoder.cpp
+++ b/Source_Files/Sound/BasicIFFDecoder.cpp
@@ -21,6 +21,11 @@
 
 */
 
+#if defined(_MSC_VER)
+#define NOMINMAX
+#include <algorithm>
+#endif
+
 #include "BasicIFFDecoder.h"
 #include "AStream.h"
 #include <vector>

--- a/Source_Files/Sound/FFmpegDecoder.cpp
+++ b/Source_Files/Sound/FFmpegDecoder.cpp
@@ -21,6 +21,11 @@
  
  */
 
+#if defined _MSC_VER
+#define NOMINMAX
+#include <algorithm>
+#endif
+
 // make FFmpeg happy
 #define __STDC_CONSTANT_MACROS
 

--- a/Source_Files/TCPMess/CommunicationsChannel.cpp
+++ b/Source_Files/TCPMess/CommunicationsChannel.cpp
@@ -39,6 +39,9 @@
 #include "cseries.h"
 #if defined(WIN32)
 #define WIN32_LEAN_AND_MEAN
+#if defined (_MSC_VER)
+#define NOMINMAX
+#endif
 #include <winsock2.h> // hacky non-cross-platform setting of nonblocking
 #else
 #include <fcntl.h> // hacky non-cross-platform setting of nonblocking


### PR DESCRIPTION
This pull request gathers all the modifications that must be done to the code to be able to build AlephOne on Windows with VS.
Not a lot of changes at all must be done, there is only 2 fix for code appearing as warnings in some compilers but as error for VS's compiler. The rest is just preprocessor directives to fix unavailable things and conflicts with MSVC.

There is just commit ca6ac29af2107cd5dbeeb3eacde6fe3e43900bc8 that is not a code changes to fix the build but a fix to a runtime assert failed on debug mode when trying to join network lobby and caused by boost library, tokenizer iterators which does not seem to properly init from `fetcher.Response()` since the temporary return value get destroyed as said by the assertion failed I guess.

Here tokens variable isn't correctly init.
![2020-08-22 17_35_06-AlephOne (Debugging) - Microsoft Visual Studio](https://user-images.githubusercontent.com/17474079/90959992-c4721d00-e49e-11ea-8d3d-93f22ac661a6.png)

Causing the assertion failed.
![2020-08-22 17_35_29-Microsoft Visual C++ Runtime Library](https://user-images.githubusercontent.com/17474079/90959997-ce941b80-e49e-11ea-9808-f112ae2b18d4.png)

With the intermediate variable.
![2020-08-22 17_46_47-AlephOne (Debugging) - Microsoft Visual Studio](https://user-images.githubusercontent.com/17474079/90960288-ea98bc80-e4a0-11ea-9c29-bed51ea6dfda.png)