### PR TITLE
Opengl video export on fullscreen with smaller screen resolution setup

### DIFF
--- a/Source_Files/FFmpeg/Movie.cpp
+++ b/Source_Files/FFmpeg/Movie.cpp
@@ -610,21 +610,9 @@ bool Movie::Setup()
 		alert_user(full_msg.c_str());
 	}
 
-    if (success)
+    if (success && MainScreenIsOpenGL())
     {
-        if (MainScreenIsOpenGL())
-        {
-            if (FBO_Allowed)
-                frameBufferObject = std::unique_ptr<FBO>(new FBO(view_rect.w, view_rect.h));
-            else
-            {
-                if (get_screen_mode()->fullscreen && (view_rect.w < MainScreenWindowWidth() || view_rect.h < MainScreenWindowHeight()))
-                {
-                    alert_user("AlephOne must switch to windowed mode to export the video.");
-                    toggle_fullscreen(false);
-                }
-            }
-        }
+        frameBufferObject = std::unique_ptr<FBO>(new FBO(view_rect.w, view_rect.h));
     }
 
     av->inited = success;
@@ -839,25 +827,18 @@ void Movie::AddFrame(FrameType ftype)
 #ifdef HAVE_OPENGL
 	else
 	{
-        if (FBO_Allowed) 
-        {
-            SDL_Rect viewportDimensions = alephone::Screen::instance()->OpenGLViewPort();
-            GLint fbx = viewportDimensions.x, fby = viewportDimensions.y, fbWidth = viewportDimensions.w, fbHeight = viewportDimensions.h;
+        SDL_Rect viewportDimensions = alephone::Screen::instance()->OpenGLViewPort();
+        GLint fbx = viewportDimensions.x, fby = viewportDimensions.y, fbWidth = viewportDimensions.w, fbHeight = viewportDimensions.h;
 
-            // Copy default frame buffer to another one with correct viewport resized/pixels rescaled
-            frameBufferObject->activate(true, GL_DRAW_FRAMEBUFFER_EXT);
-            glBlitFramebufferEXT(fbx, fby, fbWidth + fbx, fbHeight + fby, view_rect.x, view_rect.y, view_rect.w, view_rect.h, GL_COLOR_BUFFER_BIT, GL_LINEAR);
-            frameBufferObject->deactivate();
+        // Copy default frame buffer to another one with correct viewport resized/pixels rescaled
+        frameBufferObject->activate(true, GL_DRAW_FRAMEBUFFER_EXT);
+        glBlitFramebufferEXT(fbx, fby, fbWidth + fbx, fbHeight + fby, view_rect.x, view_rect.y, view_rect.w, view_rect.h, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+        frameBufferObject->deactivate();
 
-            // Read our new frame buffer with rescaled pixels
-            frameBufferObject->activate(true, GL_READ_FRAMEBUFFER_EXT);
-            glReadPixels(view_rect.x, view_rect.y, view_rect.w, view_rect.h, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, &videobuf.front());
-            frameBufferObject->deactivate();
-        } 
-        else //You better not be on fullscreen here
-        {
-            glReadPixels(view_rect.x, view_rect.y, view_rect.w, view_rect.h, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, &videobuf.front());
-        }
+        // Read our new frame buffer with rescaled pixels
+        frameBufferObject->activate(true, GL_READ_FRAMEBUFFER_EXT);
+        glReadPixels(view_rect.x, view_rect.y, view_rect.w, view_rect.h, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, &videobuf.front());
+        frameBufferObject->deactivate();
 
 		// Copy pixel buffer (which is upside-down) to surface
 		for (int y = 0; y < view_rect.h; y++)

--- a/Source_Files/FFmpeg/Movie.h
+++ b/Source_Files/FFmpeg/Movie.h
@@ -25,6 +25,7 @@
  */
 
 #include "cseries.h"
+#include "OGL_FBO.h"
 #include <string.h>
 #include <vector>
 #include <SDL_thread.h>
@@ -66,6 +67,7 @@ private:
   SDL_sem *encodeReady;
   SDL_sem *fillReady;
   bool stillEncoding;
+  std::unique_ptr<FBO> frameBufferObject;
   
   Movie();  
   bool Setup();

--- a/Source_Files/RenderMain/OGL_FBO.cpp
+++ b/Source_Files/RenderMain/OGL_FBO.cpp
@@ -47,10 +47,11 @@ FBO::FBO(GLuint w, GLuint h, bool srgb) : _h(h), _w(w), _srgb(srgb) {
 	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 }
 
-void FBO::activate(bool clear) {
+void FBO::activate(bool clear, GLuint fboTarget) {
 	if (!active_chain.size() || active_chain.back() != this) {
 		active_chain.push_back(this);
-		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, _fbo);
+		_fboTarget = fboTarget;
+		glBindFramebufferEXT(fboTarget, _fbo);
 		glPushAttrib(GL_VIEWPORT_BIT);
 		glViewport(0, 0, _w, _h);
 		if (_srgb)
@@ -73,7 +74,7 @@ void FBO::deactivate() {
 			prev_fbo = active_chain.back()->_fbo;
 			prev_srgb = active_chain.back()->_srgb;
 		}
-		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, prev_fbo);
+		glBindFramebufferEXT(_fboTarget, prev_fbo);
 		if (prev_srgb)
 			glEnable(GL_FRAMEBUFFER_SRGB_EXT);
 		else

--- a/Source_Files/RenderMain/OGL_FBO.h
+++ b/Source_Files/RenderMain/OGL_FBO.h
@@ -34,6 +34,7 @@ class FBO {
 private:
 	GLuint _fbo;
 	GLuint _depthBuffer;
+	GLuint _fboTarget;
 	static std::vector<FBO *> active_chain;
 	
 public:
@@ -45,7 +46,7 @@ public:
 	FBO(GLuint w, GLuint h, bool srgb = false);
 	~FBO();
 	
-	void activate(bool clear = false);
+	void activate(bool clear = false, GLuint fboTarget = GL_FRAMEBUFFER_EXT);
 	void deactivate();
 	
 	void draw();

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -304,11 +304,6 @@ int Screen::width()
 	return MainScreenLogicalWidth();
 }
 
-float Screen::pixel_scale()
-{
-	return MainScreenPixelScale();
-}
-
 int Screen::window_height()
 {
 	return std::max(static_cast<short>(480), screen_mode.height);
@@ -352,6 +347,11 @@ SDL_Rect Screen::window_rect()
 	r.x = (width() - r.w) / 2;
 	r.y = (height() - r.h) / 2;
 	return r;
+}
+
+SDL_Rect Screen::OpenGLViewPort()
+{
+	return m_viewport_rect;
 }
 
 SDL_Rect Screen::view_rect()

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -826,7 +826,7 @@ static void change_screen_mode(int width, int height, int depth, bool nogl, bool
 	if (main_surface)
 	{
 		prev_width = main_surface->w;
-		prev_width = main_surface->h;
+		prev_height = main_surface->h;
 	}
 	
 	int vmode_height = height;

--- a/Source_Files/RenderOther/screen.h
+++ b/Source_Files/RenderOther/screen.h
@@ -93,7 +93,6 @@ namespace alephone
 
 		int height();
 		int width();
-		float pixel_scale();
 		int window_height();
 		int window_width();
 		bool hud();
@@ -106,7 +105,8 @@ namespace alephone
 		SDL_Rect map_rect();
 		SDL_Rect term_rect();
 		SDL_Rect hud_rect();
-		
+		SDL_Rect OpenGLViewPort();
+
 		void bound_screen(bool in_game = true);
 		void bound_screen_to_rect(SDL_Rect &r, bool in_game = true);
 		void scissor_screen_to_rect(SDL_Rect &r);


### PR DESCRIPTION
I'd call that a "partial" fix or a first step/idea for #205 since I'am not 100% happy with it but hope it may be discussed.
The problem occurs only when rendering with opengl, to get the frame to export on video, we read pixels from the default frame buffer which is ok when we are exporting a video with the same size than the screen resolution. If we are on fullscreen, we can no longer read the pixels on 1:1 from the frame buffer since the viewport scaled everything up.
The way this PR handles the problem is by creating another frame buffer and copy from the default one the pixels which are rescaled to fit the export video size.
The 2 issues that bother me with the fix are that first, frame buffer objects come from an opengl extension and may not be available on every runtime system. ~~If that's the case, I just force AlephOne window to change to windowed mode before exporting.~~ But we are already using those extensions in the code without checking they are availabe so at least it stays consistent...
Second is the way it's done by going from a resolution to a higher one with the fullscreen to finaly resize to get back to the first resolution, with obviously a quality drop, probably insignificant but still.