### PR TITLE
Convert Mac OS Roman punctuation to UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Source_Files/packages
 .vs/
 *.vcxproj.user
 *.aps
+.vscode/

--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -1229,7 +1229,7 @@ bool load_game_from_file(FileSpecifier& File, bool run_scripts)
 			set_map_file(map_parent, false);
 		else
 		{
-			/* Tell the user theyÕre screwed when they try to leave this level. */
+			/* Tell the user they’re screwed when they try to leave this level. */
 			alert_user(infoError, strERRORS, cantFindMap, 0);
 
 			// LP addition: makes the game look normal
@@ -1642,7 +1642,7 @@ bool process_map_wad(
 			load_lights(data, count, version);
 		}
 
-		//	HACK!!!!!!!!!!!!!!! vulcan doesnÕt NONE .first_object field after adding scenery
+		//	HACK!!!!!!!!!!!!!!! vulcan doesn’t NONE .first_object field after adding scenery
 		{
 			for (count= 0; count<static_cast<size_t>(dynamic_world->polygon_count); ++count)
 			{

--- a/Source_Files/Files/tags.h
+++ b/Source_Files/Files/tags.h
@@ -34,13 +34,13 @@
 
 Feb 2, 2000 (Loren Petrich):
 	Changed application creator to 26.A "Aleph One"
-	Changed soundfile type to 'snd°' to be Marathon-Infinity compatible
+	Changed soundfile type to 'sndâˆž' to be Marathon-Infinity compatible
 
 Feb 3, 2000 (Loren Petrich):
-	Changed shapes-file type to 'shp°' to be Marathon-Infinity compatible
+	Changed shapes-file type to 'shpâˆž' to be Marathon-Infinity compatible
 
 Feb 4, 2000 (Loren Petrich):
-	Changed most of the other 2's to °'s to be Marathon-Infinity compatible,
+	Changed most of the other 2's to âˆž's to be Marathon-Infinity compatible,
 	except for the map file type.
 
 Feb 6, 2000 (Loren Petrich):

--- a/Source_Files/Files/wad.cpp
+++ b/Source_Files/Files/wad.cpp
@@ -35,11 +35,11 @@
 				passed in.
 
 Future Options:
-ğÊReentrancy
-ğÊUse malloc to actually make it possible to read the data as changes are made in the future?
+î€Â Reentrancy
+î€Â Use malloc to actually make it possible to read the data as changes are made in the future?
 
 	Saturday, October 28, 1995 1:13:38 PM- whoops.  Had a huge memory leak in the inflate wad
-		data.  Iâm fired.
+		data.  I'm fired.
 	
 Jan 30, 2000 (Loren Petrich):
 	Did some typecasts

--- a/Source_Files/GameWorld/devices.cpp
+++ b/Source_Files/GameWorld/devices.cpp
@@ -755,7 +755,7 @@ static void	change_panel_state(
                                 //MH: Lua script hook
                                 L_Call_Terminal_Enter(side->control_panel_permutation,player_index);
 				
-				/* this will handle changing levels, if necessary (i.e., if weÕre finished) */
+				/* this will handle changing levels, if necessary (i.e., if weâ€™re finished) */
 				enter_computer_interface(player_index, side->control_panel_permutation, calculate_level_completion_state());
 			}
 			break;

--- a/Source_Files/GameWorld/effect_definitions.h
+++ b/Source_Files/GameWorld/effect_definitions.h
@@ -38,7 +38,7 @@ enum /* flags */
 {
 	_end_when_animation_loops= 0x0001,
 	_end_when_transfer_animation_loops= 0x0002,
-	_sound_only= 0x0004, /* play the animationÕs initial sound and nothing else */
+	_sound_only= 0x0004, /* play the animationâ€™s initial sound and nothing else */
 	_make_twin_visible= 0x0008,
 	_media_effect= 0x0010
 };

--- a/Source_Files/GameWorld/effects.cpp
+++ b/Source_Files/GameWorld/effects.cpp
@@ -148,7 +148,7 @@ short new_effect(
 	return effect_index;
 }
 
-/* assumes ¶t==1 tick */
+/* assumes âˆ‚t==1 tick */
 void update_effects(
 	void)
 {
@@ -175,16 +175,16 @@ void update_effects(
 			}
 			else
 			{
-				/* update our objectÕs animation */
+				/* update our objectâ€™s animation */
 				animate_object(effect->object_index);
 				
-				/* if the effectÕs animation has terminated and weÕre supposed to deactive it, do so */
+				/* if the effectâ€™s animation has terminated and weâ€™re supposed to deactive it, do so */
 				if (((GET_OBJECT_ANIMATION_FLAGS(object)&_obj_last_frame_animated)&&(definition->flags&_end_when_animation_loops)) ||
 					((GET_OBJECT_ANIMATION_FLAGS(object)&_obj_transfer_mode_finished)&&(definition->flags&_end_when_transfer_animation_loops)))
 				{
 					remove_effect(effect_index);
 					
-					/* if weÕre supposed to make another item visible, do so */
+					/* if weâ€™re supposed to make another item visible, do so */
 					if (definition->flags&_make_twin_visible)
 					{
 						struct object_data *object= get_object_data(effect->data);
@@ -275,7 +275,7 @@ void teleport_object_out(
 	}
 }
 
-// if the given object isnÕt already teleporting in, do so
+// if the given object isnâ€™t already teleporting in, do so
 void teleport_object_in(
 	short object_index)
 {

--- a/Source_Files/GameWorld/effects.h
+++ b/Source_Files/GameWorld/effects.h
@@ -160,7 +160,7 @@ extern std::vector<effect_data> EffectList;
 /* ---------- prototypes/EFFECTS.C */
 
 short new_effect(world_point3d *origin, short polygon_index, short type, angle facing);
-void update_effects(void); /* assumes ¶t==1 tick */
+void update_effects(void); /* assumes âˆ‚t==1 tick */
 
 void remove_all_nonpersistent_effects(void);
 void remove_effect(short effect_index);

--- a/Source_Files/GameWorld/flood_map.cpp
+++ b/Source_Files/GameWorld/flood_map.cpp
@@ -163,7 +163,7 @@ short flood_map(
 			break;
 	}
 
-	/* if we found a node, mark it as expanded and add itÕs adjacent non-solid polygons to the search tree */
+	/* if we found a node, mark it as expanded and add itâ€™s adjacent non-solid polygons to the search tree */
 	if (lowest_cost_node_index!=NONE)
 	{
 		struct polygon_data *polygon;
@@ -305,7 +305,7 @@ static void add_node(
 				than the cost we are attempting to add, replace it (because we are doing
 				a best-first search, we are guarenteed never to find a better path to an
 				expanded node, and in fact if we find a path to a node we have already
-				expanded weÕre backtracking and can ignore the node) */
+				expanded weâ€™re backtracking and can ignore the node) */
 			assert(node_index>=0&&node_index<node_count);
 			node= nodes+node_index;
 			if (NODE_IS_EXPANDED(node)||node->cost<=cost) node= (struct node_data *) NULL;

--- a/Source_Files/GameWorld/items.cpp
+++ b/Source_Files/GameWorld/items.cpp
@@ -577,7 +577,7 @@ bool try_and_add_player_item(
 
 	switch (definition->item_kind)
 	{
-		case _powerup: /* powerups donÕt get added to your inventory */
+		case _powerup: /* powerups donâ€™t get added to your inventory */
 			if (legal_player_powerup(player_index, type))
 			{
 				process_player_powerup(player_index, type);

--- a/Source_Files/GameWorld/lightsource.cpp
+++ b/Source_Files/GameWorld/lightsource.cpp
@@ -26,7 +26,7 @@ Monday, March 6, 1995 9:41:50 PM  (Jason')
 Thursday, April 27, 1995 11:00:36 AM  (Jason')
 	functions with zero periods are skipped.
 Tuesday, June 13, 1995 6:13:29 PM  (Jason)
-	support for phases greater than a lightÕs initial period
+	support for phases greater than a lightâ€™s initial period
 Monday, July 10, 1995 5:20:26 PM  (Jason)
 	stateless (six phase) lights.
 
@@ -217,7 +217,7 @@ void update_lights(
 	{
 		if (SLOT_IS_USED(light))
 		{
-			/* update light phase; if weÕve overflowed our period change to the next state */
+			/* update light phase; if weâ€™ve overflowed our period change to the next state */
 			light->phase+= 1;
 			rephase_light(light_index);
 			

--- a/Source_Files/GameWorld/map.cpp
+++ b/Source_Files/GameWorld/map.cpp
@@ -155,9 +155,9 @@ static short Environments[NUMBER_OF_ENVIRONMENTS][NUMBER_OF_ENV_COLLECTIONS] =
 };
 
 /*
-static short e1[]= {_collection_walls1, _collection_scenery1, NONE}; // lhÕowon
-static short e2[]= {_collection_walls2, _collection_scenery2, NONE}; // lhÕowon
-static short e3[]= {_collection_walls3, _collection_scenery3, NONE}; // lhÕowon
+static short e1[]= {_collection_walls1, _collection_scenery1, NONE}; // lhâ€™owon
+static short e2[]= {_collection_walls2, _collection_scenery2, NONE}; // lhâ€™owon
+static short e3[]= {_collection_walls3, _collection_scenery3, NONE}; // lhâ€™owon
 static short e4[]= {_collection_walls4, _collection_scenery4, NONE}; // pathways (or marathon) (LP: jjaro)
 static short e5[]= {_collection_walls5, _collection_scenery5, NONE}; // pfhor ship
 
@@ -777,7 +777,7 @@ short attach_parasitic_object(
 	struct object_data *host_object, *parasite_object;
 	short parasite_index;
 
-	/* walk this objectÕs parasite list until we find the last parasite and then attach there */
+	/* walk this objectâ€™s parasite list until we find the last parasite and then attach there */
 	for (host_object= get_object_data(host_index);
 			host_object->parasitic_object!=NONE;
 			host_index= host_object->parasitic_object, host_object= get_object_data(host_index))
@@ -832,7 +832,7 @@ void remove_map_object(
 
 
 
-/* remove the object from the old_polygonÕs object list*/
+/* remove the object from the old_polygonâ€™s object list*/
 void
 remove_object_from_polygon_object_list(short object_index, short polygon_index)
 {
@@ -862,7 +862,7 @@ remove_object_from_polygon_object_list(short object_index)
 
 
 
-/* add the object to the new_polygonÕs object list */
+/* add the object to the new_polygonâ€™s object list */
 void
 add_object_to_polygon_object_list(short object_index, short polygon_index)
 {
@@ -949,7 +949,7 @@ perform_deferred_polygon_object_list_manipulations()
 
 
 
-/* if a new polygon index is supplied, it will be used, otherwise weÕll try to find the new
+/* if a new polygon index is supplied, it will be used, otherwise weâ€™ll try to find the new
 	polygon index ourselves */
 bool translate_map_object(
 	short object_index,
@@ -973,14 +973,14 @@ bool translate_map_object(
 			{
 				*(world_point2d *)new_location= get_polygon_data(old_polygon_index)->center;
 				new_polygon_index= old_polygon_index;
-				changed_polygons= true; /* tell the caller we switched polygons, even though we didnÕt */
+				changed_polygons= true; /* tell the caller we switched polygons, even though we didnâ€™t */
 				break;
 			}
 		}
 		while (line_index!=NONE);
 	}
 	
-	/* if we changed polygons, update the old and new polygonÕs linked lists of objects */
+	/* if we changed polygons, update the old and new polygonâ€™s linked lists of objects */
 	if (old_polygon_index!=new_polygon_index)
 	{
 		remove_object_from_polygon_object_list(object_index, old_polygon_index);
@@ -1045,10 +1045,10 @@ void get_object_shape_and_transfer_mode(
 		case _animated4:
 			switch (FACING4(theta))
 			{
-				case 0: view= 3; break; /* 90¡ (facing left) */
-				case 1: view= 0; break; /* 0¡ (facing forward) */
-				case 2: view= 1; break; /* -90¡ (facing right) */
-				case 3: view= 2; break; /* ±180¡ (facing away) */
+				case 0: view= 3; break; /* 90Â° (facing left) */
+				case 1: view= 0; break; /* 0Â° (facing forward) */
+				case 2: view= 1; break; /* -90Â° (facing right) */
+				case 3: view= 2; break; /* Â±180Â° (facing away) */
 				default:
 					data->collection_code = NONE; // Deliberate bad value
 					return;
@@ -1076,14 +1076,14 @@ void get_object_shape_and_transfer_mode(
 		case _animated8:
 			switch (FACING8(theta))
 			{
-				case 0: view= 3; break; /* 135¡ (facing left) */
-				case 1: view= 2; break; /* 90¡ (facing left) */
-				case 2: view= 1; break; /* 45¡ (facing left) */
-				case 3: view= 0; break; /* 0¡ (facing forward) */
-				case 4: view= 7; break; /* -45¡ (facing right) */
-				case 5: view= 6; break; /* -90¡ (facing right) */
-				case 6: view= 5; break; /* -135¡ (facing right) */
-				case 7: view= 4; break; /* ±180¡ (facing away) */
+				case 0: view= 3; break; /* 135Â° (facing left) */
+				case 1: view= 2; break; /* 90Â° (facing left) */
+				case 2: view= 1; break; /* 45Â° (facing left) */
+				case 3: view= 0; break; /* 0Â° (facing forward) */
+				case 4: view= 7; break; /* -45Â° (facing right) */
+				case 5: view= 6; break; /* -90Â° (facing right) */
+				case 6: view= 5; break; /* -135Â° (facing right) */
+				case 7: view= 4; break; /* Â±180Â° (facing away) */
 				default:
 					data->collection_code = NONE; // Deliberate bad value
 					return;
@@ -1192,7 +1192,7 @@ void animate_object(short object_index)
 }
 
 /* no longer called by RENDER.C; must be called by monster, projectile or effect controller;
-	now assumes ¶t==1 tick */
+	now assumes âˆ‚t==1 tick */
 void animate_object(
 	object_data* object,
 	int16_t sound_id)
@@ -1200,7 +1200,7 @@ void animate_object(
 	struct shape_animation_data *animation;
 	short animation_type= _obj_not_animated;
 
-	if (!OBJECT_IS_INVISIBLE(object)) /* invisible objects donÕt have valid .shape fields */
+	if (!OBJECT_IS_INVISIBLE(object)) /* invisible objects donâ€™t have valid .shape fields */
 	{
 		animation= get_shape_animation_data(object->shape);
 		if (!animation) return;
@@ -1378,7 +1378,7 @@ short world_point_to_polygon_index(
 }
 
 /* return the polygon on the other side of the given line from the given polygon (i.e., return
-	the polygon adjacent to line_index which isnÕt polygon_index).  can return NONE. */
+	the polygon adjacent to line_index which isnâ€™t polygon_index).  can return NONE. */
 short find_adjacent_polygon(
 	short polygon_index,
 	short line_index)
@@ -1517,7 +1517,7 @@ bool line_is_landscaped(
 	return landscaped;
 }
 
-/* return the line_index where the two polygons meet (or NONE if they donÕt meet) */
+/* return the line_index where the two polygons meet (or NONE if they donâ€™t meet) */
 short find_shared_line(
 	short polygon_index1,
 	short polygon_index2)
@@ -1603,9 +1603,9 @@ _fixed find_line_intersection(
 	
 	/* calculate the numerator and denominator to compute t; our basic strategy here is to
 		shift the numerator up by eight bits and the denominator down by eight bits, yeilding
-		a fixed number in [0,FIXED_ONE] for t.  this wonÕt work if the numerator is greater
-		than or equal to 2^24, or the numerator is less than 2^8.  the first case canÕt be
-		fixed in any decent way and shouldnÕt happen if we have small deltas.  the second case
+		a fixed number in [0,FIXED_ONE] for t.  this wonâ€™t work if the numerator is greater
+		than or equal to 2^24, or the numerator is less than 2^8.  the first case canâ€™t be
+		fixed in any decent way and shouldnâ€™t happen if we have small deltas.  the second case
 		is approximated with a denominator of 1 or -1 (depending on the sign of the old
 		denominator, although notice here that numbers in [1,2^8) will get downshifted to
 		zero and then set to one, while numbers in (-2^8,-1] will get downshifted to -1 and
@@ -1625,7 +1625,7 @@ _fixed find_line_intersection(
 	return t;
 }
 
-/* closest_point may be the same as p; if weÕre within 1 of our source point in either
+/* closest_point may be the same as p; if weâ€™re within 1 of our source point in either
 	direction assume that we are actually at the source point */
 _fixed closest_point_on_line(
 	world_point2d *e0,
@@ -1650,7 +1650,7 @@ _fixed closest_point_on_line(
 	if (!(denominator>>= 8)) denominator= 1;
 	t= numerator/denominator;
 
-	/* if weÕve only changed by ±1 in x and y, return the original p to avoid sliding down
+	/* if weâ€™ve only changed by Â±1 in x and y, return the original p to avoid sliding down
 		the edge on successive calls */
 	calculated_closest_point.x= e0->x + FIXED_INTEGERAL_PART(t*line_dx);
 	calculated_closest_point.y= e0->y + FIXED_INTEGERAL_PART(t*line_dy);
@@ -1739,8 +1739,8 @@ enum /* keep out states */
 {
 	_first_line_pass,
 	_second_line_pass, /* if _first_line_pass yeilded more than one collision we have to go back
-		and make sure we donÕt hit anything (or only hit one thing which we hit the first time) */
-	_second_line_pass_made_contact, /* weÕve already hit one thing we hit last time, if we hit
+		and make sure we donâ€™t hit anything (or only hit one thing which we hit the first time) */
+	_second_line_pass_made_contact, /* weâ€™ve already hit one thing we hit last time, if we hit
 		anything else then we abort */
 	_aborted, /* if we hit two lines on the second pass, we give up */
 	_point_pass /* checking against all points (and hit as many as we can) */
@@ -1817,7 +1817,7 @@ bool keep_line_segment_out_of_walls(
 
 					/* if a) this line is solid, b) the new polygon is farther than maximum_delta height
 						above our feet, or c) the new polygon is lower than the top of our head then
-						we canÕt move into the new polygon */
+						we canâ€™t move into the new polygon */
 					if (LINE_IS_SOLID(line) || adjacent_polygon == NULL ||
 						adjacent_polygon->floor_height-p1->z>maximum_delta_height ||
 						adjacent_polygon->ceiling_height-p1->z<height ||
@@ -1843,7 +1843,7 @@ bool keep_line_segment_out_of_walls(
 								}
 								else
 								{
-									/* forget it; we hit something we didnÕt hit the first time */
+									/* forget it; we hit something we didnâ€™t hit the first time */
 									state= _aborted;
 								}
 								break;
@@ -1882,7 +1882,7 @@ bool keep_line_segment_out_of_walls(
 	}
 	while (state==_second_line_pass);
 
-	/* if we didnÕt abort while clipping lines, try clipping against points... */
+	/* if we didnâ€™t abort while clipping lines, try clipping against points... */
 	if (state!=_aborted)
 	{
 		for (i=0;i<polygon->point_exclusion_zone_count;++i)
@@ -1994,7 +1994,7 @@ int32 point_to_line_segment_distance_squared(
 	else
 	{
 		/* if BA dot AP is greather than or equal to zero, d is the distance between A and P
-			(we donÕt calculate BA and use -AB instead */
+			(we donâ€™t calculate BA and use -AB instead */
 		if (abx*apx+aby*apy<=0)
 		{
 			distance= apx*apx + apy*apy;
@@ -2132,7 +2132,7 @@ bool change_polygon_height(
 		polygon->ceiling_height= new_ceiling_height;
 		
 		/* the highest_adjacent_floor, lowest_adjacent_ceiling and supporting_polygon_index fields
-			of all of this polygonÕs endpoints and lines are potentially invalid now.  to assure
+			of all of this polygonâ€™s endpoints and lines are potentially invalid now.  to assure
 			that they are correct, recalculate them using the appropriate redundant functions.
 			to do things quickly, slam them yourself.  only these three fields of are invalid,
 			nothing else is effected by the height change. */
@@ -2141,7 +2141,7 @@ bool change_polygon_height(
 	return legal_change;
 }
 
-/* we used to check to see that the point in question was within the playerÕs view
+/* we used to check to see that the point in question was within the playerâ€™s view
 	cone, but that was queer because stuff would appear behind him all the time
 	(which was completely inconvient when this happened to monsters) */
 /*
@@ -2249,7 +2249,7 @@ bool line_is_obstructed(
 		{
 			/* the polygon we ended up in is different than the polygon the caller thinks the
 				destination point is in; this probably means that the source is on a different
-				level than the caller, but it could also easily mean that weÕre dealing with
+				level than the caller, but it could also easily mean that weâ€™re dealing with
 				weird boundary conditions of find_line_crossed_leaving_polygon() */
 			if (polygon_index!=polygon_index2) 
 			{
@@ -2316,7 +2316,7 @@ void turn_object_to_shit( /* garbage that is, garbage */
 			could be really obvious... but who pays attention to dead bodies anyway?) */
 	  if (dynamic_world->garbage_object_count>= (graphics_preferences->double_corpse_limit? MAXIMUM_GARBAGE_OBJECTS_PER_MAP * 2 : MAXIMUM_GARBAGE_OBJECTS_PER_MAP))
 	    {
-			/* find a garbage object to remove, and do so (weÕre certain that many exist) */
+			/* find a garbage object to remove, and do so (weâ€™re certain that many exist) */
 			for (object_index= garbage_object_index, object= garbage_object;
 					SLOT_IS_FREE(object) || GET_OBJECT_OWNER(object)!=_object_is_garbage;
 					object_index= (object_index==MAXIMUM_OBJECTS_PER_MAP-1) ? 0 : (object_index+1), object= objects+object_index)
@@ -2619,7 +2619,7 @@ void _sound_add_ambient_sources_proc(
 		// add ambient sound image
 		if (media && listener->point.z<media->height)
 		{
-			// if weÕre under media donÕt play the ambient sound image
+			// if weâ€™re under media donâ€™t play the ambient sound image
 			add_one_ambient_sound_source((struct ambient_sound_data *)data, (world_location3d *) NULL, listener,
 				get_media_sound(listener_polygon->media_index, _media_snd_ambient_under), MAXIMUM_SOUND_VOLUME);
 			under_media= true;
@@ -2638,7 +2638,7 @@ void _sound_add_ambient_sources_proc(
 					listener_polygon->ambient_sound_image_index = NONE;
 			}
 
-			// if weÕre over media, play that ambient sound image
+			// if weâ€™re over media, play that ambient sound image
 			if (media && (media->height>=listener_polygon->floor_height || !MEDIA_SOUND_OBSTRUCTED_BY_FLOOR(media)))
 			{
 				source= *listener, source.point.z= media->height;

--- a/Source_Files/GameWorld/map.h
+++ b/Source_Files/GameWorld/map.h
@@ -322,7 +322,7 @@ const int SIZEOF_random_sound_image_data = 32;
 #define CLEAR_OBJECT_RENDERED_FLAG(o) ((o)->flags&=(uint16)~0x4000)
 
 /* this field is only valid after transmogrify_object_shape is called; in terms of our pipeline, that
-	means that itÕs only valid if OBJECT_WAS_RENDERED returns true *and* was cleared before
+	means that itâ€™s only valid if OBJECT_WAS_RENDERED returns true *and* was cleared before
 	the last call to render_scene() ... this means that if OBJECT_WAS_RENDERED returns false,
 	the monster and projectile managers will probably call transmogrif_object_shape themselves.
 	for reasons beyond this scope of this comment to explain, the keyframe cannot be frame zero!
@@ -798,7 +798,7 @@ struct object_frequency_definition
 	
 	int16 initial_count;   // number that initially appear. can be greater than maximum_count
 	int16 minimum_count;   // this number of objects will be maintained.
-	int16 maximum_count;   // canÕt exceed this, except at the beginning of the level.
+	int16 maximum_count;   // canâ€™t exceed this, except at the beginning of the level.
 	
 	int16 random_count;    // maximum random occurences of the object
 	uint16 random_chance;    // in (0, 65535]
@@ -1168,7 +1168,7 @@ struct shape_and_transfer_mode
 void get_object_shape_and_transfer_mode(world_point3d *camera_location, short object_index, struct shape_and_transfer_mode *data);
 void get_object_shape_and_transfer_mode(world_point3d *camera_location, object_data* object, shape_and_transfer_mode *data);
 void set_object_shape_and_transfer_mode(short object_index, shape_descriptor shape, short transfer_mode);
-void animate_object(short object_index); /* assumes ¶t==1 tick */
+void animate_object(short object_index); /* assumes âˆ‚t==1 tick */
 void animate_object(object_data* data, int16_t object_index);
 bool randomize_object_sequence(short object_index, shape_descriptor shape);
 

--- a/Source_Files/GameWorld/map_constructors.cpp
+++ b/Source_Files/GameWorld/map_constructors.cpp
@@ -60,12 +60,12 @@ const bool DoIncorrectCountVWarn = true;
 #include <vector>
 
 /*
-maps of one polygon donÕt have their impassability information computed
+maps of one polygon donâ€™t have their impassability information computed
 
 //detached polygons (i.e., shadows) and their twins will not have their neighbor polygon lists correctly computed
 //adjacent polygons should be precalculated in the polygon structure
-//intersecting_flood_proc canÕt store side information (using sign) with line index zero
-//keep_line_segment_out_of_walls() canÕt use precalculated height information and should do weird things next to elevators and doors
+//intersecting_flood_proc canâ€™t store side information (using sign) with line index zero
+//keep_line_segment_out_of_walls() canâ€™t use precalculated height information and should do weird things next to elevators and doors
 */
 
 /* ---------- structures */
@@ -287,7 +287,7 @@ void recalculate_redundant_endpoint_data(
 }
 
 /* calculates line length, highest adjacent floor and lowest adjacent ceiling and calls
-	recalculate_redundant_side_data() on the lineÕs sides */
+	recalculate_redundant_side_data() on the lineâ€™s sides */
 void recalculate_redundant_line_data(
 	short line_index)
 {
@@ -617,7 +617,7 @@ void precalculate_map_indexes(
 	
 	for (;polygon_index< dynamic_world->polygon_count;++polygon,++polygon_index)
 	{
-		if (!POLYGON_IS_DETACHED(polygon)) /* weÕll handle detached polygons during the second pass */
+		if (!POLYGON_IS_DETACHED(polygon)) /* weâ€™ll handle detached polygons during the second pass */
 		{
 			// short line_indexes[MAXIMUM_INTERSECTING_INDEXES], endpoint_indexes[MAXIMUM_INTERSECTING_INDEXES],
 			// 	polygon_indexes[MAXIMUM_INTERSECTING_INDEXES];
@@ -710,7 +710,7 @@ static long intersecting_flood_proc(
 	struct intersecting_flood_data *data=vdata;
 	struct polygon_data *polygon= get_polygon_data(source_polygon_index);
 	struct polygon_data *original_polygon= get_polygon_data(data->original_polygon_index);
-	bool keep_searching= false; // donÕt flood any deeper unless we find something close enough 
+	bool keep_searching= false; // donâ€™t flood any deeper unless we find something close enough
 	short i = 0, j = 0;
      unsigned long new_broken_note;
 	//(void) (line_index,destination_polygon_index);
@@ -740,7 +740,7 @@ static long intersecting_flood_proc(
 		}
 	}
 
-	// if any part of this polygon is close enough to our original polygon, remember itÕs index 
+	// if any part of this polygon is close enough to our original polygon, remember itâ€™s index
 	if (keep_searching)
 	{
 		for (j=0;j<data->polygon_count;++j)
@@ -792,7 +792,7 @@ void try_and_add_line(
 		(line->lowest_adjacent_ceiling<original_polygon->ceiling_height) ||
      (line->highest_adjacent_floor>original_polygon->floor_height))
 	{
-		// make sure this line isnÕt already in the line list 
+		// make sure this line isnâ€™t already in the line list
 		for (i=0; i<data->line_count; ++i)
 		{
 			if (data->line_indexes[i]==line_index)
@@ -819,7 +819,7 @@ void try_and_add_line(
 	
 	return keep_searching;
 }
-			// add this endpoint if it isnÕt already in the intersecting endpoint list 
+			// add this endpoint if it isnâ€™t already in the intersecting endpoint list
 			for (j=0;j<data->endpoint_count;++j)
 			{
 				if (data->endpoint_indexes[j]==polygon->endpoint_indexes[i])
@@ -869,7 +869,7 @@ static int32 intersecting_flood_proc(
 	struct intersecting_flood_data *data=(struct intersecting_flood_data *)vdata;
 	struct polygon_data *polygon= get_polygon_data(source_polygon_index);
 	struct polygon_data *original_polygon= get_polygon_data(data->original_polygon_index);
-	bool keep_searching= false; /* donÕt flood any deeper unless we find something close enough */
+	bool keep_searching= false; /* donâ€™t flood any deeper unless we find something close enough */
 	unsigned short i, j;
 	(void) (line_index);
 	(void) (destination_polygon_index);
@@ -880,7 +880,7 @@ static int32 intersecting_flood_proc(
 		/* update our running line and endpoint lists */	
 		for (i=0;i<polygon->vertex_count;++i)
 		{
-			/* add this line if it isnÕt already in the intersecting line list */
+			/* add this line if it isnâ€™t already in the intersecting line list */
 			for (j=0;j<LineIndices.size();++j)
 			{
 				if (LineIndices[j]==polygon->line_indexes[i] ||
@@ -921,7 +921,7 @@ static int32 intersecting_flood_proc(
 				}
 			}
 			
-			/* add this endpoint if it isnÕt already in the intersecting endpoint list */
+			/* add this endpoint if it isnâ€™t already in the intersecting endpoint list */
 			for (j=0;j<EndpointIndices.size();++j)
 			{
 				if (EndpointIndices[j]==polygon->endpoint_indexes[i])
@@ -952,7 +952,7 @@ static int32 intersecting_flood_proc(
 		}
 	}
 
-	/* if any part of this polygon is close enough to our original polygon, remember itÕs index */
+	/* if any part of this polygon is close enough to our original polygon, remember itâ€™s index */
 	if (keep_searching)
 	{
 		for (j=0;j<PolygonIndices.size();++j)
@@ -992,7 +992,7 @@ static long intersecting_flood_proc(
 	struct intersecting_flood_data *data=(struct intersecting_flood_data *)vdata;
 	struct polygon_data *polygon= get_polygon_data(source_polygon_index);
 	struct polygon_data *original_polygon= get_polygon_data(data->original_polygon_index);
-	bool keep_searching= false; // donÕt flood any deeper unless we find something close enough
+	bool keep_searching= false; // donâ€™t flood any deeper unless we find something close enough
      short i, j;
 	(void) (line_index);
 	(void) (destination_polygon_index);
@@ -1003,7 +1003,7 @@ static long intersecting_flood_proc(
 		// update our running line and endpoint lists 
 		for (i=0;i<polygon->vertex_count;++i)
 		{
-			// add this line if it isnÕt already in the intersecting line list 
+			// add this line if it isnâ€™t already in the intersecting line list
 			for (j=0;j<data->line_count;++j)
 			{
 				if (data->line_indexes[j]==polygon->line_indexes[i] ||
@@ -1048,7 +1048,7 @@ static long intersecting_flood_proc(
 				}
 			}
 			
-			// add this endpoint if it isnÕt already in the intersecting endpoint list 
+			// add this endpoint if it isnâ€™t already in the intersecting endpoint list
 			for (j=0;j<data->endpoint_count;++j)
 			{
 				if (data->endpoint_indexes[j]==polygon->endpoint_indexes[i])
@@ -1087,7 +1087,7 @@ static long intersecting_flood_proc(
 		}
 	}
 
-	// if any part of this polygon is close enough to our original polygon, remember itÕs index 
+	// if any part of this polygon is close enough to our original polygon, remember itâ€™s index
 	if (keep_searching)
 	{
 		for (j=0;j<data->polygon_count;++j)

--- a/Source_Files/GameWorld/marathon2.cpp
+++ b/Source_Files/GameWorld/marathon2.cpp
@@ -680,7 +680,7 @@ bool entering_map(bool restoring_saved)
 	if (game_is_networked) success= NetSync(); /* make sure everybody is ready */
 #endif // !defined(DISABLE_NETWORKING)
 
-	/* make sure nobodyÕs holding a weapon illegal in the new environment */
+	/* make sure nobodyâ€™s holding a weapon illegal in the new environment */
 	check_player_weapons_for_environment_change();
 
 #if !defined(DISABLE_NETWORKING)
@@ -688,7 +688,7 @@ bool entering_map(bool restoring_saved)
 #endif // !defined(DISABLE_NETWORKING)
 	randomize_scenery_shapes();
 
-//	reset_action_queues(); //¦¦
+//	reset_action_queues(); //Â¶Â¶
 //	sync_heartbeat_count();
 //	set_keyboard_controller_status(true);
 
@@ -787,13 +787,13 @@ short calculate_level_completion_state(
 {
 	short completion_state= _level_finished;
 	
-	/* if there are any monsters left on an extermination map, we havenÕt finished yet */
+	/* if there are any monsters left on an extermination map, we havenâ€™t finished yet */
 	if (static_world->mission_flags&_mission_extermination)
 	{
 		if (live_aliens_on_map()) completion_state= _level_unfinished;
 	}
 	
-	/* if there are any polygons which must be explored and have not been entered, weÕre not done */
+	/* if there are any polygons which must be explored and have not been entered, weâ€™re not done */
 	if ((static_world->mission_flags&_mission_exploration) ||
 	    (static_world->mission_flags&_mission_exploration_m1))
 	{
@@ -810,13 +810,13 @@ short calculate_level_completion_state(
 		}
 	}
 	
-	/* if there are any items left on this map, weÕre not done */
+	/* if there are any items left on this map, weâ€™re not done */
 	if (static_world->mission_flags&_mission_retrieval)
 	{
 		if (unretrieved_items_on_map()) completion_state= _level_unfinished;
 	}
 	
-	/* if there are any untoggled repair switches on this level then weÕre not there */
+	/* if there are any untoggled repair switches on this level then weâ€™re not there */
 	if ((static_world->mission_flags&_mission_repair) ||
 	    (static_world->mission_flags&_mission_repair_m1))
 	{
@@ -825,7 +825,7 @@ short calculate_level_completion_state(
 		if (untoggled_repair_switches_on_level(only_last_switch)) completion_state= _level_unfinished;
 	}
 
-	/* if weÕve finished the level, check failure conditions */
+	/* if weâ€™ve finished the level, check failure conditions */
 	if (completion_state==_level_finished)
 	{
 		/* if this is a rescue mission and more than half of the civilians died, the mission failed */

--- a/Source_Files/GameWorld/monster_definitions.h
+++ b/Source_Files/GameWorld/monster_definitions.h
@@ -149,7 +149,7 @@ enum /* flags */
 	_monster_major= 0x8, /* type -1 is minor */
 	_monster_minor= 0x10, /* type +1 is major */
 	_monster_cannot_be_dropped= 0x20, /* low levels cannot skip this monster */
-	_monster_floats= 0x40, /* exclusive from flys; forces the monster to take +¶h gradually */
+	_monster_floats= 0x40, /* exclusive from flys; forces the monster to take +âˆ‚h gradually */
 	_monster_cannot_attack= 0x80, /* monster has no weapons and cannot attack (runs constantly to safety) */
 	_monster_uses_sniper_ledges= 0x100, /* sit on ledges and hurl shit at the player (ranged attack monsters only) */
 	_monster_is_invisible= 0x200, /* this monster uses _xfer_invisibility */
@@ -158,9 +158,9 @@ enum /* flags */
 	_monster_is_berserker= 0x1000, /* below 1/4 vitality this monster goes berserk */
 	_monster_is_enlarged= 0x2000, /* monster is 1.25 times normal height */
 	_monster_has_delayed_hard_death= 0x4000, /* always dies soft, then switches to hard */
-	_monster_fires_symmetrically= 0x8000, /* fires at ±dy, simultaneously */
-	_monster_has_nuclear_hard_death= 0x10000, /* playerÕs screen whites out and slowly recovers */
-	_monster_cant_fire_backwards= 0x20000, /* monster canÕt turn more than 135¡ to fire */
+	_monster_fires_symmetrically= 0x8000, /* fires at Â±dy, simultaneously */
+	_monster_has_nuclear_hard_death= 0x10000, /* playerâ€™s screen whites out and slowly recovers */
+	_monster_cant_fire_backwards= 0x20000, /* monster canâ€™t turn more than 135Â° to fire */
 	_monster_can_die_in_flames= 0x40000, /* uses humanoid flaming body shape */
 	_monster_waits_with_clear_shot= 0x80000, /* will sit and fire (slowly) if we have a clear shot */
 	_monster_is_tiny= 0x100000, /* 0.25-size normal height */
@@ -206,7 +206,7 @@ struct attack_definition
 {
 	int16 type;
 	int16 repetitions;
-	angle error; /* ±error is added to the firing angle */
+	angle error; /* Â±error is added to the firing angle */
 	world_distance range; /* beyond which we cannot attack */
 	int16 attack_shape; /* attack occurs when keyframe is displayed */
 	
@@ -222,7 +222,7 @@ struct monster_definition /* <128 bytes */
 	uint32 flags;
 
 	int32 _class; /* our class */
-	int32 friends, enemies; /* bit fields of what classes we consider friendly and what types we donÕt like */
+	int32 friends, enemies; /* bit fields of what classes we consider friendly and what types we donâ€™t like */
 
 	_fixed sound_pitch;
 	int16 activation_sound, friendly_activation_sound, clear_sound;
@@ -230,7 +230,7 @@ struct monster_definition /* <128 bytes */
 	int16 flaming_sound; /* the scream we play when we go down in flames */
 	int16 random_sound, random_sound_mask; /* if moving and locked play this sound if we get time and our mask comes up */
 
-	int16 carrying_item_type; /* an item type we might drop if we donÕt explode */
+	int16 carrying_item_type; /* an item type we might drop if we donâ€™t explode */
 
 	world_distance radius, height;
 	world_distance preferred_hover_height;
@@ -268,7 +268,7 @@ struct monster_definition /* <128 bytes */
 struct monster_definition monster_definitions[NUMBER_OF_MONSTER_TYPES];
 const struct monster_definition original_monster_definitions[NUMBER_OF_MONSTER_TYPES]=
 {
-	{ /* _monster_marine (canÕt be used as a regular monster) */
+	{ /* _monster_marine (canâ€™t be used as a regular monster) */
 		_collection_player, /* shape collection */
 		20, 0, 0, /* vitality, immunities, weaknesses */
 		_monster_cannot_be_dropped|_monster_can_die_in_flames, /* flags */

--- a/Source_Files/GameWorld/monsters.cpp
+++ b/Source_Files/GameWorld/monsters.cpp
@@ -27,11 +27,11 @@ Friday, September 30, 1994 5:48:25 PM (Jason)
 Monday, December 5, 1994 9:07:37 PM  (Jason)
 	rebellion environment function (all _clients hate all _pfhor).
 Wednesday, February 1, 1995 2:29:01 AM  (Jason')
-	kill_sounds; invisible monsters donÕt move
+	kill_sounds; invisible monsters donâ€™t move
 Wednesday, June 14, 1995 10:14:24 AM  (Jason)
 	rewrite for marathon2 (halfway done).
 Monday, July 10, 1995 11:49:06 AM  (Jason)
-	rewrite for marathon2 done.  my bobs wonÕt listen to your fucking whining.
+	rewrite for marathon2 done.  my bobs wonâ€™t listen to your fucking whining.
 
 Jan 30, 2000 (Loren Petrich):
 	Added some typecasts
@@ -132,7 +132,7 @@ Jan 12, 2003 (Loren Petrich)
 #define MONSTER_MINIMUM_EXTERNAL_VELOCITY (10*MONSTER_EXTERNAL_DECELERATION)
 #define MONSTER_MAXIMUM_EXTERNAL_VELOCITY (TICKS_PER_SECOND*MONSTER_EXTERNAL_DECELERATION)
 
-/* the height below which we donÕt bother to float up a ledge (we just run right over it) */
+/* the height below which we donâ€™t bother to float up a ledge (we just run right over it) */
 #define MINIMUM_FLOATING_HEIGHT WORLD_ONE_FOURTH
 
 #define MINIMUM_ACTIVATION_SEPARATION TICKS_PER_SECOND
@@ -408,7 +408,7 @@ short new_monster(
 					if (location->flags&_map_object_is_deaf) flags|= _monster_is_deaf;
 					if (location->flags&_map_object_floats) flags|= _monster_teleports_out_when_deactivated;
 				
-					/* initialize the monster_data structure; we donÕt touch most of the fields here
+					/* initialize the monster_data structure; we donâ€™t touch most of the fields here
 						because the monster is initially inactive (and they will be initialized when the
 						monster is activated) */
 					monster->type= monster_type;
@@ -422,7 +422,7 @@ short new_monster(
 					monster->sound_location= object->location;
 					MARK_SLOT_AS_USED(monster);
 					
-					/* initialize the monsterÕs object */
+					/* initialize the monsterâ€™s object */
 					if (definition->flags&_monster_is_invisible) object->transfer_mode= _xfer_invisibility;
 					if (definition->flags&_monster_is_subtly_invisible) object->transfer_mode= _xfer_subtle_invisibility;
 					if (definition->flags&_monster_is_enlarged) object->flags|= _object_is_enlarged;
@@ -458,7 +458,7 @@ short new_monster(
 	return monster_index;
 }
 
-/* assumes ¶t==1 tick */
+/* assumes âˆ‚t==1 tick */
 void move_monsters(
 	void)
 {
@@ -488,8 +488,8 @@ void move_monsters(
 	
 					update_monster_vertical_physics_model(monster_index);
 	
-					/* update our objectÕs animation unless weÕre ÔsufferingÕ from an external velocity
-						or weÕre airborne (if weÕre a flying or floating monster, ignore both of these */
+					/* update our objectâ€™s animation unless weâ€™re â€˜sufferingâ€™ from an external velocity
+						or weâ€™re airborne (if weâ€™re a flying or floating monster, ignore both of these */
 					if ((!monster->external_velocity&&!monster->vertical_velocity) ||
 						(film_profile.ketchup_fix && (monster->action==_monster_is_attacking_close||monster->action==_monster_is_attacking_far)) ||
 						((monster->action!=_monster_is_being_hit||!monster->external_velocity) && (definition->flags&(_monster_floats|_monster_flys))))
@@ -504,7 +504,7 @@ void move_monsters(
 						switch (monster->mode)
 						{
 							case _monster_unlocked:
-								/* if this monster is unlocked and we havenÕt already given a monster time,
+								/* if this monster is unlocked and we havenâ€™t already given a monster time,
 									call find_closest_appropriate_target() */
 								change_monster_target(monster_index, find_closest_appropriate_target(monster_index, false));
 								monster_got_time= true;
@@ -512,7 +512,7 @@ void move_monsters(
 							
 							case _monster_lost_lock:
 							case _monster_losing_lock:
-								/* if this monster has lost or is losing lock and we havenÕt already given a monster
+								/* if this monster has lost or is losing lock and we havenâ€™t already given a monster
 									time, check to see if his target has become visible again */
 								if (clear_line_of_sight(monster_index, monster->target_index, false))
 								{
@@ -526,8 +526,8 @@ void move_monsters(
 						if (monster_got_time) dynamic_world->last_monster_index_to_get_time= monster_index;
 					}
 		
-					/* if this monster needs a path, generate one (unless weÕve already generated a
-						path this frame in which case weÕll wait until next frame, UNLESS the monster
+					/* if this monster needs a path, generate one (unless weâ€™ve already generated a
+						path this frame in which case weâ€™ll wait until next frame, UNLESS the monster
 						has no path in which case it needs one regardless) */
 					if (MONSTER_NEEDS_PATH(monster) && !MONSTER_IS_DYING(monster) && !MONSTER_IS_ATTACKING(monster) &&
 						((!monster_built_path && monster_index>dynamic_world->last_monster_index_to_build_path) || monster->path==NONE))
@@ -540,8 +540,8 @@ void move_monsters(
 						}
 					}
 					
-					/* itÕs possible that we couldnÕt get where we wanted to go, or that we arrived there
-						and deactivated ourselves; if this happens we donÕt want to continue processing
+					/* itâ€™s possible that we couldnâ€™t get where we wanted to go, or that we arrived there
+						and deactivated ourselves; if this happens we donâ€™t want to continue processing
 						the monster as if it were active */
 					if (MONSTER_IS_ACTIVE(monster))
 					{
@@ -563,7 +563,7 @@ void move_monsters(
 									{
 										/* after an attack has been initiated successfully we need to return to
 											_monster_is_moving action, kill our path and ask for a new one
-											(because weÕre pointed in the wrong direction now) */
+											(because weâ€™re pointed in the wrong direction now) */
 										set_monster_action(monster_index,
 											(monster->attack_repetitions<0 && (definition->flags&_monster_waits_with_clear_shot) && MONSTER_IS_LOCKED(monster)) ?
 												_monster_is_waiting_to_attack_again : _monster_is_moving);
@@ -652,10 +652,10 @@ void move_monsters(
 		
 		/* WARNING: a large number of unusual things could have happened here, including the monster
 			being dead, his slot being free, and his object having been removed from the map; in other
-			words, itÕs probably not a good idea to do any postprocessing here */
+			words, itâ€™s probably not a good idea to do any postprocessing here */
 	}
 	
-	/* either there are no unlocked monsters or Ôdynamic_world->last_monster_index_to_get_timeÕ is higher than
+	/* either there are no unlocked monsters or â€˜dynamic_world->last_monster_index_to_get_timeâ€™ is higher than
 		all of them (so we reset it to zero) ... same for paths */
 	if (!monster_got_time) dynamic_world->last_monster_index_to_get_time= -1;
 	if (!monster_built_path) dynamic_world->last_monster_index_to_build_path= -1;
@@ -691,7 +691,7 @@ void monster_died(
 
 //	dprintf("monster #%d is dead;g;", target_index);
 
-	/* orphan this monsterÕs projectiles if they donÕt belong to a player (playerÕs monster
+	/* orphan this monsterâ€™s projectiles if they donâ€™t belong to a player (playerâ€™s monster
 		slots are always valid and we want to correctly attribute damage and kills that ocurr
 		after a player dies) */
 	if (!MONSTER_IS_PLAYER(monster)) orphan_projectiles(target_index);
@@ -747,8 +747,8 @@ void initialize_monsters_for_new_level(
 	struct monster_data *monster;
 	short monster_index;
 
-	/* when a level is loaded after being saved all of an active monsterÕs data is still intact,
-		but itÕs path no longer exists.  this function resets all monsters so that they recalculate
+	/* when a level is loaded after being saved all of an active monsterâ€™s data is still intact,
+		but itâ€™s path no longer exists.  this function resets all monsters so that they recalculate
 		their paths, first thing. */
 	for (monster_index=0,monster=monsters;monster_index<MAXIMUM_MONSTERS_PER_MAP;++monster_index,++monster)
 	{
@@ -792,7 +792,7 @@ void mark_monster_collections(
 		/* mark the monster collection */
 		mark_collection(definition->collection, loading);
 		
-		/* mark the monsterÕs projectileÕs collection */
+		/* mark the monsterâ€™s projectileâ€™s collection */
 		mark_projectile_collections(definition->ranged_attack.type, loading);
 		mark_projectile_collections(definition->melee_attack.type, loading);
 	}
@@ -827,7 +827,7 @@ void activate_nearby_monsters(
 		short need_target_count= 0;
 		int32 flood_flags= flags;
 		
-		/* flood out from the target monsterÕs polygon, searching through the object lists of all
+		/* flood out from the target monsterâ€™s polygon, searching through the object lists of all
 			polygons we encounter */
 		polygon_index= flood_map(polygon_index, max_cost, monster_activation_flood_proc, _flagged_breadth_first, &flood_flags);
 		while (polygon_index!=NONE)
@@ -855,8 +855,8 @@ void activate_nearby_monsters(
 
 //					!MONSTER_IS_PLAYER(caller) || TYPE_IS_FRIEND(get_monster_definition(aggressor->type), caller->type) || caller_hostile
 					
-					/* donÕt activate players or ourselves, and only activate monsters on glue polygons
-						if they have previously been activated or weÕve been explicitly told to */
+					/* donâ€™t activate players or ourselves, and only activate monsters on glue polygons
+						if they have previously been activated or weâ€™ve been explicitly told to */
 					if (!MONSTER_IS_PLAYER(aggressor) && caller_index!=aggressor_index && target_index!=aggressor_index &&
 						(!(flood_flags&_passed_zone_border) || (!(aggressor->flags&_monster_has_never_been_activated))) &&
 						((flood_flags&_activate_deaf_monsters) || !MONSTER_IS_DEAF(aggressor)) && // || !MONSTER_IS_PLAYER(caller) || !TYPE_IS_FRIEND(get_monster_definition(aggressor->type), caller->type) || !caller_hostile) &&
@@ -864,7 +864,7 @@ void activate_nearby_monsters(
 					{
 						bool monster_was_active= true;
 						
-						/* activate the monster if heÕs inactive */
+						/* activate the monster if heâ€™s inactive */
 						if (!MONSTER_IS_ACTIVE(aggressor))
 						{
 							activate_monster(aggressor_index);
@@ -883,7 +883,7 @@ void activate_nearby_monsters(
 								}
 								else
 								{
-									/* but hey, if the target isnÕt hostile, maybe the caller is ...
+									/* but hey, if the target isnâ€™t hostile, maybe the caller is ...
 										(mostly for the automated defenses and the civilians on the ship) */
 									if (get_monster_attitude(aggressor_index, caller_index)==_hostile)
 									{
@@ -942,7 +942,7 @@ static int32 monster_activation_flood_proc(
 		}
 		else
 		{
-			// canÕt pass this zone border
+			// canâ€™t pass this zone border
 			cost= -1;
 		}
 	}
@@ -1131,7 +1131,7 @@ void deactivate_monster(
 			/* assume stationary shape before deactivation */
 			set_monster_action(monster_index, _monster_is_stationary);
 			
-			/* get rid of this monsterÕs path if he has one */
+			/* get rid of this monsterâ€™s path if he has one */
 			if (monster->path!=NONE) delete_path(monster->path);
 			
 			SET_MONSTER_ACTIVE_STATUS(monster, false);
@@ -1251,18 +1251,18 @@ void monster_moved(
 			{
 				struct monster_definition *definition= get_monster_definition(monster->type);
 				
-				/* we canÕt see our target: if this is first time, change from _monster_locked
-					to _monster_losing_lock, if this isnÕt the first time and our target has
+				/* we canâ€™t see our target: if this is first time, change from _monster_locked
+					to _monster_losing_lock, if this isnâ€™t the first time and our target has
 					switched polygons more times out of our sight than we have intelligence points,
-					go to _lost_lock (which means we wonÕt get any more new paths when our target
-					switches polygons, but we wonÕt clear our last one until we reach the end). */
+					go to _lost_lock (which means we wonâ€™t get any more new paths when our target
+					switches polygons, but we wonâ€™t clear our last one until we reach the end). */
 				if (monster->mode==_monster_locked) monster->changes_until_lock_lost= 0;
 				if (monster->mode==_monster_losing_lock) monster->changes_until_lock_lost+= 1;
 				set_monster_mode(monster_index, (monster->changes_until_lock_lost>=definition->intelligence) ?
 					_monster_lost_lock : _monster_losing_lock, NONE);
 			}
 			
-			/* if weÕre losing lock, donÕt recalculate our path (weÕre headed towards the targetÕs
+			/* if weâ€™re losing lock, donâ€™t recalculate our path (weâ€™re headed towards the targetâ€™s
 				last-known location) */
 			if (monster->mode!=_monster_losing_lock) monster_needs_path(monster_index, false);
 		}
@@ -1322,7 +1322,7 @@ short legal_player_move(
 				{
 					world_distance this_object_floor= obstacle_location->z+obstacle_height;
 					
-					/* itÕs possible we donÕt intersect in z */
+					/* itâ€™s possible we donâ€™t intersect in z */
 					if (new_location->z+height<obstacle_location->z) continue; 
 					if (new_location->z>this_object_floor)
 					{
@@ -1344,7 +1344,7 @@ short legal_player_move(
 /* returns NONE or a monster_index that prevented us from moving */
 short legal_monster_move(
 	short monster_index,
-	angle facing, /* could be different than object->facing for players and ÔflyingÕ (heh heh) monsters */
+	angle facing, /* could be different than object->facing for players and â€˜flyingâ€™ (heh heh) monsters */
 	world_point3d *new_location)
 {
 	struct monster_data *monster= get_monster_data(monster_index);
@@ -1461,7 +1461,7 @@ void damage_monsters_in_radius(
                         
                         get_monster_dimensions(object->permutation, &monster_radius, &monster_height);
         
-                        /* make sure we intersect the monsterÕs radius in the x,y-plane and that we intersect
+                        /* make sure we intersect the monsterâ€™s radius in the x,y-plane and that we intersect
                                 his cylinder in z */
                         if (distance<radius+monster_radius)
                         {
@@ -1747,7 +1747,7 @@ bool legal_polygon_height_change(
 	return new_polygon_height<minimum_height ? false : legal_change;
 }
 
-/* weÕve already checked and this monster is not obstructing the polygon from changing heights */
+/* weâ€™ve already checked and this monster is not obstructing the polygon from changing heights */
 void adjust_monster_for_polygon_height_change(
 	short monster_index,
 	short polygon_index,
@@ -1876,7 +1876,7 @@ static void update_monster_vertical_physics_model(
 	switch (moving_flags)
 	{
 		case 0:
-			/* if weÕre above the floor, adjust vertical velocity */
+			/* if weâ€™re above the floor, adjust vertical velocity */
 			if (above_ground) monster->vertical_velocity= FLOOR(monster->vertical_velocity-gravity, -definition->terminal_velocity);
 			if (below_ground) monster->vertical_velocity= 0, object->location.z= desired_height;
 			break;
@@ -1892,7 +1892,7 @@ static void update_monster_vertical_physics_model(
 			break;
 		
 		default:
-			/* canÕt fly and float, beavis */
+			/* canâ€™t fly and float, beavis */
 			// LP change: this stuff put in to handle the map "Aqualung" correctly
 			if (above_ground && !MONSTER_IS_ATTACKING(monster)) monster->vertical_velocity= FLOOR(monster->vertical_velocity-gravity, -definition->terminal_velocity);
 			if (below_ground) monster->vertical_velocity= CEILING(monster->vertical_velocity+gravity, definition->terminal_velocity);
@@ -1902,8 +1902,8 @@ static void update_monster_vertical_physics_model(
 	/* add our vertical velocity to z */
 	object->location.z= PIN(object->location.z+monster->vertical_velocity, polygon->floor_height, polygon->ceiling_height-definition->height);
 
-	/* if weÕre under the floor moving down, put us on the floor and clear our velocity;
-		if weÕre above the floor moving up, put us on the floor and clear our velocity if we were previously below ground */
+	/* if weâ€™re under the floor moving down, put us on the floor and clear our velocity;
+		if weâ€™re above the floor moving up, put us on the floor and clear our velocity if we were previously below ground */
 	switch (moving_flags)
 	{
 		case 0:
@@ -1922,7 +1922,7 @@ static void update_monster_vertical_physics_model(
 	/* reset desired height (flying and floating monsters often change this later) */
 	if (moving_flags&_monster_flys)
 	{
-		/* weÕre flying!: if we have no target, take the middle ground; if we have a target aim
+		/* weâ€™re flying!: if we have no target, take the middle ground; if we have a target aim
 			for his midsection */
 		if (MONSTER_HAS_VALID_TARGET(monster))
 		{
@@ -2004,7 +2004,7 @@ static void update_monster_physics_model(
 			if (translate_map_object(monster->object_index, &new_location, NONE)) monster_moved(monster_index, old_polygon_index);
 		}
 		
-		/* slow him down if heÕs touching the ground or flying */
+		/* slow him down if heâ€™s touching the ground or flying */
 		polygon= get_polygon_data(object->polygon);
 		if (object->location.z<=polygon->floor_height || (definition->flags&(_monster_flys|_monster_floats)))
 		{
@@ -2034,7 +2034,7 @@ void set_monster_mode(
 {
 	struct monster_data *monster= get_monster_data(monster_index);
 
-	/* if we were locked on a monster in our own polygon and we lost him then we donÕt have a path
+	/* if we were locked on a monster in our own polygon and we lost him then we donâ€™t have a path
 		and going anywhere would be dangerous so we need to ask for a new path */
 	if (monster->mode==_monster_locked&&new_mode!=_monster_locked&&monster->path==NONE) monster_needs_path(monster_index, false);
 
@@ -2084,14 +2084,14 @@ static void generate_new_path_for_monster(
 	world_point2d *destination;
 	world_vector2d bias;
 
-	/* delete this monsterÕs old path, if one exists, and clear the need path flag */
+	/* delete this monsterâ€™s old path, if one exists, and clear the need path flag */
 	if (monster->path!=NONE) delete_path(monster->path), monster->path= NONE;
 	SET_MONSTER_NEEDS_PATH_STATUS(monster, false);
 
 	switch (monster->mode)
 	{
 		case _monster_losing_lock:
-			/* our target is out of sight, but weÕre still zen-ing his position until we run out
+			/* our target is out of sight, but weâ€™re still zen-ing his position until we run out
 				of intelligence points */
 		case _monster_locked:
 		{
@@ -2100,7 +2100,7 @@ static void generate_new_path_for_monster(
 
 			if (definition->random_sound_mask && !(global_random()&definition->random_sound_mask)) play_object_sound(monster->object_index, definition->random_sound);
 
-			/* if we canÕt attack, run away, otherwise go for the target */
+			/* if we canâ€™t attack, run away, otherwise go for the target */
 			if (definition->flags&_monster_cannot_attack)
 			{
 				// LP changed: unnecessary to interrupt for this
@@ -2126,8 +2126,8 @@ static void generate_new_path_for_monster(
 			set_monster_mode(monster_index, _monster_unlocked, NONE);
 //			dprintf("monster #%d lost lock and reached end of path;g;", monster_index);
 		case _monster_unlocked:
-			/* if weÕre unlocked and need a new path, follow our guard path if we have one and
-				run around randomly if we donÕt */
+			/* if weâ€™re unlocked and need a new path, follow our guard path if we have one and
+				run around randomly if we donâ€™t */
 			if ((destination_polygon_index= monster->goal_polygon_index)!=NONE)
 			{
 				destination= &get_polygon_data(destination_polygon_index)->center;
@@ -2175,11 +2175,11 @@ static bool switch_target_check(
 	struct monster_data *monster= get_monster_data(monster_index);
 	bool switched_target= false;
 
-	if (!MONSTER_IS_PLAYER(monster) && !MONSTER_IS_DYING(monster)) /* donÕt mess with players or dying monsters */
+	if (!MONSTER_IS_PLAYER(monster) && !MONSTER_IS_DYING(monster)) /* donâ€™t mess with players or dying monsters */
 	{
 		if (MONSTER_HAS_VALID_TARGET(monster) && monster->target_index==attacker_index)
 		{
-			/* if we didnÕt know where our target was and he just shot us, we sort of like, know
+			/* if we didnâ€™t know where our target was and he just shot us, we sort of like, know
 				where he is now */
 			if (monster->mode==_monster_losing_lock)
 			{
@@ -2187,7 +2187,7 @@ static bool switch_target_check(
 				monster_needs_path(monster_index, false);
 			}
 
-			/* if weÕre already after this guy and he just did damage to us, remember that */
+			/* if weâ€™re already after this guy and he just did damage to us, remember that */
 			if (delta_vitality)
 				SET_TARGET_DAMAGE_FLAG(monster);
 			
@@ -2203,7 +2203,7 @@ static bool switch_target_check(
 			if (!MONSTER_IS_DYING(attacker) && !(definition->flags&_monster_cannot_attack))
 			{
 				/* if our attacker is an enemy (or a neutral doing non-zero damage or we are berserk) and
-						a) weÕre inactive, or,
+						a) weâ€™re inactive, or,
 						b) idle, or,
 						c) unlocked, or,
 						d) our current target has not done any damage
@@ -2279,7 +2279,7 @@ short find_closest_appropriate_target(
 		int32 flood_flags= _pass_one_zone_border;
 		short polygon_index= get_object_data(get_monster_data(aggressor_index)->object_index)->polygon;
 		
-		/* flood out from the aggressor monsterÕs polygon, searching through the object lists of all
+		/* flood out from the aggressor monsterâ€™s polygon, searching through the object lists of all
 			polygons we encounter */
 		polygon_index= flood_map(polygon_index, INT32_MAX, monster_activation_flood_proc, _flagged_breadth_first, &flood_flags);
 		while (polygon_index!=NONE && closest_hostile_target_index==NONE)
@@ -2338,7 +2338,7 @@ short find_closest_appropriate_target(
 	return closest_hostile_target_index;
 }
 
-/* if Ôfull_circleÕ is true, the monster can see in all directions.  if Ôfull_circleÕ is false
+/* if â€˜full_circleâ€™ is true, the monster can see in all directions.  if â€˜full_circleâ€™ is false
 	the monster respects his visual_arc and current facing.  clear_line_of_sight() is implemented
 	wholly in 2D and only attempts to connect the centers of the two monsters by a line. */
 static bool clear_line_of_sight(
@@ -2362,7 +2362,7 @@ static bool clear_line_of_sight(
 		world_distance dz= destination->z-origin->z;
 		int32 distance2d= GUESS_HYPOTENUSE(ABS(dx), ABS(dy));
 
-		/* if we canÕt see full circle, make sure the target is in our visual arc */
+		/* if we canâ€™t see full circle, make sure the target is in our visual arc */
 		if (!full_circle)
 		{
 			angle theta= arctangent(dx, dy)-viewer_object->facing;
@@ -2372,7 +2372,7 @@ static bool clear_line_of_sight(
 			if (phi>=viewer_definition->half_vertical_visual_arc&&phi<FULL_CIRCLE-viewer_definition->half_vertical_visual_arc) target_visible= false;
 		}
 
-		/* we canÕt see some transfer modes */
+		/* we canâ€™t see some transfer modes */
 		switch (target_object->transfer_mode)
 		{
 			case _xfer_invisibility:
@@ -2382,7 +2382,7 @@ static bool clear_line_of_sight(
 		}
 		
 		/* make sure the target is within our visual_range (taking any of his active
-			effects, i.e. invisibility, into account) and that he isnÕt standing in a
+			effects, i.e. invisibility, into account) and that he isnâ€™t standing in a
 			dark polygon beyond our dark_visual_range. */
 		if (target_visible)
 		{
@@ -2418,8 +2418,8 @@ static bool clear_line_of_sight(
 				}
 				else
 				{
-					/* we got to the targetÕs (x,y) location, but weÕre in a different polygon;
-						heÕs invisible */
+					/* we got to the targetâ€™s (x,y) location, but weâ€™re in a different polygon;
+						heâ€™s invisible */
 					if (polygon_index!=target_object->polygon) target_visible= false;
 				}
 			}
@@ -2431,7 +2431,7 @@ static bool clear_line_of_sight(
 }
 
 /* lock the given monster onto the given target, playing a locking sound if the monster
-	previously didnÕt have a lock */
+	previously didnâ€™t have a lock */
 void change_monster_target(
 	short monster_index,
 	short target_index)
@@ -2466,7 +2466,7 @@ void change_monster_target(
 		{
 			if (MONSTER_IS_ACTIVE(monster))
 			{
-				/* no target, if weÕre not unlocked mark us as unlocked and ask for a new path */
+				/* no target, if weâ€™re not unlocked mark us as unlocked and ask for a new path */
 				if (monster->mode!=_monster_unlocked)
 				{
 //					dprintf("monster #%d was locked on NONE;g;", monster_index);
@@ -2517,9 +2517,9 @@ static void handle_moving_or_stationary_monster(
 			}
 			else
 			{
-				/* we couldnÕt move: _monster_is_moving becomes _monster_is_stationary */
+				/* we couldnâ€™t move: _monster_is_moving becomes _monster_is_stationary */
 				if (monster->action==_monster_is_moving) set_monster_action(monster_index, _monster_is_stationary);
-				monster->ticks_since_attack+= 1; /* attacks occur twice as frequently if we canÕt move (damnit!) */
+				monster->ticks_since_attack+= 1; /* attacks occur twice as frequently if we canâ€™t move (damnit!) */
 			}
 		}
 		else
@@ -2655,7 +2655,7 @@ static void kill_monster(
 			break;
 	}
 
-	/* add an item if weÕre supposed to be carrying something */
+	/* add an item if weâ€™re supposed to be carrying something */
 	if (definition->carrying_item_type!=NONE && monster->action==_monster_is_dying_soft)
 	{
 		world_distance radius, height;
@@ -2688,7 +2688,7 @@ static void kill_monster(
 		}
 	}
 	
-	/* stuff in an appropriate dead shape (or remove our object if we donÕt have a dead shape) */
+	/* stuff in an appropriate dead shape (or remove our object if we donâ€™t have a dead shape) */
     bool remove_object = (shape == UNONE);
     if (!remove_object && (static_world->environment_flags & _environment_ouch_m1))
     {
@@ -2745,7 +2745,7 @@ static bool translate_monster(
 	new_location= object->location;
 	translate_point2d((world_point2d *)&new_location, distance, object->facing);
 
-	/* find out where weÕre going and see if we could actually move there */
+	/* find out where weâ€™re going and see if we could actually move there */
 	if ((obstacle_index= legal_monster_move(monster_index, object->facing, &new_location))==NONE)
 	{
 		/* legal move: see if there is a platform that we have to open or wait for,
@@ -2792,13 +2792,13 @@ static bool translate_monster(
 				break;
 
 			case _flying_or_floating_transition:
-				/* there is a wall in our way which we have to rise (or fall) along, so donÕt
-					go anywhere unless weÕre over it (or under it) */
+				/* there is a wall in our way which we have to rise (or fall) along, so donâ€™t
+					go anywhere unless weâ€™re over it (or under it) */
 				if (ABS(object->location.z-monster->desired_height)>MINIMUM_FLOATING_HEIGHT) legal_move= false;
 				break;
 			
 			case _standing_on_sniper_ledge:
-				/* weÕve been told to freeze on a sniper ledge (no saving throw) */
+				/* weâ€™ve been told to freeze on a sniper ledge (no saving throw) */
 				legal_move= false;
 				break;
 		}
@@ -2813,7 +2813,7 @@ static bool translate_monster(
 			{
 				short old_polygon_index= object->polygon;
 				
-				/* update the monsterÕs object to reflect his new position */
+				/* update the monsterâ€™s object to reflect his new position */
 				if (translate_map_object(monster->object_index, &new_location, NONE)) monster_moved(monster_index, old_polygon_index);
 			}
 	
@@ -2851,7 +2851,7 @@ static bool translate_monster(
 								monster_needs_path(monster_index, false);
 								if (monster->mode!=_monster_locked)
 								{
-									/* if weÕre not locked, we might want to think about deactivating here, but
+									/* if weâ€™re not locked, we might want to think about deactivating here, but
 										for now we just build a new random path by forcing our state to _unlocked. */
 									set_monster_mode(monster_index, _monster_unlocked, NONE);
 	//								dprintf("monster #%d going unlocked by obstruction;g;", monster_index);
@@ -2874,7 +2874,7 @@ static bool translate_monster(
 				
 				change_monster_target(monster_index, obstacle_object->permutation);
 				
-				/* if weÕre a kamakazi and weÕre within range, pop */
+				/* if weâ€™re a kamakazi and weâ€™re within range, pop */
 				if ((definition->flags&_monster_is_kamakazi) &&
 					object->location.z<key_height)
 				{
@@ -2968,7 +2968,7 @@ void advance_monster_path(
 
 	if (monster->path==NONE)
 	{
-		/* only locked monsters in their targetÕs polygon can advance without paths */
+		/* only locked monsters in their targetâ€™s polygon can advance without paths */
 		if (monster->mode!=_monster_locked || object->polygon!=get_object_data(get_monster_data(monster->target_index)->object_index)->polygon)
 		{
 			monster_needs_path(monster_index, true);
@@ -2982,7 +2982,7 @@ void advance_monster_path(
 		monster->path= NONE;
 	}
 
-	/* if weÕre locked without a path, head right for the bastard (heÕs in our polygon) */
+	/* if weâ€™re locked without a path, head right for the bastard (heâ€™s in our polygon) */
 	if ((done||monster->path==NONE) && monster->mode==_monster_locked)
 	{
 		struct monster_data *target= get_monster_data(monster->target_index);
@@ -3075,7 +3075,7 @@ static bool try_monster_attack(
 			/* if we have a melee attack and we're at short range, use it */
 			if (new_action==_monster_is_attacking_close)
 			{
-				/* make sure this is a valid projectile, that we donÕt hit any walls and that whatever
+				/* make sure this is a valid projectile, that we donâ€™t hit any walls and that whatever
 					we did hit is _hostile. */
 				polygon_index= position_monster_projectile(monster_index, monster->target_index, &definition->melee_attack, &origin, &destination, &_vector, theta);
 				if (preflight_projectile(&origin, polygon_index, &destination, definition->melee_attack.error,
@@ -3093,7 +3093,7 @@ static bool try_monster_attack(
 				/* make sure we have a ranged attack and our target is within range */
 				if (new_action==_monster_is_attacking_far)
 				{
-					/* make sure this is a valid projectile, that we donÕt hit any walls and that whatever
+					/* make sure this is a valid projectile, that we donâ€™t hit any walls and that whatever
 						we did hit is _hostile. */
 					polygon_index= position_monster_projectile(monster_index, monster->target_index, &definition->ranged_attack, &origin, &destination, &_vector, theta);
 					if (preflight_projectile(&origin, polygon_index, &destination, definition->ranged_attack.error,
@@ -3114,7 +3114,7 @@ static bool try_monster_attack(
 	{
 		/* we can attack; set monster facing, start the attack action and reset ticks_since_attack */
 		object->facing= theta;
-		if (monster->action!=new_action) /* if weÕre already attacking, this is a chained attack */
+		if (monster->action!=new_action) /* if weâ€™re already attacking, this is a chained attack */
 		{
 			switch (dynamic_world->game_information.difficulty_level)
 			{
@@ -3126,7 +3126,7 @@ static bool try_monster_attack(
 			monster->attack_repetitions= repetitions;
 		}
 		
-		/* on the highest level, hitting a monster in the middle of an attack doesnÕt really
+		/* on the highest level, hitting a monster in the middle of an attack doesnâ€™t really
 			stop him from continuing to attack because ticks_since_attack is never reset */
 		switch (dynamic_world->game_information.difficulty_level)
 		{
@@ -3140,7 +3140,7 @@ static bool try_monster_attack(
 	}
 	else
 	{
-		/* we canÕt attack (for whatever reason), halve ticks_since_attack so we try again soon */
+		/* we canâ€™t attack (for whatever reason), halve ticks_since_attack so we try again soon */
 		monster->ticks_since_attack= 0;
 			
 		if (obstruction_index!=NONE && get_monster_attitude(monster_index, obstruction_index)==_friendly &&
@@ -3199,7 +3199,7 @@ int32 monster_pathfinding_cost_function(
 	short object_index;
 	int32 cost;
 		
-	/* base cost is the area of the polygon weÕre leaving */
+	/* base cost is the area of the polygon weâ€™re leaving */
 	cost= source_polygon->area;
 
 	/* no solid lines (baby) */
@@ -3213,7 +3213,7 @@ int32 monster_pathfinding_cost_function(
 		if (GET_OBJECT_OWNER(object)==_object_is_monster) cost+= MONSTER_PATHFINDING_OBSTRUCTION_COST;
 	}
 
-	/* if weÕre trying to move into a polygon with an area smaller than MINIMUM_MONSTER_PATHFINDING_POLYGON_AREA, disallow the move */
+	/* if weâ€™re trying to move into a polygon with an area smaller than MINIMUM_MONSTER_PATHFINDING_POLYGON_AREA, disallow the move */
 	if (source_polygon->area<MINIMUM_MONSTER_PATHFINDING_POLYGON_AREA) cost= -1;
 
 	// do platform stuff	
@@ -3245,7 +3245,7 @@ int32 monster_pathfinding_cost_function(
 	}
 		
 	/* if the ledge between polygons is too high, the fall is too far, or there just
-		isnÕt enough vertical space, disallow the move (and ignore this if weÕre dealing with
+		isnâ€™t enough vertical space, disallow the move (and ignore this if weâ€™re dealing with
 		platforms or doors) */
 	if (respect_polygon_heights)
 	{
@@ -3262,7 +3262,7 @@ int32 monster_pathfinding_cost_function(
 
 	if (cost>0)
 	{
-		/* if weÕre trying to move into an impassable polygon, disallow the move */
+		/* if weâ€™re trying to move into an impassable polygon, disallow the move */
 		switch (destination_polygon->type)
 		{
 			case _polygon_is_zone_border:
@@ -3285,7 +3285,7 @@ int32 monster_pathfinding_cost_function(
 
 	if (cost>0)
 	{
-		/* if weÕre trying to move into media, pay the penalty */
+		/* if weâ€™re trying to move into media, pay the penalty */
 		if (destination_polygon->media_index!=NONE)
 		{
 			struct media_data *media= get_media_data(destination_polygon->media_index);
@@ -3333,7 +3333,7 @@ static short find_obstructing_terrain_feature(
 			case _polygon_is_platform:
 				if (object->polygon==polygon_index)
 				{
-					/* weÕre standing on the platform: find out where weÕre headed (if weÕre
+					/* weâ€™re standing on the platform: find out where weâ€™re headed (if weâ€™re
 						going nowhere then pretend like everything is o.k.) */
 
 					polygon_index= line_index==NONE ? NONE : find_adjacent_polygon(polygon_index, line_index);
@@ -3427,7 +3427,7 @@ static short find_obstructing_terrain_feature(
 			}
 			else
 			{
-				/* weÕre headed for a wall solid; freeze and get a new path, pronto */
+				/* weâ€™re headed for a wall solid; freeze and get a new path, pronto */
 				feature_type= _standing_on_sniper_ledge;
 				monster_needs_path(monster_index, true);
 			}
@@ -3438,7 +3438,7 @@ static short find_obstructing_terrain_feature(
 	return feature_type;
 }
 
-/* returns new polygon index; if destination is NULL then we fire along the monsterÕs facing
+/* returns new polygon index; if destination is NULL then we fire along the monsterâ€™s facing
 	and elevation, if destination is not NULL then we set it correctly and save the elevation angle */
 static short position_monster_projectile(
 	short aggressor_index,

--- a/Source_Files/GameWorld/monsters.h
+++ b/Source_Files/GameWorld/monsters.h
@@ -165,7 +165,7 @@ enum /* monster types */
 #define MONSTER_IS_IDLE(m) ((m)->flags&(uint16)0x0800)
 #define SET_MONSTER_IDLE_STATUS(m,v) ((void)((v)?((m)->flags|=(uint16)0x0800):((m)->flags&=(uint16)~0x0800)))
 
-/* this flag is set if our current target has inflicted damage on us (because if he hasnÕt, weÕll
+/* this flag is set if our current target has inflicted damage on us (because if he hasnâ€™t, weâ€™ll
 	probably go after somebody else if they hit us first) */
 #define TARGET_HAS_DONE_DAMAGE(m) ((m)->flags&(uint16)0x0200)
 #define CLEAR_TARGET_DAMAGE_FLAG(m) ((m)->flags&=(uint16)~0x0200)
@@ -226,7 +226,7 @@ struct monster_data /* 64 bytes */
 	uint16 flags; /* [slot_used.1] [need_path.1] [recovering_from_hit.1] [active.1] [idle.1] [berserk.1] [target_damage.1] [unused.6] [never_activated.1] [demoted.1] [promoted.1] */
 	
 	short path; /* NONE is no path (the need path bit should be set in this case) */
-	world_distance path_segment_length; /* distance until weÕre through with this segment of the path */
+	world_distance path_segment_length; /* distance until weâ€™re through with this segment of the path */
 	world_distance desired_height;
 	
 	short mode, action;
@@ -246,7 +246,7 @@ struct monster_data /* 64 bytes */
 	
 	short goal_polygon_index; // used instead of NONE when generating random paths
 
-	// copied from monsterÕs object every tick but updated with height
+	// copied from monsterâ€™s object every tick but updated with height
 	world_point3d sound_location;
 	short sound_polygon_index;
 
@@ -272,7 +272,7 @@ extern vector<monster_data> MonsterList;
 void initialize_monsters(void);
 void initialize_monsters_for_new_level(void); /* when a map is loaded */
 
-void move_monsters(void); /* assumes ¶t==1 tick */
+void move_monsters(void); /* assumes âˆ‚t==1 tick */
 
 short new_monster(struct object_location *location, short monster_code);
 void remove_monster(short monster_index);

--- a/Source_Files/GameWorld/pathfinding.cpp
+++ b/Source_Files/GameWorld/pathfinding.cpp
@@ -55,9 +55,9 @@ we should cut corners instead of blindly following map geometry (i.e., separate 
 	much as possible from the underlying polygon structure of the map), especially the final leg.
 
 //calculate_midpoint_of_shared_line should have some randomness (bad idea?)
-//it ocurrs to me that connecting midpoints of shared lines wonÕt always work (monsters will run through walls)
+//it ocurrs to me that connecting midpoints of shared lines wonâ€™t always work (monsters will run through walls)
 //shadow polygons screw us up (a specific case of the general "weird polygon geometry" problem)
-//random paths arenÕt really random, and (even worse) tend to be symmetric
+//random paths arenâ€™t really random, and (even worse) tend to be symmetric
 */
 
 /* ---------- constants */
@@ -193,7 +193,7 @@ short new_path(
 				out from the source polygon until we run out of stack space or we reach a cost
 				of RANDOM_PATH_AREA, whichever comes first.  in fact, our destination_point, if
 				not NULL, is a 2d vector specifying a bias in the direction we want to travel
-				(usually this will be away from somewhere we donÕt want to be) */
+				(usually this will be away from somewhere we donâ€™t want to be) */
 			polygon_index= flood_map(source_polygon_index, INT32_MAX, cost, _breadth_first, data);
 			while (polygon_index!=NONE)
 			{
@@ -201,7 +201,7 @@ short new_path(
 			}
 			
 			choose_random_flood_node((world_vector2d *)destination_point); /* choose a random destination */
-			reached_destination= false; /* we didnÕt even have one */
+			reached_destination= false; /* we didnâ€™t even have one */
 		}
 
 		depth= flood_depth();
@@ -230,7 +230,7 @@ short new_path(
 			assert(path->step_count!=NONE); /* this would be bad */
 			path->current_step= 0;
 
-			/* if we reached our destination (and itÕs not out-of-range), add it */
+			/* if we reached our destination (and itâ€™s not out-of-range), add it */
 			if (reached_destination && --step_count<MAXIMUM_POINTS_PER_PATH) path->points[step_count]= *destination_point;
 			
 			/* add all the points up to but not including the source (if we have room) */
@@ -257,7 +257,7 @@ short new_path(
 			{
 				if (memcmp(path_validation_area+path_validation_area_index, path->points, sizeof(world_point2d)*path->step_count))
 				{
-					dprintf("path #%d at %p didnÕt match point list at %p", path_index, path, path_validation_area+path_validation_area_index);
+					dprintf("path #%d at %p didnâ€™t match point list at %p", path_index, path, path_validation_area+path_validation_area_index);
 				}
 				path_validation_area_index+= sizeof(world_point2d*)*path->step_count;
 			}

--- a/Source_Files/GameWorld/physics.cpp
+++ b/Source_Files/GameWorld/physics.cpp
@@ -57,14 +57,14 @@ May 16, 2002 (Woody Zenfell):
 */
 
 /*
-running backwards shouldnÕt mean doom in a fistfight
+running backwards shouldnâ€™t mean doom in a fistfight
 
 //who decides on the physics model, anyway?  static_world-> or player->
 //falling through gridlines and crapping on elevators has to do with variables->flags being wrong after the player dies
 //absolute (or nearly-absolute) positioning information for yaw, pitch and velocity
 //the physics model is too soft (more noticable at high frame rates)
 //we can continually boot ourselves out of nearly-orthogonal walls by tiny amounts, resulting in a slide
-//itÕs fairly obvious that players can still end up in walls
+//itâ€™s fairly obvious that players can still end up in walls
 //the recenter key should work faster
 */
 
@@ -440,8 +440,8 @@ uint32 process_aim_input(uint32 action_flags, fixed_yaw_pitch delta)
 	new_location.z= FIXED_TO_WORLD(variables->position.z);
 
 	/* check for 2d collisions with walls and knock the player back out of the wall (because of
-		the way the physics updates work, we donÕt worry about collisions with the floor or
-		ceiling).  ONLY MODIFY THE PLAYERÕS FIXED_POINT3D POSITION IF WE HAD A COLLISION */
+		the way the physics updates work, we donâ€™t worry about collisions with the floor or
+		ceiling).  ONLY MODIFY THE PLAYERâ€™S FIXED_POINT3D POSITION IF WE HAD A COLLISION */
 	if (PLAYER_IS_DEAD(player)) new_location.z+= FIXED_TO_WORLD(DROP_DEAD_HEIGHT);
 	if (take_action && !first_time && player->last_supporting_polygon_index!=player->supporting_polygon_index) changed_polygon(player->last_supporting_polygon_index, player->supporting_polygon_index, player_index);
 	player->last_supporting_polygon_index= first_time ? NONE : player->supporting_polygon_index;
@@ -451,7 +451,7 @@ uint32 process_aim_input(uint32 action_flags, fixed_yaw_pitch delta)
 	if (PLAYER_IS_DEAD(player)) new_location.z-= FIXED_TO_WORLD(DROP_DEAD_HEIGHT);
 
 	/* check for 2d collisions with solid objects and knock the player back out of the object.
-		ONLY MODIFY THE PLAYERÕS FIXED_POINT3D POSITION IF WE HAD A COLLISION. */
+		ONLY MODIFY THE PLAYERâ€™S FIXED_POINT3D POSITION IF WE HAD A COLLISION. */
 	object_floor= INT16_MIN;
 	{
 		short obstruction_index= legal_player_move(player->monster_index, &new_location, &object_floor);
@@ -542,7 +542,7 @@ static void physics_update(
 	fixed_point3d new_position;
 	short sine, cosine;
 	_fixed delta_z;
-	_fixed delta; /* used as a scratch ÔchangeÕ variable */
+	_fixed delta; /* used as a scratch â€˜changeâ€™ variable */
 	
 	const bool player_is_local = (player == local_player);
 
@@ -588,7 +588,7 @@ static void physics_update(
 		action_flags&= ~_absolute_pitch_mode;
 	}
 
-	/* handle turning left or right; if weÕve exceeded our maximum velocity lock out user actions
+	/* handle turning left or right; if weâ€™ve exceeded our maximum velocity lock out user actions
 		until we return to a legal range */
 	if (action_flags&_absolute_yaw_mode)
 	{
@@ -653,10 +653,10 @@ static void physics_update(
 			action_flags|= variables->elevation<0 ? _looking_up : _looking_down;
 		}
 	
-		/* handle looking up and down; if weÕre moving at our terminal velocity forward or backward,
+		/* handle looking up and down; if weâ€™re moving at our terminal velocity forward or backward,
 			without any side-to-side motion, recenter our head vertically */
 
-		if (!(action_flags&FLAGS_WHICH_PREVENT_RECENTERING)) /* canÕt recenter if any of these are true */
+		if (!(action_flags&FLAGS_WHICH_PREVENT_RECENTERING)) /* canâ€™t recenter if any of these are true */
 		{
 			if (((action_flags&_moving_forward) && (variables->velocity==constants->maximum_forward_velocity)) ||
 				((action_flags&_moving_backward) && (variables->velocity==-constants->maximum_backward_velocity)))
@@ -699,8 +699,8 @@ static void physics_update(
 			vir_aim_delta.pitch = 0;
 	}
 
-	/* if weÕre on the ground (or rising up from it), allow movement; if weÕre flying through
-		the air, donÕt let the player adjust his velocity in any way */
+	/* if weâ€™re on the ground (or rising up from it), allow movement; if weâ€™re flying through
+		the air, donâ€™t let the player adjust his velocity in any way */
 	if (delta_z<=0 || (variables->flags&_HEAD_BELOW_MEDIA_BIT))
 	{
 		if (action_flags&_absolute_position_mode)
@@ -718,7 +718,7 @@ static void physics_update(
 		}
 		else
 		{
-			/* handle moving forward or backward; if weÕve exceeded our maximum velocity lock out user actions
+			/* handle moving forward or backward; if weâ€™ve exceeded our maximum velocity lock out user actions
 				until we return to a legal range */
 			if (variables->velocity<-constants->maximum_backward_velocity||variables->velocity>constants->maximum_forward_velocity) action_flags&= ~_moving;
 			switch (action_flags&_moving)
@@ -740,7 +740,7 @@ static void physics_update(
 			}
 		}
 		
-		/* handle sidestepping left or right; if weÕve exceeded our maximum velocity lock out user actions
+		/* handle sidestepping left or right; if weâ€™ve exceeded our maximum velocity lock out user actions
 			until we return to a legal range */
 		if (variables->perpendicular_velocity<-constants->maximum_perpendicular_velocity||variables->perpendicular_velocity>constants->maximum_perpendicular_velocity) action_flags&= ~_sidestepping;
 		switch (action_flags&_sidestepping)
@@ -820,13 +820,13 @@ static void physics_update(
 		}
 	}
 
-	/* change the playerÕs heading based on his angular velocities */
+	/* change the playerâ€™s heading based on his angular velocities */
 	variables->last_direction= variables->direction;
 	variables->direction+= variables->angular_velocity;
 	if (variables->direction<0) variables->direction+= INTEGER_TO_FIXED(FULL_CIRCLE);
 	if (variables->direction>=INTEGER_TO_FIXED(FULL_CIRCLE)) variables->direction-= INTEGER_TO_FIXED(FULL_CIRCLE);
 	
-	/* change the playerÕs x,y position based on his direction and velocities (parallel and perpendicular)  */
+	/* change the playerâ€™s x,y position based on his direction and velocities (parallel and perpendicular)  */
 	new_position= variables->position;
 	cosine= cosine_table[FIXED_INTEGERAL_PART(variables->direction)], sine= sine_table[FIXED_INTEGERAL_PART(variables->direction)];
 	new_position.x+= (variables->velocity*cosine-variables->perpendicular_velocity*sine)>>TRIG_SHIFT;
@@ -838,7 +838,7 @@ static void physics_update(
 	if (new_position.z>variables->floor_height) variables->flags|= _ABOVE_GROUND_BIT; else variables->flags&= (uint16)~_ABOVE_GROUND_BIT;
 
 	/* if we just landed on the ground, or we just came up through the ground, absorb some of
-		the playerÕs external_velocity.k (and in the case of hitting the ground, reflect it) */
+		the playerâ€™s external_velocity.k (and in the case of hitting the ground, reflect it) */
 	if (variables->external_velocity.k>0 && (variables->old_flags&_BELOW_GROUND_BIT) && !(variables->flags&_BELOW_GROUND_BIT))
 	{
 		variables->external_velocity.k/= 2*COEFFICIENT_OF_ABSORBTION; /* slow down */
@@ -871,7 +871,7 @@ static void physics_update(
 		variables->flags&= ~(_BELOW_GROUND_BIT|_ABOVE_GROUND_BIT);
 	}
 
-	/* change the playerÕs z position based on his vertical velocity (if we hit the ground coming down
+	/* change the playerâ€™s z position based on his vertical velocity (if we hit the ground coming down
 		then bounce and absorb most of the blow */
 	new_position.x+= variables->external_velocity.i;
 	new_position.y+= variables->external_velocity.j;
@@ -893,7 +893,7 @@ static void physics_update(
 		}
 	}
 
-	/* lower the playerÕs externally-induced angular velocity */
+	/* lower the playerâ€™s externally-induced angular velocity */
 	variables->external_angular_velocity= (variables->external_angular_velocity>=0) ?
 		FLOOR(variables->external_angular_velocity-constants->external_angular_deceleration, 0) :
 		CEILING(variables->external_angular_velocity+constants->external_angular_deceleration, 0);
@@ -902,8 +902,8 @@ static void physics_update(
 	variables->last_position= variables->position;
 	variables->position= new_position;
 
-	/* if the player is moving, adjust step_phase by step_delta (if the player isnÕt moving
-		continue to adjust step_phase until it is zero)  if the player is in the air, donÕt
+	/* if the player is moving, adjust step_phase by step_delta (if the player isnâ€™t moving
+		continue to adjust step_phase until it is zero)  if the player is in the air, donâ€™t
 		update phase until he lands. */
 	variables->flags&= (uint16)~_STEP_PERIOD_BIT;
 	if (constants->maximum_forward_velocity)

--- a/Source_Files/GameWorld/physics_models.h
+++ b/Source_Files/GameWorld/physics_models.h
@@ -49,7 +49,7 @@ struct physics_constants
 	_fixed maximum_elevation; /* positive and negative */
 	_fixed external_angular_deceleration;
 	
-	/* step_length is distance between adjacent nodes in the actorÕs phase */
+	/* step_length is distance between adjacent nodes in the actorâ€™s phase */
 	_fixed step_delta, step_amplitude;
 	_fixed radius, height, dead_height, camera_height, splash_height;
 	

--- a/Source_Files/GameWorld/platforms.cpp
+++ b/Source_Files/GameWorld/platforms.cpp
@@ -151,7 +151,7 @@ short new_platform(
 		platform_index= dynamic_world->platform_count++;
 		platform= platforms+platform_index;
 
-		/* remember the platform_index in the polygonÕs .permutation field */
+		/* remember the platform_index in the polygonâ€™s .permutation field */
 		polygon->permutation= platform_index;
 		polygon->type= _polygon_is_platform;
 		
@@ -287,9 +287,9 @@ void update_platforms(
 				world_distance delta_height= PLATFORM_IS_EXTENDING(platform) ? platform->speed :
 					(PLATFORM_CONTRACTS_SLOWER(platform) ? (-(platform->speed>>2)) : -platform->speed);
 
-				/* adjust and pin heights: if we think weÕre fully contracted or expanded, make
-					sure our heights reflect that (we donÕt want a split platform to have blank
-					space between it because it didnÕt quite close all the way) */
+				/* adjust and pin heights: if we think weâ€™re fully contracted or expanded, make
+					sure our heights reflect that (we donâ€™t want a split platform to have blank
+					space between it because it didnâ€™t quite close all the way) */
 				CLEAR_PLATFORM_POSITIONING_FLAGS(platform);
 				if (PLATFORM_COMES_FROM_FLOOR(platform))
 				{
@@ -323,8 +323,8 @@ void update_platforms(
 				if (change_polygon_height(platform->polygon_index, new_floor_height, new_ceiling_height,
 					PLATFORM_CAUSES_DAMAGE(platform) ? &definition->damage : (struct damage_definition *) NULL))
 				{
-					/* if we werenÕt blocked, remember that we moved last time, change our current
-						level, adjust the textures if weÕre coming down from the ceiling,
+					/* if we werenâ€™t blocked, remember that we moved last time, change our current
+						level, adjust the textures if weâ€™re coming down from the ceiling,
 						and finally adjust the heights of all endpoints and lines which make
 						up our polygon to reflect the height change */
 					if (PLATFORM_COMES_FROM_CEILING(platform))
@@ -336,8 +336,8 @@ void update_platforms(
 				}
 				else
 				{
-					/* if we were blocked, play a sound if we werenÕt blocked last time and reverse
-						directions if weÕre supposed to */
+					/* if we were blocked, play a sound if we werenâ€™t blocked last time and reverse
+						directions if weâ€™re supposed to */
 					if (PLATFORM_WAS_MOVING(platform)) sound_code= _obstructed_sound;
 					if (PLATFORM_REVERSES_DIRECTION_WHEN_OBSTRUCTED(platform))
 					{
@@ -445,7 +445,7 @@ short monster_can_enter_platform(
 	{
 		if (PLATFORM_IS_ACTIVE(platform) && PLATFORM_COMES_FROM_FLOOR(platform) && !PLATFORM_COMES_FROM_CEILING(platform))
 		{
-			/* if this platform doesnÕt go floor to ceiling and it stops at the source polygon, it might be ok */
+			/* if this platform doesnâ€™t go floor to ceiling and it stops at the source polygon, it might be ok */
 			if (platform->maximum_floor_height!=platform->minimum_ceiling_height &&
 				(platform->minimum_floor_height==source_polygon->floor_height ||
 				platform->maximum_floor_height==source_polygon->floor_height))
@@ -527,9 +527,9 @@ void player_touch_platform_state(
 	if (!definition) return;
 	short sound_code= NONE;
 	
-	/* if we canÕt control this platform, play the uncontrollable sound, if itÕs inactive activate
-		it and if itÕs active and moving reverse itÕs direction if thatÕs what it does when itÕs
-		obstructed, if itÕs active but not moving then zero the delay */
+	/* if we canâ€™t control this platform, play the uncontrollable sound, if itâ€™s inactive activate
+		it and if itâ€™s active and moving reverse itâ€™s direction if thatâ€™s what it does when itâ€™s
+		obstructed, if itâ€™s active but not moving then zero the delay */
 	if (PLATFORM_IS_PLAYER_CONTROLLABLE(platform))
 	{
 		if (PLATFORM_IS_ACTIVE(platform))
@@ -876,7 +876,7 @@ void adjust_platform_endpoint_and_line_heights(
 			line->highest_adjacent_floor= MAX(polygon->floor_height, adjacent_polygon->floor_height);
 			line->lowest_adjacent_ceiling= MIN(polygon->ceiling_height, adjacent_polygon->ceiling_height);
 
-			/* only worry about transparency and solidity if thereÕs a polygon on the other side */
+			/* only worry about transparency and solidity if thereâ€™s a polygon on the other side */
 			if (LINE_IS_VARIABLE_ELEVATION(line))
 			{
 				SET_LINE_TRANSPARENCY(line, line->highest_adjacent_floor<line->lowest_adjacent_ceiling);
@@ -949,9 +949,9 @@ static void play_platform_sound(
 	SoundManager::instance()->CauseAmbientSoundSourceUpdate();
 }
 
-/* rules for using native polygon heights: a) if this is a floor platform, then take the polygonÕs
+/* rules for using native polygon heights: a) if this is a floor platform, then take the polygonâ€™s
 	native floor height to be the maximum height if it is greater than the minimum height, otherwise
-	use it as the minimum height; b) if this is a ceiling platform, then take the polygonÕs native
+	use it as the minimum height; b) if this is a ceiling platform, then take the polygonâ€™s native
 	ceiling height to be the minimum height if it is less than the maximum height, otherwise use it
 	as the maximum height; c) native polygon height is not used for floor/ceiling platforms */
 static void calculate_platform_extrema(

--- a/Source_Files/GameWorld/platforms.h
+++ b/Source_Files/GameWorld/platforms.h
@@ -80,7 +80,7 @@ enum /* static platform flags */
 	_platform_comes_from_floor, /* platform rises from floor */
 	_platform_comes_from_ceiling, /* platform lowers from ceiling */
 	_platform_causes_damage, /* when obstructed by monsters, this platform causes damage */
-	_platform_does_not_activate_parent, /* does not reactive itÕs parent (i.e., that platform which activated it) */
+	_platform_does_not_activate_parent, /* does not reactive itâ€™s parent (i.e., that platform which activated it) */
 	_platform_activates_only_once, /* cannot be activated a second time */
 	_platform_activates_light, /* activates floor and ceiling lightsources while activating */
 	_platform_deactivates_light, /* deactivates floor and ceiling lightsources while deactivating */
@@ -241,7 +241,7 @@ struct platform_data /* 140 bytes */
 
 	uint16 dynamic_flags;
 	world_distance floor_height, ceiling_height;
-	int16 ticks_until_restart; /* if weÕre not moving but are active, this is our delay until we move again */
+	int16 ticks_until_restart; /* if weâ€™re not moving but are active, this is our delay until we move again */
 
 	struct endpoint_owner_data endpoint_owners[MAXIMUM_VERTICES_PER_POLYGON];
 

--- a/Source_Files/GameWorld/player.cpp
+++ b/Source_Files/GameWorld/player.cpp
@@ -27,7 +27,7 @@ Wednesday, October 26, 1994 3:18:59 PM (Jason)
 Wednesday, November 30, 1994 6:56:20 PM  (Jason)
 	oxygen is used up faster by running and by firing.
 Thursday, January 12, 1995 11:18:18 AM  (Jason')
-	dead players donÕt continue to use up oxygen.
+	dead players donâ€™t continue to use up oxygen.
 Thursday, July 6, 1995 4:53:52 PM
 	supports multi-player cooperative games. (Ryan)
 
@@ -539,7 +539,7 @@ reset_player_queues()
 {
 	sRealActionQueues->reset();
 	reset_recording_and_playback_queues();
-	sync_heartbeat_count(); //¥¥ÊMY ADDITION...
+	sync_heartbeat_count(); //â€¢â€¢Â MY ADDITION...
 }
 
 // ZZZ addition: need to reset (potentially) multiple sets of ActionQueues, not just the RealActionQueues.
@@ -634,7 +634,7 @@ void decode_hotkeys(ModifiableActionQueues& action_queues)
 	}
 }
 
-/* assumes ¶t==1 tick */
+/* assumes âˆ‚t==1 tick */
 void update_players(ActionQueues* inActionQueuesToUse, bool inPredictive)
 {
 	struct player_data *player;
@@ -686,7 +686,7 @@ void update_players(ActionQueues* inActionQueuesToUse, bool inPredictive)
 		
 		bool IsSwimming = TEST_FLAG(player->variables.flags,_HEAD_BELOW_MEDIA_BIT) && player_settings.CanSwim;
 
-		// if weÕve got the ball we canÕt run (that sucks)
+		// if weâ€™ve got the ball we canâ€™t run (that sucks)
 		// Benad: also works with _game_of_rugby and _game_of_capture_the_flag
 		// LP change: made it possible to swim under a liquid if one has the ball
 		// START Benad changed oct. 1st (works with ANY ball color, d'uh...)
@@ -699,7 +699,7 @@ void update_players(ActionQueues* inActionQueuesToUse, bool inPredictive)
 		
 		// if (GET_GAME_TYPE()==_game_of_kill_man_with_ball && dynamic_world->game_player_index==player_index) action_flags&= ~_run_dont_walk;
 		
-		// if our head is under media, we canÕt run (that sucks, too)
+		// if our head is under media, we canâ€™t run (that sucks, too)
 		if (IsSwimming && (action_flags&_run_dont_walk)) action_flags&= ~_run_dont_walk, action_flags|= _swim;
 		
 		update_player_physics_variables(player_index, action_flags, inPredictive);
@@ -1465,7 +1465,7 @@ static void update_player_teleport(
 					{
 						player= get_player_data(other_player_index);
 
-						/* Set them to be teleporting if the already arenÕt, or if they are but it */
+						/* Set them to be teleporting if the already arenâ€™t, or if they are but it */
 						/*  is a simple teleport (intralevel) */
 						if (player_index!=other_player_index)
 						{
@@ -1584,7 +1584,7 @@ static void set_player_shapes(
 	
 	get_player_transfer_mode(player_index, &transfer_mode, &transfer_period);
 	
-	/* if weÕre not dead, handle changing shapes (if we are dead, the correct dying shape has
+	/* if weâ€™re not dead, handle changing shapes (if we are dead, the correct dying shape has
 		already been set and we just have to wait for the animation to finish) */
 	if (!PLAYER_IS_DEAD(player))
 	{
@@ -1619,11 +1619,11 @@ static void set_player_shapes(
 	
 	if (animate)
 	{
-		/* animate the player only if weÕre not airborne and not totally dead */
+		/* animate the player only if weâ€™re not airborne and not totally dead */
 		if ((variables->action!=_player_airborne || (PLAYER_IS_TELEPORTING(player) || PLAYER_IS_INTERLEVEL_TELEPORTING(player)))&&!PLAYER_IS_TOTALLY_DEAD(player)) animate_object(monster->object_index);
 		if (PLAYER_IS_DEAD(player) && !PLAYER_IS_TELEPORTING(player) && (GET_OBJECT_ANIMATION_FLAGS(legs)&_obj_last_frame_animated) && !PLAYER_IS_TOTALLY_DEAD(player))
 		{
-			/* weÕve finished the animation; let the player reincarnate if he wants to */
+			/* weâ€™ve finished the animation; let the player reincarnate if he wants to */
 			SET_PLAYER_TOTALLY_DEAD_STATUS(player, true);
 			set_player_dead_shape(player_index, false);
 
@@ -1649,13 +1649,13 @@ void revive_player(
 
 	monster->action= _monster_is_moving; /* was probably _dying or something */
 
-	/* remove only the playerÕs torso, which should be invisible anyway, and turn his legs
+	/* remove only the playerâ€™s torso, which should be invisible anyway, and turn his legs
 		into garbage */
 	remove_parasitic_object(monster->object_index);
 	turn_object_to_shit(monster->object_index);
 
-	/* create a new pair of legs, and (completely behind MONSTERS.CÕs back) reattach it to
-		itÕs monster (shape will be set by set_player_shapes, below) */
+	/* create a new pair of legs, and (completely behind MONSTERS.Câ€™s back) reattach it to
+		itâ€™s monster (shape will be set by set_player_shapes, below) */
 	player->object_index= monster->object_index= new_map_object(&location, 0);
 	object= get_object_data(monster->object_index);
 	SET_OBJECT_SOLIDITY(object, true);
@@ -1888,7 +1888,7 @@ static void remove_dead_player_items(
 			short item_kind= get_item_kind(item_type);
 			bool dropped= false;
 			
-			// if weÕre not set to burn items or this is an important item (i.e., repair chip) drop it
+			// if weâ€™re not set to burn items or this is an important item (i.e., repair chip) drop it
 			if (!(GET_GAME_OPTIONS()&_burn_items_on_death) ||
 				(item_kind==_item && dynamic_world->player_count>1))
 			{

--- a/Source_Files/GameWorld/player.h
+++ b/Source_Files/GameWorld/player.h
@@ -279,7 +279,7 @@ struct physics_variables
 	_fixed actual_height;
 
 	/* used by mask_in_absolute_positioning_information (because it is not really absolute) to
-		keep track of where weÕre going */
+		keep track of where weâ€™re going */
 	_fixed adjusted_pitch, adjusted_yaw;
 	
 	fixed_vector3d external_velocity; /* from impacts; slowly absorbed */
@@ -293,7 +293,7 @@ struct physics_variables
 	_fixed ceiling_height; /* same as above, but ceiling height */
 	_fixed media_height; /* media height */
 
-	int16 action; /* what the playerÕs legs are doing, basically */
+	int16 action; /* what the playerâ€™s legs are doing, basically */
 	uint16 old_flags, flags; /* stuff like _RECENTERING */
 };
 
@@ -362,7 +362,7 @@ struct player_data
 	int16 team;
 	char name[MAXIMUM_PLAYER_NAME_LENGTH+1];
 	
-	/* shadowed from physics_variables structure below and the playerÕs object (read-only) */
+	/* shadowed from physics_variables structure below and the playerâ€™s object (read-only) */
 	world_point3d location;
 	world_point3d camera_location; // beginning of fake world_location3d structure
 	int16 camera_polygon_index;
@@ -370,10 +370,10 @@ struct player_data
 	int16 supporting_polygon_index; /* what polygon is actually supporting our weight */
 	int16 last_supporting_polygon_index;
 
-	/* suit energy shadows vitality in the playerÕs monster slot */
+	/* suit energy shadows vitality in the playerâ€™s monster slot */
 	int16 suit_energy, suit_oxygen;
 	
-	int16 monster_index; /* this playerÕs entry in the monster list */
+	int16 monster_index; /* this playerâ€™s entry in the monster list */
 	int16 object_index; /* monster->object_index */
 	
 	/* Reset by initialize_player_weapons */
@@ -500,7 +500,7 @@ void team_damage_from_player_data(void);
 // ZZZ: this now takes a set of ActionQueues as a parameter so the caller can redirect
 // the update routine's input.  Also, now callers can request a 'predictive update',
 // which changes less state, in an effort to make partial state saving/restoration successful.
-void update_players(ActionQueues* inActionQueuesToUse, bool inPredictive); /* assumes ¶t==1 tick */
+void update_players(ActionQueues* inActionQueuesToUse, bool inPredictive); /* assumes âˆ‚t==1 tick */
 void decode_hotkeys(ModifiableActionQueues& action_queues);
 
 // handle pausing Marathon 1 terminals

--- a/Source_Files/GameWorld/projectile_definitions.h
+++ b/Source_Files/GameWorld/projectile_definitions.h
@@ -46,7 +46,7 @@ enum /* projectile flags */
 	_no_vertical_error= 0x0040,
 	_can_toggle_control_panels= 0x0080,
 	_positive_vertical_error= 0x0100,
-	_melee_projectile= 0x0200, /* can use a monsterÕs custom melee detonation */
+	_melee_projectile= 0x0200, /* can use a monsterâ€™s custom melee detonation */
 	_persistent_and_virulent= 0x0400, /* keeps moving and doing damage after a successful hit */
 	_usually_pass_transparent_side= 0x0800,
 	_sometimes_pass_transparent_side= 0x1000,
@@ -54,7 +54,7 @@ enum /* projectile flags */
 	_rebounds_from_floor= 0x4000, /* unless v.z<kvzMIN */
 	_penetrates_media= 0x8000, /* huh uh huh ... i said penetrate */
 	_becomes_item_on_detonation= 0x10000, /* item type in .permutation field of projectile */
-	_bleeding_projectile= 0x20000, /* can use a monsterÕs custom bleeding detonation */
+	_bleeding_projectile= 0x20000, /* can use a monsterâ€™s custom bleeding detonation */
 	_horizontal_wander= 0x40000, /* random horizontal error perpendicular to direction of movement */
 	_vertical_wander= 0x80000, /* random vertical movement perpendicular to direction of movement */
 	_affected_by_half_gravity= 0x100000,
@@ -91,7 +91,7 @@ struct projectile_definition
 static struct projectile_definition projectile_definitions[NUMBER_OF_PROJECTILE_TYPES];
 const struct projectile_definition original_projectile_definitions[NUMBER_OF_PROJECTILE_TYPES]=
 {
-	{	/* playerÕs rocket */
+	{	/* playerâ€™s rocket */
 		_collection_rocket, 0, /* collection number, shape number */
 		_effect_rocket_explosion, NONE, /* detonation effect, media_detonation_effect */
 		_effect_rocket_contrail, 1, NONE, /* contrail effect, ticks between contrails, maximum contrails */
@@ -110,7 +110,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 		_snd_rocket_flyby, NONE, /* flyby sound, rebound sound */
 	},
 	
-	{	/* playerÕs grenade */
+	{	/* playerâ€™s grenade */
 		_collection_rocket, 3, /* collection number, shape number */
 		_effect_grenade_explosion, _medium_media_detonation_effect, /* detonation effect, media_detonation_effect */
 		_effect_grenade_contrail, 1, 8, /* contrail effect, ticks between contrails, maximum contrails */
@@ -129,7 +129,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 		_snd_grenade_flyby, NONE, /* flyby sound, rebound sound */
 	},
 	
-	{	/* playerÕs pistol bullet */
+	{	/* playerâ€™s pistol bullet */
 		NONE, 0, /* collection number, shape number */
 		_effect_bullet_ricochet, _small_media_detonation_effect, /* detonation effect, media_detonation_effect */
 		NONE, 0, 0, /* contrail effect, ticks between contrails, maximum contrails */
@@ -148,7 +148,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 		NONE, NONE, /* flyby sound, rebound sound */
 	},
 	
-	{	/* playerÕs rifle bullet */
+	{	/* playerâ€™s rifle bullet */
 		NONE, 0, /* collection number, shape number */
 		_effect_bullet_ricochet, _small_media_detonation_effect, /* detonation effect, media_detonation_effect */
 		NONE, 0, 0, /* contrail effect, ticks between contrails, maximum contrails */
@@ -167,7 +167,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 		NONE, NONE, /* flyby sound, rebound sound */
 	},
 
-	{	/* playerÕs shotgun bullet */
+	{	/* playerâ€™s shotgun bullet */
 		NONE, 0, /* collection number, shape number */
 		_effect_bullet_ricochet, _small_media_detonation_effect, /* detonation effect, media_detonation_effect */
 		NONE, 0, 0, /* contrail effect, ticks between contrails, maximum contrails */
@@ -224,7 +224,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 		_snd_fighter_projectile_flyby, NONE, /* flyby sound, rebound sound */
 	},
 	
-	{	/* playerÕs flame thrower burst */
+	{	/* playerâ€™s flame thrower burst */
 		_collection_rocket, 6, /* collection number, shape number */
 		NONE, NONE, /* detonation effect, media_detonation_effect */
 		NONE, 0, 0, /* contrail effect, ticks between contrails, maximum contrails */
@@ -364,7 +364,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 
 		WORLD_ONE/4, /* radius */
 		0, /* area-of-effect */
-		{_damage_fist, 0, 50, 10}, /* damage (will be scaled by playerÕs velocity) */
+		{_damage_fist, 0, 50, 10}, /* damage (will be scaled by playerâ€™s velocity) */
 		
 		_usually_pass_transparent_side|_can_toggle_control_panels|_melee_projectile|_penetrates_media, /* flags */
 		
@@ -505,7 +505,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 
 		WORLD_ONE/8, /* radius */
 		0, /* area-of-effect */
-		{_damage_energy_drain, 0, 4, 0}, /* damage (will be scaled by playerÕs velocity) */
+		{_damage_energy_drain, 0, 4, 0}, /* damage (will be scaled by playerâ€™s velocity) */
 		
 		_melee_projectile|_penetrates_media, /* flags */
 		
@@ -524,7 +524,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 
 		WORLD_ONE/8, /* radius */
 		0, /* area-of-effect */
-		{_damage_energy_drain, 0, 8, 0}, /* damage (will be scaled by playerÕs velocity) */
+		{_damage_energy_drain, 0, 8, 0}, /* damage (will be scaled by playerâ€™s velocity) */
 		
 		_melee_projectile|_penetrates_media, /* flags */
 		
@@ -543,7 +543,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 
 		WORLD_ONE/8, /* radius */
 		0, /* area-of-effect */
-		{_damage_oxygen_drain, 0, 4, 0}, /* damage (will be scaled by playerÕs velocity) */
+		{_damage_oxygen_drain, 0, 4, 0}, /* damage (will be scaled by playerâ€™s velocity) */
 		
 		_melee_projectile|_penetrates_media, /* flags */
 		
@@ -783,7 +783,7 @@ const struct projectile_definition original_projectile_definitions[NUMBER_OF_PRO
 	},
 	
 	// LP addition: SMG bullet is a clone of the rifle one, except for entering/exiting liquids
-	{	/* playerÕs smg bullet */
+	{	/* playerâ€™s smg bullet */
 		NONE, 0, /* collection number, shape number */
 		_effect_bullet_ricochet, _small_media_detonation_effect, /* detonation effect, media_detonation_effect */
 		NONE, 0, 0, /* contrail effect, ticks between contrails, maximum contrails */

--- a/Source_Files/GameWorld/projectiles.cpp
+++ b/Source_Files/GameWorld/projectiles.cpp
@@ -176,7 +176,7 @@ projectile_definition *get_projectile_definition(
 	return definition;
 }
 
-/* false means donÕt fire this (itÕs in a floor or ceiling or outside of the map), otherwise
+/* false means donâ€™t fire this (itâ€™s in a floor or ceiling or outside of the map), otherwise
 	the monster that was intersected first (or NONE) is returned in target_index */
 bool preflight_projectile(
 	world_point3d *origin,
@@ -247,7 +247,7 @@ short new_projectile(
 	world_point3d *origin,
 	short polygon_index,
 	world_point3d *_vector,
-	angle delta_theta, /* ±¶theta is added (in a circle) to the angle before firing */
+	angle delta_theta, /* Â±âˆ‚theta is added (in a circle) to the angle before firing */
 	short type,
 	short owner_index,
 	short owner_type,
@@ -318,7 +318,7 @@ short new_projectile(
 
 extern void track_contrail_interpolation(int16_t, int16_t);
 
-/* assumes ¶t==1 tick */
+/* assumes âˆ‚t==1 tick */
 void move_projectiles(
 	void)
 {
@@ -342,10 +342,10 @@ void move_projectiles(
 				
 				new_location= old_location= object->location;
 	
-				/* update our objectÕs animation */
+				/* update our objectâ€™s animation */
 				animate_object(projectile->object_index);
 				
-				/* if weÕre supposed to end when our animation loops, check this condition */
+				/* if weâ€™re supposed to end when our animation loops, check this condition */
 				if ((definition->flags&_stop_when_animation_loops) && (GET_OBJECT_ANIMATION_FLAGS(object)&_obj_last_frame_animated))
 				{
 					remove_projectile(projectile_index);
@@ -373,7 +373,7 @@ void move_projectiles(
 
 					if (PROJECTILE_HAS_CROSSED_MEDIA_BOUNDARY(projectile)) adjusted_definition_flags= _penetrates_media;
 					
-					/* move the projectile and check for collisions; if we didnÕt detonate move the
+					/* move the projectile and check for collisions; if we didnâ€™t detonate move the
 						projectile and check to see if we need to leave a contrail */
 					if ((definition->flags&_affected_by_half_gravity) && (dynamic_world->tick_count&1)) projectile->gravity-= GRAVITATIONAL_ACCELERATION;
 					if (definition->flags&_affected_by_gravity) projectile->gravity-= GRAVITATIONAL_ACCELERATION;
@@ -526,7 +526,7 @@ void move_projectiles(
 											reassign_projectile = MONSTER_IS_PLAYER(monster) || !MONSTER_IS_DYING(monster);
 										}
 										if (reassign_projectile)
-											projectile->owner_index= monster_obstruction_index; /* keep going, but donÕt hit this target again */
+											projectile->owner_index= monster_obstruction_index; /* keep going, but donâ€™t hit this target again */
 									}
 									// LP addition: don't remove a projectile that will hit media and continue (PMB flag)
 									else if (!will_go_through)
@@ -651,7 +651,7 @@ void mark_projectile_collections(
 			loading ? mark_collection_for_loading(definition->collection) : mark_collection_for_unloading(definition->collection);
 		}
 		
-		/* mark the projectileÕs effectÕs collection */
+		/* mark the projectileâ€™s effectâ€™s collection */
 		mark_effect_collections(definition->detonation_effect, loading);
 		mark_effect_collections(definition->contrail_effect, loading);
 	}
@@ -721,7 +721,7 @@ static short adjust_projectile_type(
 #define MAXIMUM_GUIDED_DELTA_YAW 8
 #define MAXIMUM_GUIDED_DELTA_PITCH 6
 
-/* changes are at a rate of ±1 angular unit per tick */
+/* changes are at a rate of Â±1 angular unit per tick */
 static void update_guided_projectile(
 	short projectile_index)
 {
@@ -740,7 +740,7 @@ static void update_guided_projectile(
 	{
 		case _xfer_invisibility:
 		case _xfer_subtle_invisibility:
-			/* canÕt hold lock on invisible targets unless on _total_carnage_level */
+			/* canâ€™t hold lock on invisible targets unless on _total_carnage_level */
 			if (dynamic_world->game_information.difficulty_level!=_total_carnage_level) break;
 		default:
 		{
@@ -812,7 +812,7 @@ uint16 translate_projectile(
 			traveled_underneath = (definition->flags&_penetrates_media_boundary) && (old_location->z <= media_height);
 		}
 		
-		/* add this polygonÕs monsters to our non-redundant list of possible intersections */
+		/* add this polygonâ€™s monsters to our non-redundant list of possible intersections */
 		if (!(definition->flags & _passes_through_objects))
 		{
 			possible_intersecting_monsters(&IntersectedObjects, GLOBAL_INTERSECTING_MONSTER_BUFFER_SIZE, old_polygon_index, true);
@@ -904,7 +904,7 @@ uint16 translate_projectile(
 		}
 		else
 		{
-			/* make sure we didnÕt hit the ceiling or floor in this polygon */
+			/* make sure we didnâ€™t hit the ceiling or floor in this polygon */
 			// LP change: if PMB is set, then a projectile can travel as if the liquid did not exist,
 			// but it will be able to run into a media surface.
 			// Here, test for whether the projectile is above the floor or the media surface;
@@ -914,7 +914,7 @@ uint16 translate_projectile(
 				// If PMB was set, check to see if the projectile hit the media surface.
 				if ((!traveled_underneath || new_location->z<media_height) && new_location->z<old_polygon->ceiling_height)
 				{
-					/* weÕre staying in this polygon and weÕre finally done screwing around;
+					/* weâ€™re staying in this polygon and weâ€™re finally done screwing around;
 						the caller can look in *new_polygon_index to find out where we ended up */
 				}
 				else
@@ -938,7 +938,7 @@ uint16 translate_projectile(
 	}
 	while (line_index!=NONE&&contact==_hit_nothing);
 	
-	/* ceilings and floor intersections still donÕt have accurate intersection points, so calculate
+	/* ceilings and floor intersections still donâ€™t have accurate intersection points, so calculate
 		them */
 	if (contact!=_hit_nothing)
 	{
@@ -979,7 +979,7 @@ uint16 translate_projectile(
 				(world_point2d *)old_location, (world_point2d *)new_location);
 			world_distance radius, height;
 				
-			if (object->permutation!=owner_index) /* donÕt hit ourselves */
+			if (object->permutation!=owner_index) /* donâ€™t hit ourselves */
 			{
 				int32 radius_squared;
 				
@@ -993,7 +993,7 @@ uint16 translate_projectile(
 				}
 				radius_squared= (radius+definition->radius)*(radius+definition->radius);
 				
-				if (separation<radius_squared) /* if weÕre within radius^2 we passed through this monster */
+				if (separation<radius_squared) /* if weâ€™re within radius^2 we passed through this monster */
 				{
 					world_distance distance= distance2d((world_point2d *)old_location, (world_point2d *)&object->location);
 					world_distance projectile_z= distance_traveled ? 
@@ -1023,7 +1023,7 @@ uint16 translate_projectile(
 				}
 				else
 				{
-					if (GET_OBJECT_OWNER(object)==_object_is_monster && separation<12*radius_squared) /* if weÕre within (x*radius)^2 we passed near this monster */
+					if (GET_OBJECT_OWNER(object)==_object_is_monster && separation<12*radius_squared) /* if weâ€™re within (x*radius)^2 we passed near this monster */
 					{
 						if (MONSTER_IS_PLAYER(get_monster_data(object->permutation)) && 
 							monster_index_to_player_index(object->permutation)==current_player_index)

--- a/Source_Files/GameWorld/projectiles.h
+++ b/Source_Files/GameWorld/projectiles.h
@@ -115,7 +115,7 @@ struct projectile_data /* 32 bytes */
 
 	short target_index; /* for guided projectiles, the current target index */
 
-	angle elevation; /* facing is stored in the projectileÕs object */
+	angle elevation; /* facing is stored in the projectileâ€™s object */
 	
 	short owner_index; /* ownerless if NONE */
 	short owner_type; /* identical to the monster type which fired this projectile (valid even if owner==NONE) */
@@ -174,7 +174,7 @@ void detonate_projectile(world_point3d *origin, short polygon_index, short type,
 // as may happen for a "penetrates media boundary" projectile.
 uint16 translate_projectile(short type, world_point3d *old_location, short old_polygon_index, world_point3d *new_location, short *new_polygon_index, short owner_index, short *obstruction_index, short *last_line_index, bool preflight, short projectile_indexx);
 
-void move_projectiles(void); /* assumes ¶t==1 tick */
+void move_projectiles(void); /* assumes âˆ‚t==1 tick */
 
 void remove_projectile(short projectile_index);
 void remove_all_projectiles(void);

--- a/Source_Files/GameWorld/scenery.cpp
+++ b/Source_Files/GameWorld/scenery.cpp
@@ -23,7 +23,7 @@ Thursday, December 1, 1994 11:56:43 AM  (Jason)
 Friday, June 16, 1995 11:48:23 AM  (Jason)
 	animated scenery; audible scenery.
 Tuesday, October 10, 1995 10:30:58 AM  (Jason)
-	destroyable scenery; new_scenery doesnÕt bail on out-of-range scenery.
+	destroyable scenery; new_scenery doesnâ€™t bail on out-of-range scenery.
 
 Jan 30, 2000 (Loren Petrich):
 	Added some typecasts

--- a/Source_Files/GameWorld/scenery_definitions.h
+++ b/Source_Files/GameWorld/scenery_definitions.h
@@ -94,7 +94,7 @@ struct scenery_definition scenery_definitions[]=
 	{_scenery_is_solid, BUILD_DESCRIPTOR(_collection_scenery1, 16), WORLD_ONE_FOURTH, WORLD_ONE_HALF}, // security monitor
 	{_scenery_is_solid, BUILD_DESCRIPTOR(_collection_scenery1, 17), WORLD_ONE_FOURTH, WORLD_ONE_HALF}, // alien supply can
 	{_scenery_is_animated, BUILD_DESCRIPTOR(_collection_scenery1, 18)}, // machine
-	{0, BUILD_DESCRIPTOR(_collection_scenery1, 20)}, // fighterÕs staff
+	{0, BUILD_DESCRIPTOR(_collection_scenery1, 20)}, // fighterâ€™s staff
 
 	// sewage
 	{_scenery_is_solid|_scenery_can_be_destroyed, BUILD_DESCRIPTOR(_collection_scenery3, 5), WORLD_ONE/6, -WORLD_ONE/8, _effect_sewage_lamp_breaking, BUILD_DESCRIPTOR(_collection_scenery3, 6)}, // stubby green light

--- a/Source_Files/GameWorld/weapon_definitions.h
+++ b/Source_Files/GameWorld/weapon_definitions.h
@@ -209,7 +209,7 @@ struct weapon_definition {
 	_fixed firing_light_intensity;
 	int16 firing_intensity_decay_ticks;
 
-	/* weapon will come up to FIXED_ONE when fired; idle_height±bob_amplitude should be in
+	/* weapon will come up to FIXED_ONE when fired; idle_heightÂ±bob_amplitude should be in
 		the range [0,FIXED_ONE] */
 	_fixed idle_height, bob_amplitude, kick_height, reload_height;
 	_fixed idle_width, horizontal_amplitude;

--- a/Source_Files/GameWorld/weapons.cpp
+++ b/Source_Files/GameWorld/weapons.cpp
@@ -380,11 +380,11 @@ void mark_weapon_collections(
 	{
 		struct weapon_definition *definition= get_weapon_definition(index);
 		
-		/* Mark the weaponÕs collection */	
+		/* Mark the weaponâ€™s collection */
 		loading ? mark_collection_for_loading(definition->collection) : 
 			mark_collection_for_unloading(definition->collection);
 
-		/* Mark the projectileÕs collection, NONE is handled correctly */
+		/* Mark the projectileâ€™s collection, NONE is handled correctly */
 		if(index != _weapon_ball)
 		{
 			mark_projectile_collections(definition->weapons_by_trigger[_primary_weapon].projectile_type, loading);
@@ -2204,7 +2204,7 @@ static bool check_reload(
 							} else {
 								if(which_trigger==_primary_weapon)
 								{
-									/* ¥¥ÊProblems? */
+									/* â€¢â€¢Â Problems? */
 									struct trigger_data *other_trigger= 
 										get_player_trigger_data(player_index, !which_trigger);
 										

--- a/Source_Files/GameWorld/world.cpp
+++ b/Source_Files/GameWorld/world.cpp
@@ -27,15 +27,15 @@ Thursday, January 21, 1993 9:46:24 PM
 Saturday, January 23, 1993 9:46:34 PM
 	fixed arctangent, hopefully for the last time.  normalize_angle() is a little faster.
 Monday, January 25, 1993 3:01:47 PM
-	arctangent works (tested at 0.5¡ increments against SANEÕs tan), the only anomoly was
-	apparently arctan(0)==180¡.
+	arctangent works (tested at 0.5Â° increments against SANEâ€™s tan), the only anomoly was
+	apparently arctan(0)==180Â°.
 Wednesday, January 27, 1993 3:49:04 PM
-	final fix to arctangent, we swear.  recall lim(arctan(x)) as x approaches ¹/2 or 3¹/4 is ±°,
+	final fix to arctangent, we swear.  recall lim(arctan(x)) as x approaches Ï€/2 or 3Ï€/4 is Â±âˆž,
 	depending on which side we come from.  because we didn't realize this, arctan failed in the
-	case where x was very close to but slightly below ¹/2.  i think weÕve seen the last monster
-	suddenly ÔpanicÕ and bolt directly into a wall.
+	case where x was very close to but slightly below Ï€/2.  i think weâ€™ve seen the last monster
+	suddenly â€˜panicâ€™ and bolt directly into a wall.
 Sunday, July 25, 1993 11:51:42 PM
-	the arctan of 0/0 is now (arbitrairly) ¹/2 because weÕre sick of assert(y) failing.
+	the arctan of 0/0 is now (arbitrairly) Ï€/2 because weâ€™re sick of assert(y) failing.
 Monday, June 20, 1994 4:15:06 PM
 	bug fix in translate_point3d().
 
@@ -86,8 +86,8 @@ angle normalize_angle(
 */
 
 /* remember this is not wholly accurate, both distance or the sine/cosine values could be
-	negative, and the shift canÕt make negative numbers zero; this is probably ok because
-	weÕll have -1/1024th instead of zero, which is basically our margin for error anyway ... */
+	negative, and the shift canâ€™t make negative numbers zero; this is probably ok because
+	weâ€™ll have -1/1024th instead of zero, which is basically our margin for error anyway ... */
 world_point2d *translate_point2d(
 	world_point2d *point,
 	world_distance distance,
@@ -225,7 +225,7 @@ void build_trig_tables(
 		if (i==HALF_CIRCLE) sine_table[i]= 0, cosine_table[i]= -TRIG_MAGNITUDE;
 		if (i==THREE_QUARTER_CIRCLE) sine_table[i]= -TRIG_MAGNITUDE, cosine_table[i]= 0;
 		
-		/* what we care about here is NOT accuracy, rather weÕre concerned with matching the
+		/* what we care about here is NOT accuracy, rather weâ€™re concerned with matching the
 			ratio of the existing sine and cosine tables as exactly as possible */
 		if (cosine_table[i])
 		{
@@ -233,7 +233,7 @@ void build_trig_tables(
 		}
 		else
 		{
-			/* we always take -°, even though the limit is ±°, depending on which side you
+			/* we always take -âˆž, even though the limit is Â±âˆž, depending on which side you
 				approach it from.  this is because of the direction we traverse the circle
 				looking for matches during arctan. */
 			tangent_table[i]= INT32_MIN;
@@ -291,11 +291,11 @@ static angle m2_arctangent(
 	}
 	else
 	{
-		/* so arctan(0,0)==¹/2 (bill me) */
+		/* so arctan(0,0)==Ï€/2 (bill me) */
 		return y<0 ? THREE_QUARTER_CIRCLE : QUARTER_CIRCLE;
 	}
 }
-/* one day weÕll come back here and actually make this run fast */
+/* one day weâ€™ll come back here and actually make this run fast */
 // LP change: made this long-distance friendly
 //
 static angle a1_arctangent(

--- a/Source_Files/GameWorld/world.h
+++ b/Source_Files/GameWorld/world.h
@@ -86,7 +86,7 @@ typedef int16 world_distance;
 /* arguments must be positive (!) or use guess_hypotenuse() */
 #define GUESS_HYPOTENUSE(x, y) ((x)>(y) ? ((x)+((y)>>1)) : ((y)+((x)>>1)))
 
-/* -360¡<t<720¡ (!) or use normalize_angle() */
+/* -360Â°<t<720Â° (!) or use normalize_angle() */
 //#define NORMALIZE_ANGLE(t) ((t)<(angle)0?(t)+NUMBER_OF_ANGLES:((t)>=NUMBER_OF_ANGLES?(t)-NUMBER_OF_ANGLES:(t)))
 #define NORMALIZE_ANGLE(t) ((t)&(angle)(NUMBER_OF_ANGLES-1))
 
@@ -199,7 +199,7 @@ world_point3d *translate_point3d(world_point3d *point, world_distance distance, 
 world_point2d *transform_point2d(world_point2d *point, world_point2d *origin, angle theta);
 world_point3d *transform_point3d(world_point3d *point, world_point3d *origin, angle theta, angle phi);
 
-/* angle is in [0,NUMBER_OF_ANGLES), or, [0,2¹) */
+/* angle is in [0,NUMBER_OF_ANGLES), or, [0,2Ï€) */
 // LP change: made this long-distance friendly
 angle arctangent(int32 x, int32 y);
 

--- a/Source_Files/Misc/ActionQueues.cpp
+++ b/Source_Files/Misc/ActionQueues.cpp
@@ -98,7 +98,7 @@ ActionQueues::resetQueue(int inPlayerIndex)
 
 
 // Lifted from player.cpp::queue_action_flags()
-/* queue an action flag on the given playerÕs queue (no zombies allowed) */
+/* queue an action flag on the given playerâ€™s queue (no zombies allowed) */
 void
 ActionQueues::enqueueActionFlags(
 	int player_index,
@@ -125,7 +125,7 @@ ActionQueues::enqueueActionFlags(
 
 
 // Lifted from player.cpp::dequeue_action_flags()
-/* dequeueÕs a single action flag from the given queue (zombies always return zero) */
+/* dequeueâ€™s a single action flag from the given queue (zombies always return zero) */
 uint32
 ActionQueues::dequeueActionFlags(
 	int player_index)

--- a/Source_Files/Misc/interface.cpp
+++ b/Source_Files/Misc/interface.cpp
@@ -23,7 +23,7 @@
 
 	Friday, July 8, 1994 2:32:44 PM (alain)
 		All old code in here is obsolete. This now has interface for the top-level
-		interface (Begin Game, etc…)
+		interface (Begin Game, etc‚Ä¶)
 	Saturday, September 10, 1994 12:45:48 AM  (alain)
 		the interface gutted again. just the stuff that handles the menu though, the rest stayed
 		the same.
@@ -840,7 +840,7 @@ bool join_networked_resume_game()
                         }
                         else
                         {
-                                /* Tell the user they’re screwed when they try to leave this level. */
+                                /* Tell the user they‚Äôre screwed when they try to leave this level. */
                                 // ZZZ: should really issue a different warning since the ramifications are different
                                 alert_user(infoError, strERRORS, cantFindMap, 0);
         
@@ -1209,7 +1209,7 @@ bool idle_game_state(uint32 time)
 		game_state.last_ticks_on_idle= machine_tick_count();
 	}
 
-	/* if we’re not paused and there’s something to draw (i.e., anything different from
+	/* if we‚Äôre not paused and there‚Äôs something to draw (i.e., anything different from
 		last time), render a frame */
 	if(game_state.state==_game_in_progress)
 	{
@@ -1789,7 +1789,7 @@ static void display_about_dialog()
 	authors.push_back("Carl Gherardi");
 	authors.push_back("Thomas Herzog");
 	authors.push_back("Chris Hallock (LidMop)");
-	authors.push_back("Benoît Hauquier (Kolfering)");
+	authors.push_back("Beno√Æt Hauquier (Kolfering)");
 	authors.push_back("Peter Hessler");
 	authors.push_back("Matthew Hielscher");
 	authors.push_back("Rhys Hill");

--- a/Source_Files/Misc/interface.cpp
+++ b/Source_Files/Misc/interface.cpp
@@ -1789,7 +1789,7 @@ static void display_about_dialog()
 	authors.push_back("Carl Gherardi");
 	authors.push_back("Thomas Herzog");
 	authors.push_back("Chris Hallock (LidMop)");
-	authors.push_back("Benoît Hauquier (Kolfering)");
+	authors.push_back(utf8_to_mac_roman("Benoît Hauquier (Kolfering)"));
 	authors.push_back("Peter Hessler");
 	authors.push_back("Matthew Hielscher");
 	authors.push_back("Rhys Hill");

--- a/Source_Files/Misc/vbl.cpp
+++ b/Source_Files/Misc/vbl.cpp
@@ -29,9 +29,9 @@ Thursday, November 19, 1992 1:27:23 AM
 	the enumeration 'turning_head' had to be changed to '_turn_not_rotate' to make this
 	file compile.  go figure.
 Wednesday, December 2, 1992 2:31:05 PM
-	the world doesnÕt change while the mouse button is pressed.
+	the world doesnâ€™t change while the mouse button is pressed.
 Friday, January 15, 1993 11:19:11 AM
-	the world doesnÕt change after 14 ticks have passed without a screen refresh.
+	the world doesnâ€™t change after 14 ticks have passed without a screen refresh.
 Friday, January 22, 1993 3:06:32 PM
 	world_ticks was never being initialized to zero.  hmmm.
 Saturday, March 6, 1993 12:23:48 PM
@@ -47,7 +47,7 @@ Sunday, May 22, 1994 8:51:15 PM
 	distribute a circular queue of keyboard flags (we're the keyboard_controller, not the
 	movement_controller).
 Thursday, June 2, 1994 12:55:52 PM
-	gee, now we donÕt even maintain the queue we just send our actions to PLAYER.C.
+	gee, now we donâ€™t even maintain the queue we just send our actions to PLAYER.C.
 Tuesday, July 5, 1994 9:27:49 PM
 	nuked most of the shit in here. changed the vbl task to a time
 	manager task. the only functions from the old vbl.c that remain are precalculate_key_information()
@@ -456,8 +456,8 @@ static bool pull_flags_from_recording(
 	short player_index;
 	bool success= true;
 	
-	// first check that we can pull something from each playerÕs queue
-	// (at the beginning of the game, we wonÕt be able to)
+	// first check that we can pull something from each playerâ€™s queue
+	// (at the beginning of the game, we wonâ€™t be able to)
 	// i'm not sure that i really need to do this check. oh well.
 	for (player_index = 0; success && player_index<dynamic_world->player_count; player_index++)
 	{

--- a/Source_Files/Network/network.cpp
+++ b/Source_Files/Network/network.cpp
@@ -1607,7 +1607,7 @@ NetCancelJoin
 
 	<--- error
 
-canÕt be called after the player has been gathered
+canâ€™t be called after the player has been gathered
 */
 
 bool NetGameJoin(
@@ -1885,7 +1885,7 @@ static void NetInitializeTopology(
 	assert(player_data_size>=0&&player_data_size<MAXIMUM_PLAYER_DATA_SIZE);
 	assert(game_data_size>=0&&game_data_size<MAXIMUM_GAME_DATA_SIZE);
 
-	/* initialize the local player (assume weÕre index zero, identifier zero) */
+	/* initialize the local player (assume weâ€™re index zero, identifier zero) */
 	localPlayerIndex= localPlayerIdentifier= 0;
 	local_player= topology->players + localPlayerIndex;
 	local_player->identifier= localPlayerIdentifier;
@@ -1897,7 +1897,7 @@ static void NetInitializeTopology(
 	if (player_data_size > 0)
 		memcpy(&local_player->player_data, player_data, player_data_size);
 	
-	/* initialize the network topology (assume weÕre the only player) */
+	/* initialize the network topology (assume weâ€™re the only player) */
 	topology->player_count= 1;
 	topology->nextIdentifier= 1;
 	if (game_data_size > 0)
@@ -1941,7 +1941,7 @@ static bool NetSetSelfSend(
 
 
 /* ------ this needs to let the gatherer keep going if there was an error.. */
-/* ¥¥¥ÊMarathon Specific Code ¥¥¥ */
+/* â€¢â€¢â€¢Â Marathon Specific Code â€¢â€¢â€¢ */
 /* Returns error code.. */
 // ZZZ annotation: this function doesn't seem to belong here - maybe more like interface.cpp?
 bool NetChangeMap(
@@ -2443,7 +2443,7 @@ short NetUpdateJoinState(
       break;
     }
   
-  /* return netPlayerAdded to tell the caller to refresh his topology, but donÕt change netState to that */
+  /* return netPlayerAdded to tell the caller to refresh his topology, but donâ€™t change netState to that */
   // ZZZ: similar behavior for netChatMessageReceived and netStartingResumeGame
   if (newState!=netPlayerAdded && newState!=netPlayerDropped && newState!=netPlayerChanged && newState != netChatMessageReceived && newState != netStartingResumeGame && newState != NONE)
     netState= newState;
@@ -2492,7 +2492,7 @@ NetDistributeTopology
 
 	<--- error
 
-connect to everyoneÕs dspAddress and give them the latest copy of the network topology.  this
+connect to everyoneâ€™s dspAddress and give them the latest copy of the network topology.  this
 used to be NetStart() and it used to connect all upring and downring ADSP connections.
 */
 static void NetDistributeTopology(

--- a/Source_Files/Network/network.h
+++ b/Source_Files/Network/network.h
@@ -114,7 +114,7 @@ struct prospective_joiner_info {
 
 
 /* ---------------- functions from network.c */
-enum /* message types passed to the userÕs names lookup update procedure */
+enum /* message types passed to the userâ€™s names lookup update procedure */
 {
 	removeEntity,
 	insertEntity

--- a/Source_Files/Network/network_games.cpp
+++ b/Source_Files/Network/network_games.cpp
@@ -355,7 +355,7 @@ short get_network_compass_state(
 	{
                 switch (GET_GAME_TYPE())
                 {
-                        case _game_of_king_of_the_hill: // whereÕs the hill
+                        case _game_of_king_of_the_hill: // whereâ€™s the hill
                         // Benad
                         case _game_of_defense:
                                 if (get_polygon_data(get_player_data(player_index)->supporting_polygon_index)->type==_polygon_is_hill)
@@ -368,7 +368,7 @@ short get_network_compass_state(
                                 }
                                 break;
 			
-                        case _game_of_tag: // whereÕs it
+                        case _game_of_tag: // whereâ€™s it
                                 if (dynamic_world->game_player_index==player_index)
                                 {
                                         state= _network_compass_all_on;
@@ -396,7 +396,7 @@ short get_network_compass_state(
                                 }
                                 break;
                         //END Benad
-                        case _game_of_kill_man_with_ball: // whereÕs the ball
+                        case _game_of_kill_man_with_ball: // whereâ€™s the ball
                                 if (player_has_ball(player_index, SINGLE_BALL_COLOR))
                                 {
                                         state= _network_compass_all_on;
@@ -427,7 +427,7 @@ short get_network_compass_state(
 	return state;
 }
 
-// if false is returned, donÕt attribute kill
+// if false is returned, donâ€™t attribute kill
 bool player_killed_player(
 	short dead_player_index,
 	short aggressor_player_index)
@@ -445,7 +445,7 @@ bool player_killed_player(
 				{
 					if (dynamic_world->game_player_index!=dead_player_index)
 					{
-						// change of ÔitÕ
+						// change of â€˜itâ€™
 						player_data* player = get_player_data(dead_player_index);
 						play_object_sound(player->object_index, _snd_you_are_it);
 						dynamic_world->game_player_index= dead_player_index;
@@ -576,7 +576,7 @@ bool update_net_game(
 							/*if(player->netgame_parameters[_offender_time_in_base]>GET_GAME_PARAMETER(_maximum_offender_time_in_base))
 							{
 								dprintf("Game is over. Offender won.");
-								//¥¥
+								//â€¢â€¢
 								dynamic_world->game_information.parameters[_winning_team]= player->team;
 								net_game_over= true;
 							}*/

--- a/Source_Files/Network/network_private.h
+++ b/Source_Files/Network/network_private.h
@@ -180,7 +180,7 @@ struct NetDistributionPacket
 	int16 distribution_type;  // type of information
 	int16 first_player_index; // who sent the information
 	int16 data_size;          // how much they're sending.
-	uint8  data[2];            // the chunk Õo shit to send
+	uint8  data[2];            // the chunk â€™o shit to send
 };
 typedef struct NetDistributionPacket NetDistributionPacket, *NetDistributionPacketPtr;
 

--- a/Source_Files/RenderMain/RenderPlaceObjs.cpp
+++ b/Source_Files/RenderMain/RenderPlaceObjs.cpp
@@ -516,7 +516,7 @@ void RenderPlaceObjsClass::sort_render_object_into_tree(
 		}
 	}
 
-	/* find the node weÕd like to be in (that is, the node closest to the viewer of all the nodes
+	/* find the node weâ€™d like to be in (that is, the node closest to the viewer of all the nodes
 		we cross and therefore the latest one in the sorted node list) */
 	desired_node= base_nodes[0];
 	for (i= 1; i<base_node_count; ++i) if (base_nodes[i]>desired_node) desired_node= base_nodes[i];
@@ -546,7 +546,7 @@ void RenderPlaceObjsClass::sort_render_object_into_tree(
 		}
 	}
 	
-	/* update the .node fields of all the objects weÕre about to add to reflect their new
+	/* update the .node fields of all the objects weâ€™re about to add to reflect their new
 		location in the sorted node list */
 	for (render_object= new_render_object; render_object; render_object= render_object->next_object)
 	{
@@ -599,8 +599,8 @@ enum /* build_base_node_list() states */
 };
 
 /* we once thought it would be a clever idea to use the transformed endpoints, but, not.  we
-	now bail if we canÕt find a way out of the polygon we are given; usually this happens
-	when weÕre moving along gridlines */
+	now bail if we canâ€™t find a way out of the polygon we are given; usually this happens
+	when weâ€™re moving along gridlines */
 short RenderPlaceObjsClass::build_base_node_list(
 	short origin_polygon_index,
 	world_point3d *origin,
@@ -649,7 +649,7 @@ short RenderPlaceObjsClass::build_base_node_list(
 		do
 		{
 			polygon_data *polygon= get_polygon_data(polygon_index);
-			short state= _looking_for_first_nonzero_vertex; /* really: testing first vertex state (we donÕt have zero vertices) */
+			short state= _looking_for_first_nonzero_vertex; /* really: testing first vertex state (we donâ€™t have zero vertices) */
 			short vertex_index= 0, vertex_delta= 1; /* start searching clockwise from vertex zero */
 			world_point2d *vertex, *next_vertex;
 			
@@ -697,7 +697,7 @@ short RenderPlaceObjsClass::build_base_node_list(
 				/* adjust vertex_index (clockwise or counterclockwise, depending on vertex_delta) */
 				vertex_index= (vertex_delta<0) ? WRAP_LOW(vertex_index, polygon->vertex_count-1) :
 					WRAP_HIGH(vertex_index, polygon->vertex_count-1);
-				if (state!=NONE&&!vertex_index) polygon_index= state= NONE; /* we canÕt find a way out; give up */
+				if (state!=NONE&&!vertex_index) polygon_index= state= NONE; /* we canâ€™t find a way out; give up */
 			}
 			while (state!=NONE);
 			
@@ -705,19 +705,19 @@ short RenderPlaceObjsClass::build_base_node_list(
 			{
 				polygon= get_polygon_data(polygon_index);
 				
-				/* canÕt do above clipping (see note in change history) */
+				/* canâ€™t do above clipping (see note in change history) */
 				if ((view->origin.z<origin->z && polygon->floor_height<origin_polygon_floor_height) ||
 					(view->origin.z>origin->z && origin->z+WORLD_ONE_HALF<polygon->floor_height && polygon->floor_height>origin_polygon_floor_height))
 				{
-					/* if weÕre above the viewer and going into a lower polygon or below the viewer and going
-						into a higher polygon, donÕt */
+					/* if weâ€™re above the viewer and going into a lower polygon or below the viewer and going
+						into a higher polygon, donâ€™t */
 //					dprintf("discarding polygon #%d by height", polygon_index);
 					polygon_index= NONE;
 				}
 				else
 				{
 //					dprintf("  into polygon #%d", polygon_index);
-					if (!TEST_RENDER_FLAG(polygon_index, _polygon_is_visible)) polygon_index= NONE; /* donÕt have transformed data, donÕt even try! */
+					if (!TEST_RENDER_FLAG(polygon_index, _polygon_is_visible)) polygon_index= NONE; /* donâ€™t have transformed data, donâ€™t even try! */
 					if ((destination.x-vertex->x)*(next_vertex->y-vertex->y) - (destination.y-vertex->y)*(next_vertex->x-vertex->x) <= 0) polygon_index= NONE;
 					if (polygon_index!=NONE && base_node_count<MAXIMUM_OBJECT_BASE_NODES) base_nodes[base_node_count++]= polygon_index_to_sorted_node[polygon_index];
 				}
@@ -874,7 +874,7 @@ void RenderPlaceObjsClass::build_aggregate_render_object_clipping_window(
 					first_window= window;
 				}
 				
-				/* advance left by one, then advance right until itÕs greater than left */
+				/* advance left by one, then advance right until itâ€™s greater than left */
 				if (++left<left_count) while (x0[left]>x1[right] && right<right_count) ++right;
 			}
 			else

--- a/Source_Files/RenderMain/RenderRasterize.cpp
+++ b/Source_Files/RenderMain/RenderRasterize.cpp
@@ -179,7 +179,7 @@ void RenderRasterizerClass::render_node(
 	// LP change: always render liquids that are semitransparent
 	else if (!SeeThruLiquids)
 	{
-		// if weÕre trying to draw a polygon without media from under a polygon with media, donÕt
+		// if weâ€™re trying to draw a polygon without media from under a polygon with media, donâ€™t
 		if (view->under_media_boundary) return;
 	}
 	
@@ -692,7 +692,7 @@ short RenderRasterizerClass::xy_clip_horizontal_polygon(
 //					dprintf("vertex#%d is on the clip line s==#%d", vertex_index, state);
 					switch (state)
 					{
-						/* if weÕre testing the first vertex, this tells us nothing */
+						/* if weâ€™re testing the first vertex, this tells us nothing */
 						
 						case _searching_cw_for_out_in_transition:
 							entrance_vertex= vertex_index;
@@ -729,7 +729,7 @@ short RenderRasterizerClass::xy_clip_horizontal_polygon(
 			}
 
 			/* adjust vertex_index (clockwise or counterclockwise, depending on vertex_delta)
-				if weÕve come back to the first vertex without finding an entrance point weÕre
+				if weâ€™ve come back to the first vertex without finding an entrance point weâ€™re
 				either all the way in or all the way out */
 			vertex_index= (vertex_delta<0) ? WRAP_LOW(vertex_index, vertex_count-1) :
 				WRAP_HIGH(vertex_index, vertex_count-1);
@@ -749,7 +749,7 @@ short RenderRasterizerClass::xy_clip_horizontal_polygon(
 		}
 		while (state!=NONE);
 		
-		if (exit_vertex!=NONE) /* weÕve got clipping to do */
+		if (exit_vertex!=NONE) /* weâ€™ve got clipping to do */
 		{
 			flagged_world_point2d new_entrance_point, new_exit_point;
 			
@@ -824,9 +824,9 @@ short RenderRasterizerClass::xy_clip_horizontal_polygon(
 }
 
 /* sort points before clipping to assure consistency; there is a way to make this more accurate
-	but it requires the downshifting game, as played in SCOTTISH_TEXTURES.C.  itÕs tempting to
+	but it requires the downshifting game, as played in SCOTTISH_TEXTURES.C.  itâ€™s tempting to
 	think that having a smaller scale for our world coordinates would help here (i.e., less bits
-	per distance) but then wouldnÕt we be screwed when we tried to rotate? */
+	per distance) but then wouldnâ€™t we be screwed when we tried to rotate? */
 // LP change: make it better able to do long-distance views
 void RenderRasterizerClass::xy_clip_flagged_world_points(
 	flagged_world_point2d *p0,
@@ -844,8 +844,8 @@ void RenderRasterizerClass::xy_clip_flagged_world_points(
 	short shift_count= FIXED_FRACTIONAL_BITS;
 	_fixed t;
 
-	/* give numerator 16 significant bits over denominator and then calculate t==n/d;  MPWÕs PPCC
-		didnÕt seem to like (INT32_MIN>>1) and i had to substitute 0xc0000000 instead (hmmm) */
+	/* give numerator 16 significant bits over denominator and then calculate t==n/d;  MPWâ€™s PPCC
+		didnâ€™t seem to like (INT32_MIN>>1) and i had to substitute 0xc0000000 instead (hmmm) */
 	while (numerator<=(int32)0x3fffffff && numerator>=(int32)0xc0000000 && shift_count--) numerator<<= 1;
 	if (shift_count>0) denominator>>= shift_count;
 	t= numerator;
@@ -931,7 +931,7 @@ short RenderRasterizerClass::z_clip_horizontal_polygon(
 				{
 					switch (state)
 					{
-						/* if weÕre testing the first vertex (_testing_first_vertex), this tells us nothing */
+						/* if weâ€™re testing the first vertex (_testing_first_vertex), this tells us nothing */
 						
 						case _searching_cw_for_out_in_transition:
 							entrance_vertex= vertex_index;
@@ -951,7 +951,7 @@ short RenderRasterizerClass::z_clip_horizontal_polygon(
 			}
 
 			/* adjust vertex_index (clockwise or counterclockwise, depending on vertex_delta)
-				if weÕve come back to the first vertex without finding an entrance point weÕre
+				if weâ€™ve come back to the first vertex without finding an entrance point weâ€™re
 				either all the way in or all the way out */
 			vertex_index= (vertex_delta<0) ? WRAP_LOW(vertex_index, vertex_count-1) :
 				WRAP_HIGH(vertex_index, vertex_count-1);
@@ -971,7 +971,7 @@ short RenderRasterizerClass::z_clip_horizontal_polygon(
 		}
 		while (state!=NONE);
 		
-		if (exit_vertex!=NONE) /* weÕve got clipping to do */
+		if (exit_vertex!=NONE) /* weâ€™ve got clipping to do */
 		{
 			flagged_world_point2d new_entrance_point, new_exit_point;
 			
@@ -1045,7 +1045,7 @@ short RenderRasterizerClass::z_clip_horizontal_polygon(
 	return vertex_count;
 }
 
-/* sort points before clipping to assure consistency; this is almost identical to xz_clipÉ()
+/* sort points before clipping to assure consistency; this is almost identical to xz_clipâ€¦()
 	except that it clips 2d points in the xy-plane at the given height. */
 // LP change: make it better able to do long-distance views
 void RenderRasterizerClass::z_clip_flagged_world_points(
@@ -1065,8 +1065,8 @@ void RenderRasterizerClass::z_clip_flagged_world_points(
 	short shift_count= FIXED_FRACTIONAL_BITS;
 	_fixed t;
 
-	/* give numerator 16 significant bits over denominator and then calculate t==n/d;  MPWÕs PPCC
-		didnÕt seem to like (INT32_MIN>>1) and i had to substitute 0xc0000000 instead (hmmm) */
+	/* give numerator 16 significant bits over denominator and then calculate t==n/d;  MPWâ€™s PPCC
+		didnâ€™t seem to like (INT32_MIN>>1) and i had to substitute 0xc0000000 instead (hmmm) */
 	while (numerator<=(int32)0x3fffffff && numerator>=(int32)0xc0000000 && shift_count--) numerator<<= 1;
 	if (shift_count>0) denominator>>= shift_count;
 	t= numerator;
@@ -1183,7 +1183,7 @@ short RenderRasterizerClass::xz_clip_vertical_polygon(
 //					dprintf("vertex#%d is on the clip line s==#%d", vertex_index, state);
 					switch (state)
 					{
-						/* if weÕre testing the first vertex, this tells us nothing */
+						/* if weâ€™re testing the first vertex, this tells us nothing */
 						
 						case _searching_cw_for_out_in_transition:
 							entrance_vertex= vertex_index;
@@ -1220,7 +1220,7 @@ short RenderRasterizerClass::xz_clip_vertical_polygon(
 			}
 
 			/* adjust vertex_index (clockwise or counterclockwise, depending on vertex_delta)
-				if weÕve come back to the first vertex without finding an entrance point weÕre
+				if weâ€™ve come back to the first vertex without finding an entrance point weâ€™re
 				either all the way in or all the way out */
 			vertex_index= (vertex_delta<0) ? WRAP_LOW(vertex_index, vertex_count-1) :
 				WRAP_HIGH(vertex_index, vertex_count-1);
@@ -1240,7 +1240,7 @@ short RenderRasterizerClass::xz_clip_vertical_polygon(
 		}
 		while (state!=NONE);
 		
-		if (exit_vertex!=NONE) /* weÕve got clipping to do */
+		if (exit_vertex!=NONE) /* weâ€™ve got clipping to do */
 		{
 			flagged_world_point3d new_entrance_point, new_exit_point;
 			
@@ -1333,8 +1333,8 @@ void RenderRasterizerClass::xz_clip_flagged_world_points(
 	short shift_count= FIXED_FRACTIONAL_BITS;
 	_fixed t;
 
-	/* give numerator 16 significant bits over denominator and then calculate t==n/d;  MPWÕs PPCC
-		didnÕt seem to like (INT32_MIN>>1) and i had to substitute 0xc0000000 instead (hmmm) */
+	/* give numerator 16 significant bits over denominator and then calculate t==n/d;  MPWâ€™s PPCC
+		didnâ€™t seem to like (INT32_MIN>>1) and i had to substitute 0xc0000000 instead (hmmm) */
 	while (numerator<=(int32)0x3fffffff && numerator>=(int32)0xc0000000 && shift_count--) numerator<<= 1;
 	if (shift_count>0) denominator>>= shift_count;
 	t = numerator;

--- a/Source_Files/RenderMain/RenderRasterize.h
+++ b/Source_Files/RenderMain/RenderRasterize.h
@@ -62,12 +62,12 @@ struct flagged_world_point3d /* for ceilings */
 
 /* ---------- vertical surface definition */
 
-/* itÕs not worth putting this into the side_data structure, although the transfer mode should
+/* itâ€™s not worth putting this into the side_data structure, although the transfer mode should
 	be in the side_texture_definition structure */
 struct vertical_surface_data
 {
 	short lightsource_index;
-	_fixed ambient_delta; /* a delta to the lightsourceÕs intensity, then pinned to [0,FIXED_ONE] */
+	_fixed ambient_delta; /* a delta to the lightsourceâ€™s intensity, then pinned to [0,FIXED_ONE] */
 	
 	world_distance length;
 	world_distance h0, h1, hmax; /* h0<h1; hmax<=h1 and is the height where this wall side meets the ceiling */

--- a/Source_Files/RenderMain/RenderRasterize_Shader.cpp
+++ b/Source_Files/RenderMain/RenderRasterize_Shader.cpp
@@ -1148,7 +1148,7 @@ void RenderRasterize_Shader::render_viewer_sprite_layer(RenderStep renderStep)
         rect.Opacity = 1;
 
         /* get_weapon_display_information() returns true if there is a weapon to be drawn.  it
-           should initially be passed a count of zero.  it returns the weaponÕs texture and
+           should initially be passed a count of zero.  it returns the weapon’s texture and
            enough information to draw it correctly. */
 	count= 0;
 	while (get_weapon_display_information(&count, &display_data))
@@ -1188,7 +1188,7 @@ void RenderRasterize_Shader::render_viewer_sprite_layer(RenderStep renderStep)
 		rect.flip_horizontal= display_data.flip_horizontal;
 		rect.flip_vertical= display_data.flip_vertical;
 		
-		/* lighting: depth of zero in the cameraÕs polygon index */
+		/* lighting: depth of zero in the camera’s polygon index */
 		rect.depth= 0;
 		rect.ambient_shade= get_light_intensity(get_polygon_data(view->origin_polygon_index)->floor_lightsource_index);
 		rect.ambient_shade= MAX(shape_information->minimum_light_intensity, rect.ambient_shade);
@@ -1198,7 +1198,7 @@ void RenderRasterize_Shader::render_viewer_sprite_layer(RenderStep renderStep)
 		// for the convenience of doing teleport-in/teleport-out
 		rect.xc = (rect.x0 + rect.x1) >> 1;
 
-                /* make the weapon reflect the ownerÕs transfer mode */
+                /* make the weapon reflect the owner’s transfer mode */
 		instantiate_rectangle_transfer_mode(view, &rect, display_data.transfer_mode, display_data.transfer_phase);
 
                 render_viewer_sprite(rect, renderStep);

--- a/Source_Files/RenderMain/RenderSortPoly.cpp
+++ b/Source_Files/RenderMain/RenderSortPoly.cpp
@@ -82,10 +82,10 @@ void RenderSortPolyClass::initialize_sorted_render_tree()
 tree decomposition:
 
 pick a leaf polygon
-	make sure the polygon is everywhere a leaf (donÕt walk the tree, search it linearly) 
-		if itÕs not, pick the node which obstructed it to test next
-		if it is, pull it off the tree (destructively) and accumulate itÕs clipping information
-			pick the one of the nodeÕs siblings (or itÕs parent if it has none) to handle next
+	make sure the polygon is everywhere a leaf (donâ€™t walk the tree, search it linearly)
+		if itâ€™s not, pick the node which obstructed it to test next
+		if it is, pull it off the tree (destructively) and accumulate itâ€™s clipping information
+			pick the one of the nodeâ€™s siblings (or itâ€™s parent if it has none) to handle next
 */
 
 void RenderSortPolyClass::sort_render_tree()
@@ -103,10 +103,10 @@ void RenderSortPolyClass::sort_render_tree()
 	{
 		// LP change: no more growable list of aliases,
 		// due to the sorted-polygon-tree structure of the nodes.
-		bool leaf_has_children= false; /* i.e., itÕs not a leaf */
+		bool leaf_has_children= false; /* i.e., itâ€™s not a leaf */
 		node_data *node = NULL;
 
-		/* if we donÕt have a leaf, find one */
+		/* if we donâ€™t have a leaf, find one */
 		if (!leaf)
 			for (leaf= &Nodes.front(); leaf->children; leaf= leaf->children)
 				;
@@ -211,14 +211,14 @@ void RenderSortPolyClass::sort_render_tree()
 				_polygon_is_visible) */
 			polygon_index_to_sorted_node[sorted_node->polygon_index]= sorted_node;
 			
-			/* walk this nodeÕs alias list, removing each from the tree */
+			/* walk this nodeâ€™s alias list, removing each from the tree */
 			// LP change: move down the chain of polygon-sharing nodes
 			for (node_data *Alias = FoundNode; Alias; Alias = Alias->PS_Shared)
 			{
 				// LP change: remember what the node was for when we break out
 				node = Alias;
 
-				/* remove this node and update the next nodeÕs reference (if there is a
+				/* remove this node and update the next nodeâ€™s reference (if there is a
 					reference and if there is a next node) */
 				if (node->reference)
 				{
@@ -227,7 +227,7 @@ void RenderSortPolyClass::sort_render_tree()
 				}
 			}
 
-			/* try to handle this nodeÕs siblings next (if there arenÕt any, then a ÔrandomÕ
+			/* try to handle this nodeâ€™s siblings next (if there arenâ€™t any, then a â€˜randomâ€™
 				node will be chosen) */
 			leaf= node ? node->siblings : NULL;
 		}
@@ -238,7 +238,7 @@ void RenderSortPolyClass::sort_render_tree()
 
 /* ---------- initializing and calculating clip data */
 
-/* be sure to examine all of a nodeÕs parents for clipping information (gak!) */
+/* be sure to examine all of a nodeâ€™s parents for clipping information (gak!) */
 clipping_window_data *RenderSortPolyClass::build_clipping_windows(
 	node_data *ChainBegin)
 {
@@ -247,7 +247,7 @@ clipping_window_data *RenderSortPolyClass::build_clipping_windows(
 	AccumulatedEndpointClips.clear();
 	endpoint_clip_data *endpoint;
 	line_clip_data *line;
-	short x0, x1; /* ignoring what clipping parameters weÕve gotten, this is the left and right borders of this node on the screen */
+	short x0, x1; /* ignoring what clipping parameters weâ€™ve gotten, this is the left and right borders of this node on the screen */
 	short i, j;
 
 	// LP: references to simplify the code

--- a/Source_Files/RenderMain/RenderVisTree.cpp
+++ b/Source_Files/RenderMain/RenderVisTree.cpp
@@ -181,7 +181,7 @@ void RenderVisTreeClass::build_render_tree()
 				}
 				
 				/* do two cross products to determine whether this endpoint is in our view cone or not
-					(we donÕt have to cast at points outside the cone) */
+					(we donâ€™t have to cast at points outside the cone) */
 				if ((view->right_edge.i*_vector.j - view->right_edge.j*_vector.i)<=0 && (view->left_edge.i*_vector.j - view->left_edge.j*_vector.i)>=0)
 				{
 					cast_render_ray(&_vector, ENDPOINT_IS_TRANSPARENT(endpoint) ? NONE : endpoint_index, &Nodes.front(), _no_bias);
@@ -295,7 +295,7 @@ void RenderVisTreeClass::cast_render_ray(
 				}
 			}
 
-			/* update the line clipping information, if necessary, for this node (donÕt add
+			/* update the line clipping information, if necessary, for this node (donâ€™t add
 				duplicates */
 			if (clipping_line_index!=NONE)
 			{
@@ -346,8 +346,8 @@ uint16 RenderVisTreeClass::next_polygon_along_line(
 	short *polygon_index,
 	world_point2d *origin, /* not necessairly in polygon_index */
 	long_vector2d *_vector, // world_vector2d *vector,
-	short *clipping_endpoint_index, /* if non-NONE on entry this is the solid endpoint weÕre shooting for */
-	short *clipping_line_index, /* NONE on exit if this polygon transition wasnÕt accross an elevation line */
+	short *clipping_endpoint_index, /* if non-NONE on entry this is the solid endpoint weâ€™re shooting for */
+	short *clipping_line_index, /* NONE on exit if this polygon transition wasnâ€™t accross an elevation line */
 	short bias)
 {
 	polygon_data *polygon= get_polygon_data(*polygon_index);
@@ -438,10 +438,10 @@ uint16 RenderVisTreeClass::next_polygon_along_line(
 		    {
 			if (endpoint_index==*clipping_endpoint_index) passed_through_solid_vertex= true;
 
-			/* if we think we know whatÕs on the other side of this zero (these zeros)
-			change the state: if we donÕt find what weÕre looking for then the polygon
+			/* if we think we know whatâ€™s on the other side of this zero (these zeros)
+			change the state: if we donâ€™t find what weâ€™re looking for then the polygon
 			is entirely on one side of the line or the other (except for this vertex),
-			in any case we need to call decide_where_vertex_leads() to find out whatÕs
+			in any case we need to call decide_where_vertex_leads() to find out whatâ€™s
 			on the other side of this vertex */
 			switch (state)
 			{
@@ -466,8 +466,8 @@ uint16 RenderVisTreeClass::next_polygon_along_line(
 
 //	dprintf("exiting, cli=#%d, npi=#%d", crossed_line_index, next_polygon_index);
 
-	/* if we didnÕt pass through the solid vertex we were aiming for, set clipping_endpoint_index to NONE,
-		we assume the line we passed through doesnÕt clip, and set clipping_line_index to NONE
+	/* if we didnâ€™t pass through the solid vertex we were aiming for, set clipping_endpoint_index to NONE,
+		we assume the line we passed through doesnâ€™t clip, and set clipping_line_index to NONE
 		(this will be corrected in a few moments if we chose poorly) */
 	if (!passed_through_solid_vertex) *clipping_endpoint_index= NONE;
 	*clipping_line_index= NONE;
@@ -483,7 +483,7 @@ uint16 RenderVisTreeClass::next_polygon_along_line(
 		if (crossed_side_index!=NONE) SET_RENDER_FLAG(crossed_side_index, _side_is_visible);
 
 		/* if this line is transparent we need to check for a change in elevation for clipping,
-			if itÕs not transparent then we canÕt pass through it */
+			if itâ€™s not transparent then we canâ€™t pass through it */
 		// LP change: added test for there being a polygon on the other side
 		if (LINE_IS_TRANSPARENT(line) && next_polygon_index != NONE)
 		{
@@ -582,7 +582,7 @@ uint16 RenderVisTreeClass::decide_where_vertex_leads(
 			
 			if ((bias==_clockwise_bias&&cross_product>=0) || (bias==_counterclockwise_bias&&cross_product<=0))
 			{
-				/* weÕre leaving this endpoint, set clip flag in case itÕs solid */
+				/* weâ€™re leaving this endpoint, set clip flag in case itâ€™s solid */
 				clip_flags|= (bias==_clockwise_bias) ? _clip_left : _clip_right;
 			}
 		}
@@ -661,7 +661,7 @@ void RenderVisTreeClass::calculate_line_clipping_information(
 	// LP addition: place for new line data
 	line_clip_data *data= &LineClips[LastIndex];
 
-	/* itÕs possible (in fact, likely) that this lineÕs endpoints have not been transformed yet,
+	/* itâ€™s possible (in fact, likely) that this lineâ€™s endpoints have not been transformed yet,
 		so we have to do it ourselves */
 	// LP change: making the operation long-distance friendly
 	uint16 p0_flags = 0, p1_flags = 0;
@@ -712,7 +712,7 @@ void RenderVisTreeClass::calculate_line_clipping_information(
 				if (y0<y1) y= y0, p= &p0; else y= y1, p= &p1;
 				y= PIN(y, 0, view->screen_height);
 				
-				/* if weÕre not useless (clipping up off the top of the screen) set up top-clip information) */
+				/* if weâ€™re not useless (clipping up off the top of the screen) set up top-clip information) */
 				if (y<=0)
 				{
 					clip_flags&= ~_clip_up;
@@ -737,7 +737,7 @@ void RenderVisTreeClass::calculate_line_clipping_information(
 				if (y0>y1) y= y0, p= &p0; else y= y1, p= &p1;
 				y= PIN(y, 0, view->screen_height);
 				
-				/* if weÕre not useless (clipping up off the bottom of the screen) set up top-clip information) */
+				/* if weâ€™re not useless (clipping up off the bottom of the screen) set up top-clip information) */
 				if (y>=view->screen_height)
 				{
 					clip_flags&= ~_clip_down;
@@ -756,7 +756,7 @@ void RenderVisTreeClass::calculate_line_clipping_information(
 }
 
 /* we can actually rely on the given endpoint being transformed because we only set clipping
-	information for endpoints weÕre aiming at, and we transform endpoints before firing at them */
+	information for endpoints weâ€™re aiming at, and we transform endpoints before firing at them */
 // Returns NONE of it does not have valid clip info
 short RenderVisTreeClass::calculate_endpoint_clipping_information(
 	short endpoint_index,
@@ -781,7 +781,7 @@ short RenderVisTreeClass::calculate_endpoint_clipping_information(
 	int32 x;
 
 	assert((clip_flags&(_clip_left|_clip_right))); /* must have a clip flag */
-	assert((clip_flags&(_clip_left|_clip_right))!=(_clip_left|_clip_right)); /* but canÕt have both */
+	assert((clip_flags&(_clip_left|_clip_right))!=(_clip_left|_clip_right)); /* but canâ€™t have both */
 	assert(!TEST_RENDER_FLAG(endpoint_index, _endpoint_has_clip_data));
 	
 	// LP change: compose a true transformed point to replace endpoint->transformed,

--- a/Source_Files/RenderMain/RenderVisTree.h
+++ b/Source_Files/RenderMain/RenderVisTree.h
@@ -69,7 +69,7 @@ enum /* next_polygon_along_line() states */
 
 /* ---------- clipping data */
 
-enum /* É_clip_data flags */
+enum /* â€¦_clip_data flags */
 {
 	_clip_left= 0x0001,
 	_clip_right= 0x0002,

--- a/Source_Files/RenderMain/collection_definition.h
+++ b/Source_Files/RenderMain/collection_definition.h
@@ -31,7 +31,7 @@ Wednesday, June 22, 1994 3:53:22 PM
 	scaling modifications.
 Wednesday, June 22, 1994 10:07:38 PM
 	added _scenery_collection type, .size field to collection_definition structure, changed
-	Ôshape_indexesÕ to Ôlow_level_shape_indexesÕ in high_level_shape_definition structure
+	â€˜shape_indexesâ€™ to â€˜low_level_shape_indexesâ€™ in high_level_shape_definition structure
 Saturday, July 9, 1994 3:36:05 PM
 	added NUMBER_OF_PRIVATE_COLORS constant.
 */

--- a/Source_Files/RenderMain/low_level_textures.h
+++ b/Source_Files/RenderMain/low_level_textures.h
@@ -22,7 +22,7 @@ Friday, August 19, 1994 2:05:54 PM
 
 Monday, February 27, 1995 11:40:47 PM  (Jason')
 	rob suggests that the PPC might not write-allocate cache lines so we might be faster if we
-	read from a location weÕre about to write to.  he also suggested a rowbytes of 704 instead
+	read from a location weâ€™re about to write to.  he also suggested a rowbytes of 704 instead
 	of 640 off-screen for better cache performance.
 
 Jan 30, 2000 (Loren Petrich):

--- a/Source_Files/RenderMain/render.cpp
+++ b/Source_Files/RenderMain/render.cpp
@@ -26,15 +26,15 @@ Sunday, September 11, 1994 7:32:49 PM  (Jason')
 	the clock on the 540 was wrong, yesterday was Saturday (not Friday).  on quads again, but
 	back home now.  something will draw before i go to bed tonight.  dinner at the nile?
 Tuesday, September 13, 1994 2:54:56 AM  (Jason')
-	no fair!ÑÑ itÕs still monday, really.  with the aid of some graphical debugging the clipping
-	all works now and iÕm trying to have the entire floor/ceiling thing going tonight (the nile
+	no fair!â€”â€” itâ€™s still monday, really.  with the aid of some graphical debugging the clipping
+	all works now and iâ€™m trying to have the entire floor/ceiling thing going tonight (the nile
 	was closed by the time i got around to taking a shower and heading out).
 Friday, September 16, 1994 4:06:17 AM  (Jason')
 	walls, floors and ceilings texture, wobble, etc.  contemplating objects ... maybe this will
 	work after all.
 Monday, September 19, 1994 11:03:49 AM  (Jason')
 	unified xz_clip_vertical_polygon() and z_clip_horizontal_polygon() to get rid of the last
-	known whitespace problem.  canÕt wait to see what others i have.  objects now respect the
+	known whitespace problem.  canâ€™t wait to see what others i have.  objects now respect the
 	clipping windows of all nodes they cross.
 Monday, October 24, 1994 4:35:38 PM (Jason)
 	fixed render sorting problem with objects of equal depth (i.e., parasitic objects). 
@@ -47,7 +47,7 @@ Wednesday, October 26, 1994 3:18:59 PM (Jason)
 Wednesday, November 2, 1994 3:49:57 PM (Jason)
 	the bottom panel of short split sides sometimes takes on the ceiling lightsource.
 Tuesday, November 8, 1994 5:29:12 PM  (Jason')
-	implemented new transfer modes: _slide, _wander.  _render_effect_earthquake doesnÕt work
+	implemented new transfer modes: _slide, _wander.  _render_effect_earthquake doesnâ€™t work
 	yet because the player can shake behind his own shape.
 Thursday, December 15, 1994 12:15:55 AM  (Jason)
 	the object depth sort order problem ocurrs with multiple objects in the same polygon,
@@ -256,15 +256,15 @@ extern WindowPtr screen_window;
 there exists a problem where an object can overlap into a polygon which is clipped by something
 	behind the object but that will clip the object because clip windows are subtractive; how
 	is this solved?
-itÕs still possible to get ambiguous clip flags, usually in very narrow (e.g., 1 pixel) windows
+itâ€™s still possible to get ambiguous clip flags, usually in very narrow (e.g., 1 pixel) windows
 the renderer has a maximum range beyond which it shits bricks yet which it allows to be exceeded
-itÕs still possible, especially in high-res full-screen, for points to end up (slightly) off
+itâ€™s still possible, especially in high-res full-screen, for points to end up (slightly) off
 	the screen (usually discarding these has no noticable effect on the scene)
 whitespace results when two adjacent polygons are clipped to different vertical windows.  this
 	is not trivially solved with the current implementation, and may be acceptable (?)
 
 //build_base_polygon_index_list() should discard lower polygons for objects above the viewer and
-//	higher polygons for objects below the viewer because we certainly donÕt sort objects
+//	higher polygons for objects below the viewer because we certainly donâ€™t sort objects
 //	correctly in these cases
 //in strange cases, objects are sorted out of order.  this seems to involve players in some way
 //	(i.e., parasitic objects).
@@ -385,8 +385,8 @@ void initialize_view_data(
 	view->half_screen_width= view->screen_width/2;
 	view->half_screen_height= view->screen_height/2;
 	
-	/* if thereÕs a round-off error in half_cone, we want to make the cone too big (so when we clip
-		lines Ôto the edge of the screenÕ theyÕre actually off the screen, thus +1.0) */
+	/* if thereâ€™s a round-off error in half_cone, we want to make the cone too big (so when we clip
+		lines â€˜to the edge of the screenâ€™ theyâ€™re actually off the screen, thus +1.0) */
 	view->half_cone= (angle) (adjusted_half_cone*((double)NUMBER_OF_ANGLES)/two_pi+1.0);
 	
 	// LP change: find the adjusted yaw for the landscapes;
@@ -500,7 +500,7 @@ void render_view(
 			RenPtr->render_tree();
 			
 			// LP: won't put this into a separate class
-			/* render the playerÕs weapons, etc. */
+			/* render the playerâ€™s weapons, etc. */
                         if (!RenPtr->renders_viewer_sprites_in_tree()) {
                             render_viewer_sprite_layer(view, RasPtr);
                         }
@@ -642,8 +642,8 @@ static void update_view_data(
 	view->bottom_edge.i= view->world_to_screen_y;
 	view->bottom_edge.j= - view->half_screen_height + view->dtanpitch; /* ==k */
 
-	/* if weÕre sitting on one of the endpoints in our origin polygon, move us back slightly (±1) into
-		that polygon.  when we split rays weÕre assuming that weÕll never pass through a given
+	/* if weâ€™re sitting on one of the endpoints in our origin polygon, move us back slightly (Â±1) into
+		that polygon.  when we split rays weâ€™re assuming that weâ€™ll never pass through a given
 		vertex in different directions (because if we do the tree becomes a graph) but when
 		we start on a vertex this can happen.  this is a destructive modification of the origin. */
 	{
@@ -1002,7 +1002,7 @@ static void render_viewer_sprite_layer(view_data *view, RasterizerClass *RasPtr)
 	textured_rectangle.Opacity = 1;
 
 	/* get_weapon_display_information() returns true if there is a weapon to be drawn.  it
-		should initially be passed a count of zero.  it returns the weaponÕs texture and
+		should initially be passed a count of zero.  it returns the weaponâ€™s texture and
 		enough information to draw it correctly. */
 	count= 0;
 	while (get_weapon_display_information(&count, &display_data))
@@ -1069,7 +1069,7 @@ static void render_viewer_sprite_layer(view_data *view, RasterizerClass *RasPtr)
 		textured_rectangle.flip_horizontal= display_data.flip_horizontal;
 		textured_rectangle.flip_vertical= display_data.flip_vertical;
 		
-		/* lighting: depth of zero in the cameraÕs polygon index */
+		/* lighting: depth of zero in the cameraâ€™s polygon index */
 		textured_rectangle.depth= 0;
 		textured_rectangle.ambient_shade= get_light_intensity(get_polygon_data(view->origin_polygon_index)->floor_lightsource_index);
 		textured_rectangle.ambient_shade= MAX(shape_information->minimum_light_intensity, textured_rectangle.ambient_shade);
@@ -1079,7 +1079,7 @@ static void render_viewer_sprite_layer(view_data *view, RasterizerClass *RasPtr)
 		// for the convenience of doing teleport-in/teleport-out
 		textured_rectangle.xc = (textured_rectangle.x0 + textured_rectangle.x1) >> 1;
 		
-		/* make the weapon reflect the ownerÕs transfer mode */
+		/* make the weapon reflect the ownerâ€™s transfer mode */
 		instantiate_rectangle_transfer_mode(view, &textured_rectangle, display_data.transfer_mode, display_data.transfer_phase);
 		
 		/* and draw it */
@@ -1158,7 +1158,7 @@ static void shake_view_origin(
 	new_origin.y+= half_delta - ((delta*sine_table[NORMALIZE_ANGLE(((view->tick_count+5*TICKS_PER_SECOND)&~3)*(7*FULL_CIRCLE))])>>TRIG_SHIFT);
 	new_origin.z+= half_delta - ((delta*sine_table[NORMALIZE_ANGLE(((view->tick_count+7*TICKS_PER_SECOND)&~3)*(7*FULL_CIRCLE))])>>TRIG_SHIFT);
 
-	/* only use the new origin if we didnÕt cross a polygon boundary */
+	/* only use the new origin if we didnâ€™t cross a polygon boundary */
 	if (find_line_crossed_leaving_polygon(view->origin_polygon_index, (world_point2d *) &view->origin,
 		(world_point2d *) &new_origin)==NONE)
 	{

--- a/Source_Files/RenderMain/render.h
+++ b/Source_Files/RenderMain/render.h
@@ -154,7 +154,7 @@ struct view_data
 enum /* render flags */
 {
 	_polygon_is_visible_bit, /* some part of this polygon is horizontally in the view cone */
-	_endpoint_has_been_visited_bit, /* weÕve already tried to cast a ray out at this endpoint */
+	_endpoint_has_been_visited_bit, /* weâ€™ve already tried to cast a ray out at this endpoint */
 	_endpoint_is_visible_bit, /* this endpoint is horizontally in the view cone */
 	_side_is_visible_bit, /* this side was crossed while building the tree and should be drawn */
 	_line_has_clip_data_bit, /* this line has a valid clip entry */

--- a/Source_Files/RenderMain/scottish_textures.cpp
+++ b/Source_Files/RenderMain/scottish_textures.cpp
@@ -20,8 +20,8 @@ SCOTTISH_TEXTURES.C
 
 Wednesday, April 20, 1994 9:35:36 AM
 
-this is not your fatherÕs texture mapping library.
-(in fact it isnÕt yours either, dillweed)
+this is not your fatherâ€™s texture mapping library.
+(in fact it isnâ€™t yours either, dillweed)
 
 Wednesday, April 20, 1994 3:39:21 PM
 	vertical repeats would be difficult because it would require testing repeats in the
@@ -43,7 +43,7 @@ Wednesday, April 27, 1994 9:49:55 AM
 	i'm just looking for one divine hammer (to bang it all day).  solid polygons are currently
 	unaffected by darkening.  i'm not entirely certain we'll even use them.
 Sunday, May 8, 1994 8:32:11 AM
-	LISPÕs lexical contours kick C firmly and painfully in the ass. everything is fast now
+	LISPâ€™s lexical contours kick C firmly and painfully in the ass. everything is fast now
 	except the landscape mapper which has just been routed and is in full retreat.
 Friday, May 13, 1994 10:05:08 AM
 	low-level unification of trapezoids and rectangles, transparent runs in shapes are run-length
@@ -54,7 +54,7 @@ Wednesday, May 18, 1994 2:16:26 PM
 Sunday, May 22, 1994 12:32:02 PM
 	drawing things in column order to cached (i.e., non-screen) memory is like crapping in the
 	data cache, right?  maybe drawing rectangles in column-order wasn't such a great idea after all.
-	it also occurs to me that i know nothing about how to order instructions for the Õ040 pipelines.
+	it also occurs to me that i know nothing about how to order instructions for the â€™040 pipelines.
 Thursday, June 16, 1994 9:56:14 PM
 	modified _render_textured_polygon_line to handle elevation.
 Thursday, July 7, 1994 1:23:09 PM
@@ -62,14 +62,14 @@ Thursday, July 7, 1994 1:23:09 PM
 	now the problem is floor/ceiling matching with trapezoids, which should fall out with the 
 	rewrite...
 Tuesday, July 26, 1994 3:42:16 PM
-	OBSOLETEÕed nearly the entire file (fixed_pixels are no more).  rewriting texture_rectangle.
+	OBSOLETEâ€™ed nearly the entire file (fixed_pixels are no more).  rewriting texture_rectangle.
 	will do 16bit mapping, soon.  a while ago i rewrote everything in 68k.
 Friday, September 16, 1994 6:03:11 PM  (Jason')
 	texture_rectangle() now respects top and bottom clips
 Tuesday, September 20, 1994 9:58:30 PM  (Jason')
-	if weÕre so close to a rectangle that n>LARGEST_N then we donÕt draw anything
+	if weâ€™re so close to a rectangle that n>LARGEST_N then we donâ€™t draw anything
 Wednesday, October 26, 1994 3:18:59 PM (Jason)
-	for non-convex or otherwise weird lines (dx<=0, dy<=0) we donÕt draw anything (somebodyÕll
+	for non-convex or otherwise weird lines (dx<=0, dy<=0) we donâ€™t draw anything (somebodyâ€™ll
 	notice that for sure).
 Friday, November 4, 1994 7:35:48 PM  (Jason')
 	pretexture_horizontal_polygon_lines() now respects the (x,y) polygon origin and uses z as height.
@@ -102,7 +102,7 @@ May 16, 2002 (Woody Zenfell):
 rectangle shrinking has vertical error and appears to randomly shear the bitmap
 pretexture_horizontal_polygon_lines() has integer error in large height cases
 
-_static_transfer doesnÕt work for ceilings and floors (because they call the wall mapper)
+_static_transfer doesnâ€™t work for ceilings and floors (because they call the wall mapper)
 build_y_table and build_x_table could both be sped up in nearly-horizontal and nearly-vertical cases (respectively)
 _pretexture_vertical_polygon_lines() takes up to half the time _texture_vertical_polygon_lines() does
 not only that, but texture_horizontal_polygon() is actually faster than texture_vertical_polygon()
@@ -174,7 +174,7 @@ static void calculate_shading_table(void * &result,view_data *view, void *shadin
 
 /* these tables are used by the polygon rasterizer (to store the x-coordinates of the left and
 	right lines of the current polygon), the trapezoid rasterizer (to store the y-coordinates
-	of the top and bottom of the current trapezoid) and the rectangle mapper (for itÕs
+	of the top and bottom of the current trapezoid) and the rectangle mapper (for itâ€™s
 	vertical and if necessary horizontal distortion tables).  these are not necessary as
 	globals, just as global storage. */
 static short *scratch_table0 = NULL, *scratch_table1 = NULL;
@@ -246,7 +246,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 		short *left_table= scratch_table0, *right_table= scratch_table1;
 
 		left_line_count= right_line_count= 0; /* zero counts so the left and right lines get initialized */
-		aggregate_left_line_count= aggregate_right_line_count= 0; /* weÕve precalculated nothing initially */
+		aggregate_left_line_count= aggregate_right_line_count= 0; /* weâ€™ve precalculated nothing initially */
 		left_vertex= right_vertex= highest_vertex; /* both sides start at the highest vertex */
 		total_line_count= vertices[lowest_vertex].y-vertices[highest_vertex].y; /* calculate vertical line count */
 
@@ -257,7 +257,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 		while (total_line_count>0)
 		{
 			
-			/* if weÕre out of scan lines on the left side, get a new vertex and build a table
+			/* if weâ€™re out of scan lines on the left side, get a new vertex and build a table
 				of x-coordinates so we can walk toward the new vertex */
 			if (left_line_count<=0)
 			{
@@ -273,7 +273,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 				while (!left_line_count);
 			}
 
-			/* if weÕre out of scan lines on the right side, get a new vertex and build a table
+			/* if weâ€™re out of scan lines on the right side, get a new vertex and build a table
 				of x-coordinates so we can walk toward the new vertex */
 			if (right_line_count<=0)
 			{
@@ -297,7 +297,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 			left_line_count-= delta;
 			right_line_count-= delta;
 			
-			fc_assert(delta||!total_line_count); /* if our delta is zero, weÕd better be out of lines */
+			fc_assert(delta||!total_line_count); /* if our delta is zero, weâ€™d better be out of lines */
 		}
 		
 		/* make sure every coordinate is accounted for in our tables */
@@ -466,7 +466,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 		short *left_table= scratch_table0, *right_table= scratch_table1;
 
 		left_line_count= right_line_count= 0; /* zero counts so the left and right lines get initialized */
-		aggregate_left_line_count= aggregate_right_line_count= 0; /* weÕve precalculated nothing initially */
+		aggregate_left_line_count= aggregate_right_line_count= 0; /* weâ€™ve precalculated nothing initially */
 		left_vertex= right_vertex= highest_vertex; /* both sides start at the highest vertex */
 		total_line_count= vertices[lowest_vertex].x-vertices[highest_vertex].x; /* calculate vertical line count */
 
@@ -476,7 +476,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 		aggregate_total_line_count= total_line_count;
 		while (total_line_count>0)
 		{			
-			/* if weÕre out of scan lines on the left side, get a new vertex and build a table
+			/* if weâ€™re out of scan lines on the left side, get a new vertex and build a table
 				of y-coordinates so we can walk toward the new vertex */
 			if (left_line_count<=0)
 			{
@@ -492,7 +492,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 				while (!left_line_count);
 			}
 
-			/* if weÕre out of scan lines on the right side, get a new vertex and build a table
+			/* if weâ€™re out of scan lines on the right side, get a new vertex and build a table
 				of y-coordinates so we can walk toward the new vertex */
 			if (right_line_count<=0)
 			{
@@ -515,7 +515,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 			left_line_count-= delta;
 			right_line_count-= delta;
 			
-			fc_assert(delta||!total_line_count); /* if our delta is zero, weÕd better be out of lines */
+			fc_assert(delta||!total_line_count); /* if our delta is zero, weâ€™d better be out of lines */
 		}
 		
 		/* make sure every coordinate is accounted for in our tables */
@@ -773,7 +773,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 					if (FIXED_INTEGERAL_PART(texture_y0)<first)
 					{
 						delta= (INTEGER_TO_FIXED(first) - texture_y0)/texture_dy + 1;
-						fc_vassert(delta>=0, csprintf(temporary, "[%x,%x] ¶=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
+						fc_vassert(delta>=0, csprintf(temporary, "[%x,%x] âˆ‚=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
 						
 						y0= MIN(y1, y0+delta);
 						texture_y+= delta*texture_dy;
@@ -782,7 +782,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 					if (FIXED_INTEGERAL_PART(texture_y1)>last)
 					{
 						delta= (texture_y1 - INTEGER_TO_FIXED(last))/texture_dy + 1;
-						fc_vassert(delta>=0, csprintf(temporary, "[%x,%x] ¶=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
+						fc_vassert(delta>=0, csprintf(temporary, "[%x,%x] âˆ‚=%x (#%d,#%d)", texture_y0, texture_y1, texture_dy, first, last));
 						
 						y1= MAX(y0, y1-delta);
 					}
@@ -932,7 +932,7 @@ static void _pretexture_vertical_polygon_lines(
 		_fixed ty, ty_delta;
 
 		/* would our precision be greater here if we shifted the numerator up to $7FFFFFFF and
-			then downshifted only the numerator?  too bad we canÕt use BFFFO in 68k */
+			then downshifted only the numerator?  too bad we canâ€™t use BFFFO in 68k */
 		{
 			int32 adjusted_tx_denominator= tx_denominator;
 			int32 adjusted_tx_numerator= tx_numerator;
@@ -954,7 +954,7 @@ static void _pretexture_vertical_polygon_lines(
 		}
 		
 		world_x = polygon->origin.x + (int32(1LL*tx*polygon->vector.i) >> FIXED_FRACTIONAL_BITS);
-		if (world_x<0) world_x= -world_x; /* it is mostly unclear what weÕre supposed to do with negative x values */
+		if (world_x<0) world_x= -world_x; /* it is mostly unclear what weâ€™re supposed to do with negative x values */
 
 		/* calculate and rescale ty_numerator, ty_denominator and calculate ty */
 		ty_numerator= world_x*screen_y0 - dz0;
@@ -1097,7 +1097,7 @@ static void _pretexture_horizontal_polygon_lines(
 }
 
 
-// height must be determined emperically (texture is vertically centered at 0¡)
+// height must be determined emperically (texture is vertically centered at 0Â°)
 // #define LANDSCAPE_REPEAT_BITS 1
 static void _prelandscape_horizontal_polygon_lines(
 	struct polygon_definition *polygon,
@@ -1220,7 +1220,7 @@ static short *build_x_table(
 	}
 	else
 	{
-		/* canÕt build a table for negative dy */
+		/* canâ€™t build a table for negative dy */
 		if (dy<0) return NULL;
 	}
 	
@@ -1286,7 +1286,7 @@ static short *build_y_table(
 	}
 	else
 	{
-		/* canÕt build a table for a negative dx */
+		/* canâ€™t build a table for a negative dx */
 		return NULL;
 	}
 	

--- a/Source_Files/RenderMain/scottish_textures.h
+++ b/Source_Files/RenderMain/scottish_textures.h
@@ -56,7 +56,7 @@ enum /* transfer modes */
 {
 	_tinted_transfer, /* pass background through given shading table for non-transparent
 		pixels; config word is $mmnn: mm is a mask applied to a random number in [0,32)
-		which is then added to nn and used to retrieve a tinting table.  ÔordinaryÕ (pathways-style)
+		which is then added to nn and used to retrieve a tinting table.  â€˜ordinaryâ€™ (pathways-style)
 		tinting can be accomplished by passing an alternate shading table. */
 	_solid_transfer, /* writes (0,0) color of texture for non-transparent pixels; does not
 		respect shading */

--- a/Source_Files/RenderMain/shape_descriptors.h
+++ b/Source_Files/RenderMain/shape_descriptors.h
@@ -24,8 +24,8 @@ SHAPE_DESCRIPTORS.H
 Saturday, July 9, 1994 3:24:56 PM
 
 Saturday, July 9, 1994 6:47:04 PM
-	this header file is not in the makefile, so changing it wonÕt result in the nearly-full
-	rebuild that it should.  if you change this, which you shouldnÕt, you must touch the makefile.
+	this header file is not in the makefile, so changing it wonâ€™t result in the nearly-full
+	rebuild that it should.  if you change this, which you shouldnâ€™t, you must touch the makefile.
 	
 Feb 3, 2000 (Loren Petrich):
 	Renamed _collection_madd to _collection_vacbob

--- a/Source_Files/RenderMain/shapes.cpp
+++ b/Source_Files/RenderMain/shapes.cpp
@@ -23,7 +23,7 @@ Saturday, September 4, 1993 9:26:41 AM
 Thursday, May 19, 1994 9:06:28 AM
 	unification of wall and object shapes complete, new shading table builder.
 Wednesday, June 22, 1994 11:55:07 PM
-	we now read data from alainÕs shape extractor.
+	we now read data from alainâ€™s shape extractor.
 Saturday, July 9, 1994 3:22:11 PM
 	lightening_table removed; we now build darkening tables on a collection-by-collection basis
 	(one 8k darkening table per clut permutation of the given collection)
@@ -142,7 +142,7 @@ enum /* collection status */
 	markNONE,
 	markLOAD= 1,
 	markUNLOAD= 2,
-	markSTRIP= 4 /* we donÕt want bitmaps, just high/low-level shape data */,
+	markSTRIP= 4 /* we donâ€™t want bitmaps, just high/low-level shape data */,
 	markPATCHED = 8 /* force re-load */
 };
 
@@ -1192,7 +1192,7 @@ void strip_collection(
 	}
 }
 
-/* returns count, doesnÕt fill NULL buffer */
+/* returns count, doesnâ€™t fill NULL buffer */
 short get_shape_descriptors(
 	short shape_type,
 	shape_descriptor *buffer)
@@ -1419,7 +1419,7 @@ void load_collections(
 	{
 //		if (with_progress_bar)
 //			draw_progress_bar(MAXIMUM_COLLECTIONS+collection_index, 2*MAXIMUM_COLLECTIONS);
-		/* donÕt reload collections which are already in memory, but do lock them */
+		/* donâ€™t reload collections which are already in memory, but do lock them */
 		if (collection_loaded(header))
 		{
 			// In case the substitute images had been changed by some level-specific MML...
@@ -1537,7 +1537,7 @@ static void precalculate_bit_depth_constants(
 }
 
 /* given a list of RGBColors, find out which one, if any, match the given color.  if there
-	arenÕt any matches, add a new entry and return that index. */
+	arenâ€™t any matches, add a new entry and return that index. */
 static short find_or_add_color(
 	struct rgb_color_value *color,
 	struct rgb_color_value *colors,
@@ -1612,8 +1612,8 @@ static void update_color_environment(
 	colors[0].flags= colors[0].value= 0;
 	color_count= 1;
 
-	/* loop through all collections, only paying attention to the loaded ones.  weÕre
-		depending on finding the gray run (white to black) first; so itÕs the responsibility
+	/* loop through all collections, only paying attention to the loaded ones.  weâ€™re
+		depending on finding the gray run (white to black) first; so itâ€™s the responsibility
 		of the lowest numbered loaded collection to give us this */
 	for (collection_index=0;collection_index<MAXIMUM_COLLECTIONS;++collection_index)
 	{
@@ -1630,7 +1630,7 @@ static void update_color_environment(
 //			if (collection_index==15) dprintf("primary clut %p", primary_colors);
 //			dprintf("primary clut %d entries;dm #%d #%d", collection->color_count, primary_colors, collection->color_count*sizeof(ColorSpec));
 
-			/* add the colors from this collectionÕs primary color table to the aggregate color
+			/* add the colors from this collectionâ€™s primary color table to the aggregate color
 				table and build the remapping table */
 			for (color_index=0;color_index<collection->color_count-NUMBER_OF_PRIVATE_COLORS;++color_index)
 			{
@@ -1720,7 +1720,7 @@ static void update_color_environment(
 			/* 8-bit interface, non-8-bit main window; remember interface CLUT separately */
 			if (collection_index==_collection_interface && interface_bit_depth==8 && bit_depth!=interface_bit_depth) _change_clut(change_interface_clut, colors, color_count);
 			
-			/* if weÕre not in 8-bit, we donÕt have to carry our colors over into the next collection */
+			/* if weâ€™re not in 8-bit, we donâ€™t have to carry our colors over into the next collection */
 			if (bit_depth!=8) color_count= 1;
 		}
 	}

--- a/Source_Files/RenderOther/OverheadMapRenderer.cpp
+++ b/Source_Files/RenderOther/OverheadMapRenderer.cpp
@@ -510,14 +510,14 @@ int32 OverheadMapClass::false_automap_cost_proc(
 	(void) (line_index);
 	(void) (caller_data);
 	
-	/* canÕt leave secret platforms */
+	/* canâ€™t leave secret platforms */
 	if (source_polygon->type==_polygon_is_platform &&
 		PLATFORM_IS_SECRET(get_platform_data(source_polygon->permutation)))
 	{
 		cost= -1;
 	}
 	
-	/* canÕt enter secret platforms which are also doors */
+	/* canâ€™t enter secret platforms which are also doors */
 	if (destination_polygon->type==_polygon_is_platform)
 	{
 		struct platform_data *platform= get_platform_data(destination_polygon->permutation);

--- a/Source_Files/RenderOther/computer_interface.cpp
+++ b/Source_Files/RenderOther/computer_interface.cpp
@@ -594,7 +594,7 @@ void enter_computer_interface(
 	next_terminal_group(player_index, terminal_text);
 }
 
-/*  Assumes ¶t==1 tick */
+/*  Assumes âˆ‚t==1 tick */
 void update_player_for_terminal_mode(
 	short player_index)
 {

--- a/Source_Files/RenderOther/fades.cpp
+++ b/Source_Files/RenderOther/fades.cpp
@@ -639,7 +639,7 @@ static void randomize_color_table(
 	}
 }
 
-/* unlike pathways, all colors wonÕt pass through 50% gray at the same time */
+/* unlike pathways, all colors wonâ€™t pass through 50% gray at the same time */
 static void negate_color_table(
 	struct color_table *original_color_table,
 	struct color_table *animated_color_table,

--- a/Source_Files/RenderOther/game_window.cpp
+++ b/Source_Files/RenderOther/game_window.cpp
@@ -148,7 +148,7 @@ struct weapon_interface_data weapon_interface_definitions[NUMBER_OF_WEAPON_INTER
 		_i_assault_rifle,
 		BUILD_DESCRIPTOR(_collection_interface, _assault_panel),
 		430, 452,
-		439, NONE, //¥¥
+		439, NONE, //â€¢â€¢
 		366, 460, 
 		false,
 		{
@@ -246,7 +246,7 @@ struct weapon_interface_data weapon_interface_definitions[NUMBER_OF_WEAPON_INTER
 		_i_smg,
 		BUILD_DESCRIPTOR(_collection_interface, _smg),
 		430, 452,
-		439, NONE, //¥¥
+		439, NONE, //â€¢â€¢
 		366, 460, 
 		false,
 		{

--- a/Source_Files/RenderOther/motion_sensor.cpp
+++ b/Source_Files/RenderOther/motion_sensor.cpp
@@ -161,8 +161,8 @@ struct motion_sensor_definition motion_sensor_settings = {
 
 /* ---------- structures */
 
-/* an entity canÕt just be jerked from the array, because his signal should fade out, so we
-	mark him as Ôbeing removedÕ and wait until his last signal fades away to actually remove
+/* an entity canâ€™t just be jerked from the array, because his signal should fade out, so we
+	mark him as â€˜being removedâ€™ and wait until his last signal fades away to actually remove
 	him */
 #define SLOT_IS_BEING_REMOVED_BIT 0x4000
 #define SLOT_IS_BEING_REMOVED(e) ((e)->flags&(uint16)SLOT_IS_BEING_REMOVED_BIT)
@@ -252,7 +252,7 @@ void initialize_motion_sensor(
 	/* precalculate the sensor region */
 	precalculate_sensor_region(side_length);	
 
-	/* reset_motion_sensor() should be called before the motion sensor is used, but after itÕs
+	/* reset_motion_sensor() should be called before the motion sensor is used, but after itâ€™s
 		shapes are loaded (because it will do bitmap copying) */
 }
 
@@ -403,7 +403,7 @@ void erase_all_entity_blips(void)
 	short entity_index;
 
 	/* first erase all locations where the entity changed locations and then did not change
-		locations, and erase itÕs last location */
+		locations, and erase itâ€™s last location */
 	for (entity_index=0,entity=entities;entity_index<MAXIMUM_MOTION_SENSOR_ENTITIES;++entity_index,++entity)
 	{
 		if (SLOT_IS_USED(entity))
@@ -411,15 +411,15 @@ void erase_all_entity_blips(void)
 			motion_sensor_changed = true;
 //			dprintf("entity #%d (%p) valid", entity_index, entity);
 			/* see if our monster slot is free; if it is mark this entity as being removed; of
-				course this isnÕt wholly accurate and we might start tracking a new monster
-				which has been placed in our old monsterÕs slot, but we eat that chance
+				course this isnâ€™t wholly accurate and we might start tracking a new monster
+				which has been placed in our old monsterâ€™s slot, but we eat that chance
 				without remorse */
 			if (SLOT_IS_USED(monsters+entity->monster_index))
 			{
 				struct object_data *object= get_object_data(get_monster_data(entity->monster_index)->object_index);
 				world_distance distance= guess_distance2d((world_point2d *) &object->location, (world_point2d *) &owner_object->location);
 				
-				/* verify that weÕre still in range (and mark us as being removed if weÕre not */
+				/* verify that weâ€™re still in range (and mark us as being removed if weâ€™re not */
 				if (distance>MOTION_SENSOR_RANGE || !OBJECT_IS_VISIBLE_TO_MOTION_SENSOR(object))
 				{
 //					dprintf("removed2");
@@ -437,7 +437,7 @@ void erase_all_entity_blips(void)
 			memmove(entity->previous_points+1, entity->previous_points, (NUMBER_OF_PREVIOUS_LOCATIONS-1)*sizeof(point2d));
 			entity->visible_flags[0]= false;
 				
-			/* if weÕre not being removed, make room for a new location and calculate it */
+			/* if weâ€™re not being removed, make room for a new location and calculate it */
 			if (!SLOT_IS_BEING_REMOVED(entity))
 			{
 				struct monster_data *monster= get_monster_data(entity->monster_index);

--- a/Source_Files/Sound/SoundManager.cpp
+++ b/Source_Files/Sound/SoundManager.cpp
@@ -363,7 +363,7 @@ void SoundManager::PlaySound(short sound_index,
 			     short identifier, // NONE is no identifer and the sound is immediately orphaned
 			     _fixed pitch) // on top of all existing pitch modifiers
 {
-	/* donÕt do anything if weÕre not initialized or active, or our sound_code is NONE,
+	/* donâ€™t do anything if weâ€™re not initialized or active, or our sound_code is NONE,
 		or our volume is zero, our we have no sound channels */
 	if (sound_index!=NONE && active && parameters.volume_db > MINIMUM_VOLUME_DB && total_channel_count > 0)
 	{
@@ -393,7 +393,7 @@ void SoundManager::PlaySound(short sound_index,
 				/* start the sound playing */
 				BufferSound(*channel, sound_index, pitch);
 
-				/* if we have a valid source, copy it, otherwise remember that we donÕt */
+				/* if we have a valid source, copy it, otherwise remember that we donâ€™t */
 				if (source)
 				{
 					channel->source= *source;
@@ -409,7 +409,7 @@ void SoundManager::PlaySound(short sound_index,
 				
 void SoundManager::DirectPlaySound(short sound_index, angle direction, short volume, _fixed pitch)
 {
-	/* donÕt do anything if weÕre not initialized or active, or our sound_code is NONE,
+	/* donâ€™t do anything if weâ€™re not initialized or active, or our sound_code is NONE,
 	   or our volume is zero, our we have no sound channels */
 
 	if (sound_index != NONE && active && parameters.volume_db > MINIMUM_VOLUME_DB && total_channel_count > 0)
@@ -889,9 +889,9 @@ SoundManager::Channel *SoundManager::BestChannel(short sound_index, Channel::Var
 						}
 					}
 					
-					/* if we havenÕt found an alternative channel or this channel is at a lower
-					   volume than our previously best channel (which isnÕt an unused channel),
-					   then weÕve found a new best channel */
+					/* if we havenâ€™t found an alternative channel or this channel is at a lower
+					   volume than our previously best channel (which isnâ€™t an unused channel),
+					   then weâ€™ve found a new best channel */
 					if (!best_channel ||
 					    (SLOT_IS_USED(best_channel) && best_channel->variables.volume > channel->variables.volume) ||
 					    (SLOT_IS_USED(best_channel) && best_channel->variables.priority < channel->variables.priority))
@@ -903,7 +903,7 @@ SoundManager::Channel *SoundManager::BestChannel(short sound_index, Channel::Var
 				{
 					if (channel->sound_index == sound_index && !(definition->flags & _sound_does_not_self_abort))
 					{
-						/* if weÕre already playing this sound at a higher volume, donÕt abort it */
+						/* if weâ€™re already playing this sound at a higher volume, donâ€™t abort it */
 						best_channel = 0;
 						break;
 					}
@@ -912,7 +912,7 @@ SoundManager::Channel *SoundManager::BestChannel(short sound_index, Channel::Var
 			}
 			else
 			{
-				/* unused channel (we wonÕt get much better than this!) */
+				/* unused channel (we wonâ€™t get much better than this!) */
 				if (SLOT_IS_USED(channel))
 					FreeChannel(*channel);
 				best_channel = channel;

--- a/Source_Files/Sound/sound_definitions.h
+++ b/Source_Files/Sound/sound_definitions.h
@@ -260,7 +260,7 @@ static struct sound_definition sound_definitions[NUMBER_OF_SOUND_DEFINITIONS]=
 	{11010, _sound_is_normal}, // _snd_metallic_ricochet
 	{11020, _sound_is_quiet}, // _snd_empty_gun
 
-	// sÕpht doors and platforms
+	// sâ€™pht doors and platforms
 	{12000, _sound_is_normal}, // _snd_spht_door_opening,
 	{12010, _sound_is_normal}, // _snd_spht_door_closing,
 	{12020, _sound_is_normal}, // _snd_spht_door_obstructed,
@@ -342,11 +342,11 @@ static struct sound_definition sound_definitions[NUMBER_OF_SOUND_DEFINITIONS]=
 	{15400, _sound_is_loud}, // _snd_human_wail
 	{15410, _sound_is_normal}, // _snd_human_scream
 	{15420, _sound_is_normal}, // _snd_human_hit
-	{15430, _sound_is_normal, _sound_cannot_be_restarted}, // _snd_human_chatter "theyÕre everywhere!"
-	{15440, _sound_is_normal, _sound_cannot_be_restarted}, // _snd_assimilated_human_chatter "thank god itÕs you!"
+	{15430, _sound_is_normal, _sound_cannot_be_restarted}, // _snd_human_chatter "theyâ€™re everywhere!"
+	{15440, _sound_is_normal, _sound_cannot_be_restarted}, // _snd_assimilated_human_chatter "thank god itâ€™s you!"
 	{15450, _sound_is_normal, _sound_cannot_be_restarted, _seventy_percent}, // _snd_human_trash_talk "eat that!"
 	{15460, _sound_is_normal, _sound_cannot_be_restarted}, // _snd_human_apology "oops!"
-	{15470, _sound_is_normal, _sound_cannot_be_restarted}, // _snd_human_activation "theyÕre over here!"
+	{15470, _sound_is_normal, _sound_cannot_be_restarted}, // _snd_human_activation "theyâ€™re over here!"
 	{15480, _sound_is_normal, _sound_cannot_be_restarted, _fifty_percent}, // _snd_human_clear "out of the way!"
 	{15490, _sound_is_normal, _sound_cannot_be_restarted, _thirty_percent}, // _snd_human_stop_shooting_me_you_bastard
 	{15500, _sound_is_normal, _sound_cannot_be_restarted, _fifty_percent}, // _snd_human_area_secure

--- a/Source_Files/shell.h
+++ b/Source_Files/shell.h
@@ -24,7 +24,7 @@ SHELL.H
 Saturday, August 22, 1992 2:18:48 PM
 
 Saturday, January 2, 1993 10:22:46 PM
-	thank god c doesnÕt choke on incomplete structure references.
+	thank god c doesnâ€™t choke on incomplete structure references.
 
 Jul 5, 2000 (Loren Petrich):
 	Added XML support for controlling the cheats


### PR DESCRIPTION
This PR is the result of running `iconv -f mac -t utf-8` on the A1 source files. It's a large diff, but it should just be changes in comment punctuation -- mostly correcting the apostrophe `’` as well as the occasional lowercase delta `∂`, infinity sign `∞`, and some other characters in various places.