### PR TITLE
Workaround SDL_WINDOW_FULLSCREEN_DESKTOP issues.

### DIFF
--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -190,6 +190,8 @@ void Screen::Initialize(screen_mode_data* mode)
 		pixel_format_32 = *pf;
 		SDL_FreeFormat(pf);
 
+		SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
+
 		uncorrected_color_table = (struct color_table *)malloc(sizeof(struct color_table));
 		world_color_table = (struct color_table *)malloc(sizeof(struct color_table));
 		visible_color_table = (struct color_table *)malloc(sizeof(struct color_table));


### PR DESCRIPTION
With some window managers the fullscreen for alephone will be lost when changing workspaces. Additionally the video will break requiring the player to restart the game.

Setting `SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=0` in the environment works around this issue, but its more convenient doing it directly in alephone.

Note that when losing focus the game will still pause and can be unpaused by clicking the game. I think that behavior is intended?