### PR TITLE
Fix memory leak ImageBlitter (SDL_CreateRGBSurface)

### DIFF
--- a/Source_Files/Misc/sdl_widgets.cpp
+++ b/Source_Files/Misc/sdl_widgets.cpp
@@ -236,35 +236,6 @@ void w_slider_text::draw(SDL_Surface *s) const
 	draw_text(s, text, rect.x, rect.y + font->get_ascent() + (rect.h - font->get_line_height()) / 2, get_theme_color(LABEL_WIDGET, state, FOREGROUND_COLOR), font, style);
 }
 
-/*
- *  Picture (PICT resource)
- */
-
-w_pict::w_pict(int id)
-{
-	LoadedResource rsrc;
-	get_resource(FOUR_CHARS_TO_INT('P', 'I', 'C', 'T'), id, rsrc);
-	picture = picture_to_surface(rsrc);
-	if (picture) {
-		rect.w = static_cast<uint16>(picture->w);
-		rect.h = static_cast<uint16>(picture->h);
-		SDL_SetColorKey(picture, SDL_TRUE, SDL_MapRGB(picture->format, 0xff, 0xff, 0xff));
-	} else
-		rect.w = rect.h = 0;
-}
-
-w_pict::~w_pict()
-{
-	if (picture)
-		SDL_FreeSurface(picture);
-}
-
-void w_pict::draw(SDL_Surface *s) const
-{
-	if (picture)
-		SDL_BlitSurface(picture, NULL, s, const_cast<SDL_Rect *>(&rect));
-}
-
 
 /*
  *  Button

--- a/Source_Files/Misc/sdl_widgets.h
+++ b/Source_Files/Misc/sdl_widgets.h
@@ -234,23 +234,6 @@ protected:
 
 
 /*
- *  Picture (PICT resource)
- */
-
-class w_pict : public widget {
-public:
-	w_pict(int id);
-	~w_pict();
-
-	void draw(SDL_Surface *s) const;
-	bool is_selectable(void) const {return false;}
-
-private:
-	SDL_Surface *picture;
-};
-
-
-/*
  *  Button
  */
 

--- a/Source_Files/RenderOther/Image_Blitter.cpp
+++ b/Source_Files/RenderOther/Image_Blitter.cpp
@@ -50,10 +50,9 @@ bool Image_Blitter::Load(int picture_resource)
     bool ret = false;
     LoadedResource PictRsrc;
     if (get_picture_resource_from_images(picture_resource, PictRsrc)) {
-        SDL_Surface *hud_pict = picture_to_surface(PictRsrc);
+        auto hud_pict = picture_to_surface(PictRsrc);
         if (hud_pict) {
             ret = Load(*hud_pict);
-            SDL_FreeSurface(hud_pict);
         }
     }
     return ret;

--- a/Source_Files/RenderOther/OGL_Blitter.cpp
+++ b/Source_Files/RenderOther/OGL_Blitter.cpp
@@ -58,16 +58,16 @@ void OGL_Blitter::_LoadTextures()
 		m_tile_height = std::max(m_tile_height, 128);
 	}
 
-	SDL_Surface *t = nullptr;
+	std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)> t(nullptr, SDL_FreeSurface);
 	if (PlatformIsLittleEndian()) {
-		t = SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+		t.reset(SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000));
 	} else {
-		t = SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+		t.reset(SDL_CreateRGBSurface(SDL_SWSURFACE, m_tile_width, m_tile_height, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff));
 	}
 	if (!t)
 		return;
 	
-	SDL_SetSurfaceBlendMode(t, SDL_BLENDMODE_NONE);
+	SDL_SetSurfaceBlendMode(t.get(), SDL_BLENDMODE_NONE);
 	
 	// calculate how many rects we need
 	int v_rects = ((m_src.h + m_tile_height - 1) / m_tile_height);
@@ -92,7 +92,7 @@ void OGL_Blitter::_LoadTextures()
 			m_rects[i].h = std::min(m_tile_height, static_cast<int>(m_src.h - y * m_tile_height));
 
 			SDL_Rect sr = { m_rects[i].x, m_rects[i].y, m_rects[i].w, m_rects[i].h }; 
-			SDL_BlitSurface(m_surface, &sr, t, NULL);
+			SDL_BlitSurface(m_surface, &sr, t.get(), NULL);
 
 			// to avoid edge artifacts, smear edge pixels out to texture boundary
 			for (int row = 0; row < m_rects[i].h; ++row)
@@ -128,7 +128,6 @@ void OGL_Blitter::_LoadTextures()
 		}
 	}
 	
-	SDL_FreeSurface(t);
 	m_textures_loaded = true;
 	return;
 }

--- a/Source_Files/RenderOther/computer_interface.cpp
+++ b/Source_Files/RenderOther/computer_interface.cpp
@@ -1150,12 +1150,11 @@ static void display_picture(
 	short flags)
 {
 	LoadedResource PictRsrc;
-	SDL_Surface *s = NULL;
 
-	if (get_picture_resource_from_scenario(picture_id, PictRsrc))
-	{
-		s = picture_to_surface(PictRsrc);
-	}
+	auto s = get_picture_resource_from_scenario(picture_id, PictRsrc) ? 
+			 picture_to_surface(PictRsrc) :
+			 std::shared_ptr<SDL_Surface>(nullptr, SDL_FreeSurface);
+
 	if (s)
 	{
 		Rect bounds;
@@ -1207,16 +1206,15 @@ static void display_picture(
 
 		SDL_Rect r = {bounds.left, bounds.top, bounds.right - bounds.left, bounds.bottom - bounds.top};
 		if ((s->w == r.w && s->h == r.h) || cinemascopeHack)
-			SDL_BlitSurface(s, NULL, /*world_pixels*/draw_surface, &r);
+			SDL_BlitSurface(s.get(), NULL, /*world_pixels*/draw_surface, &r);
 		else {
 			// Rescale picture
-			SDL_Surface *s2 = rescale_surface(s, r.w, r.h);
+			SDL_Surface *s2 = rescale_surface(s.get(), r.w, r.h);
 			if (s2) {
 				SDL_BlitSurface(s2, NULL, /*world_pixels*/draw_surface, &r);
 				SDL_FreeSurface(s2);
 			}
 		}
-		SDL_FreeSurface(s);
 		/* And let the caller know where we drew the picture */
 		*frame= bounds;
 	} else {

--- a/Source_Files/RenderOther/game_window.cpp
+++ b/Source_Files/RenderOther/game_window.cpp
@@ -500,9 +500,9 @@ void draw_panels(void)
 	ensure_HUD_buffer();
 
 	// Draw static HUD picture
-	static SDL_Surface *static_hud_pict = NULL;
+	static std::shared_ptr<SDL_Surface> static_hud_pict = std::shared_ptr<SDL_Surface>(nullptr, SDL_FreeSurface);
 	static bool hud_pict_not_found = false;
-	if (static_hud_pict == NULL && !hud_pict_not_found) {
+	if (!static_hud_pict && !hud_pict_not_found) {
 		LoadedResource rsrc;
 		if (get_picture_resource_from_images(INTERFACE_PANEL_BASE, rsrc))
 			static_hud_pict = picture_to_surface(rsrc);
@@ -513,7 +513,7 @@ void draw_panels(void)
 	if (!hud_pict_not_found) {
 		SDL_Rect dst_rect = {0, 320, 640, 160};
 		if (!LuaTexturePaletteSize())
-			SDL_BlitSurface(static_hud_pict, NULL, HUD_Buffer, &dst_rect);
+			SDL_BlitSurface(static_hud_pict.get(), NULL, HUD_Buffer, &dst_rect);
 		else
 			SDL_FillRect(HUD_Buffer, &dst_rect, 0);
 	}

--- a/Source_Files/RenderOther/images.h
+++ b/Source_Files/RenderOther/images.h
@@ -74,7 +74,7 @@ extern bool get_sound_resource_from_scenario(int resource_number, LoadedResource
 extern bool get_text_resource_from_scenario(int resource_number, LoadedResource& TextRsrc);
 
 // Convert MacOS PICT resource to SDL surface
-extern SDL_Surface *picture_to_surface(LoadedResource &rsrc);
+extern std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)> picture_to_surface(LoadedResource &rsrc);
 
 // Rescale/tile surface
 extern SDL_Surface *rescale_surface(SDL_Surface *s, int width, int height);


### PR DESCRIPTION
This is simply a fix for a memory leak issue with SDL_Surface management.
I just "upgraded" the code a little bit with smart pointers (no more than necessary I must say) to get rid of the memory leak.
The memory leak can easily be detected by starting alephone => opening a menu like the preferences menu => returning back to the loby and by repeating the previous sequence you should notice the ram memory used by alephone growing up.

Here memory snapshots of what I described above with the issue:
![withmemoryleak](https://user-images.githubusercontent.com/17474079/89849084-05596000-db88-11ea-9587-db670434eab6.png)

Here the same thing but with the fix:
![nomemoryleak](https://user-images.githubusercontent.com/17474079/89849120-14d8a900-db88-11ea-8fa1-8f8a04915755.png)
