### PR TITLE
Move level script loading code upward to execute before map load

### DIFF
--- a/Source_Files/AlephOne.vcxproj
+++ b/Source_Files/AlephOne.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="GameWorld\devices.cpp" />
     <ClCompile Include="GameWorld\dynamic_limits.cpp" />
     <ClCompile Include="GameWorld\effects.cpp" />
+    <ClCompile Include="GameWorld\ephemera.cpp" />
     <ClCompile Include="GameWorld\flood_map.cpp" />
     <ClCompile Include="GameWorld\items.cpp" />
     <ClCompile Include="GameWorld\lightsource.cpp" />
@@ -160,6 +161,7 @@
     <ClCompile Include="GameWorld\world.cpp" />
     <ClCompile Include="Input\joystick_sdl.cpp" />
     <ClCompile Include="Input\mouse_sdl.cpp" />
+    <ClCompile Include="Lua\lua_ephemera.cpp" />
     <ClCompile Include="Lua\lua_hud_objects.cpp" />
     <ClCompile Include="Lua\lua_hud_script.cpp" />
     <ClCompile Include="Lua\lua_map.cpp" />
@@ -359,6 +361,7 @@
     <ClInclude Include="GameWorld\editor.h" />
     <ClInclude Include="GameWorld\effects.h" />
     <ClInclude Include="GameWorld\effect_definitions.h" />
+    <ClInclude Include="GameWorld\ephemera.h" />
     <ClInclude Include="GameWorld\flood_map.h" />
     <ClInclude Include="GameWorld\items.h" />
     <ClInclude Include="GameWorld\item_definitions.h" />
@@ -383,6 +386,7 @@
     <ClInclude Include="Input\joystick.h" />
     <ClInclude Include="Input\mouse.h" />
     <ClInclude Include="Lua\language_definition.h" />
+    <ClInclude Include="Lua\lua_ephemera.h" />
     <ClInclude Include="Lua\lua_hud_objects.h" />
     <ClInclude Include="Lua\lua_hud_script.h" />
     <ClInclude Include="Lua\lua_map.h" />

--- a/Source_Files/AlephOne.vcxproj.filters
+++ b/Source_Files/AlephOne.vcxproj.filters
@@ -724,6 +724,12 @@
     <ClCompile Include="shell_misc.cpp">
       <Filter>Main\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="GameWorld\ephemera.cpp">
+      <Filter>GameWorld\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Lua\lua_ephemera.cpp">
+      <Filter>Lua\Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CSeries\BStream.h">
@@ -1406,6 +1412,12 @@
     </ClInclude>
     <ClInclude Include="shell.h">
       <Filter>Main\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GameWorld\ephemera.h">
+      <Filter>GameWorld\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Lua\lua_ephemera.h">
+      <Filter>Lua\Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -1598,8 +1598,6 @@ bool process_map_wad(
 	assert(data_length == count*SIZEOF_polygon_data);
 	load_polygons(data, count, version);
 	
-	init_ephemera(dynamic_world->polygon_count);
-
 	/* Extract the lightsources */
 	if(restoring_game)
 	{
@@ -1814,6 +1812,8 @@ bool process_map_wad(
 	PhysicsModelLoadedEarlier = PhysicsModelLoaded;
 	
 	RunScriptChunks();
+
+	init_ephemera(dynamic_world->polygon_count);
 
 	/* If we are restoring the game, then we need to add the dynamic data */
 	if(restoring_game)

--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -750,6 +750,17 @@ bool goto_level(
 		SoundManager::instance()->UnloadAllSounds();
 	}
 
+	// LP: doing this here because level-specific MML may specify which level-specific
+	// textures to load.
+	if (!game_is_networked || use_map_file(((game_info*)NetGetGameData())->parent_checksum))
+	{
+		RunLevelScript(entry->level_number);
+	}
+	else
+	{
+		ResetLevelScript();
+	}
+
 #if !defined(DISABLE_NETWORKING)
 	/* If the game is networked, then I must call the network code to do the right */
 	/* thing with the map.. */
@@ -770,18 +781,8 @@ bool goto_level(
 	
 	if (success)
 	{
-		// LP: doing this here because level-specific MML may specify which level-specific
-		// textures to load.
 		// Being careful to carry over errors so that Pfhortran errors can be ignored
 		short SavedType, SavedError = get_game_error(&SavedType);
-		if (!game_is_networked || use_map_file(((game_info *) NetGetGameData())->parent_checksum))
-		{
-			RunLevelScript(entry->level_number);
-		}
-		else
-		{
-			ResetLevelScript();
-		}
 		RunScriptChunks();
 		if (!game_is_networked && number_of_players == 1)
 		{

--- a/Source_Files/Files/game_wad.h
+++ b/Source_Files/Files/game_wad.h
@@ -34,6 +34,7 @@ Aug 12, 2000 (Loren Petrich):
 */
 
 #include "cstypes.h"
+#include <map.h>
 #include <string>
 
 class FileSpecifier;
@@ -55,8 +56,9 @@ bool process_map_wad(struct wad_data *wad, bool restoring_game, short version);
 
 bool match_checksum_with_map(short vRefNum, long dirID, uint32 checksum, 
 	FileSpecifier& File);
-void set_map_file(FileSpecifier& File);
-
+void set_map_file(FileSpecifier& File, bool runScript = true);
+dynamic_data get_dynamic_data_from_save(FileSpecifier& File);
+void get_dynamic_data_from_wad(wad_data* wad, dynamic_data* dest);
 //CP Addition: get_map_file returns the FileDesc pointer to the current map
 FileSpecifier& get_map_file(void);
 

--- a/Source_Files/XML/XML_LevelScript.cpp
+++ b/Source_Files/XML/XML_LevelScript.cpp
@@ -248,8 +248,6 @@ void RunLevelScript(int LevelIndex)
 	LuaFound = false;
 #endif /* HAVE_LUA */
 	
-	ResetLevelScript();
-
 	GeneralRunScript(LevelScriptHeader::Default);
 	GeneralRunScript(LevelIndex);
 	


### PR DESCRIPTION
Just a move up of the level specific script loading code to execute before `load_level_from_map` function and thus before map objects are created. If not executed first, map embedded mml will be executed too late when it needs to replace shapes with others and so default shapes won't be replaced.
The problem happens on the first run of the level (start A1, start a level), not on the next ones (if you quit the level and restart it, correct shapes are loaded)
It also happens on film replays.

fixes #204 
fixes #201 