### PR TITLE
calculate teleport view distortion at >30fps

### DIFF
--- a/Source_Files/RenderMain/render.cpp
+++ b/Source_Files/RenderMain/render.cpp
@@ -759,18 +759,19 @@ static void update_render_effect(
 	}
 	else
 	{
+		float interpolated_phase = MAX(0, phase - 1 + view->heartbeat_fraction);
 		switch (effect)
 		{
 			case _render_effect_explosion:
-				shake_view_origin(view, EXPLOSION_EFFECT_RANGE - ((EXPLOSION_EFFECT_RANGE/2)*phase)/period);
+				shake_view_origin(view, EXPLOSION_EFFECT_RANGE - ((EXPLOSION_EFFECT_RANGE/2)*interpolated_phase)/period);
 				break;
 			
 			case _render_effect_fold_in:
-				phase= period-phase;
+				interpolated_phase= period-interpolated_phase;
 			case _render_effect_fold_out:
 				/* calculate world_to_screen based on phase */
-				view->world_to_screen_x= view->real_world_to_screen_x + (4*view->real_world_to_screen_x*phase)/period;
-				view->world_to_screen_y= view->real_world_to_screen_y - (view->real_world_to_screen_y*phase)/(period+period/4);
+				view->world_to_screen_x= view->real_world_to_screen_x + (4*view->real_world_to_screen_x*interpolated_phase)/period;
+				view->world_to_screen_y= view->real_world_to_screen_y - (view->real_world_to_screen_y*interpolated_phase)/(period+period/4);
 				break;
 		}
 	}

--- a/Source_Files/RenderMain/render.h
+++ b/Source_Files/RenderMain/render.h
@@ -106,6 +106,7 @@ struct view_data
 
 	short ticks_elapsed;
 	uint32 tick_count; /* for effects and transfer modes */
+	float heartbeat_fraction;
 	short origin_polygon_index;
 	angle yaw, pitch, roll;
 	fixed_angle virtual_yaw, virtual_pitch;

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -1266,6 +1266,7 @@ void render_screen(short ticks_elapsed)
 	update_world_view_camera();
 
 	auto heartbeat_fraction = get_heartbeat_fraction();
+	world_view->heartbeat_fraction = heartbeat_fraction;
 	update_interpolated_world(heartbeat_fraction);
 
 	bool SwitchedModes = false;


### PR DESCRIPTION
Add `heartbeat_fraction` to `struct view_data` so we can pass it into `render_view()`, and calculate the teleport view distortion for interpolated frames.