### PR TITLE
Fix missing ending row in Lua_HotkeyBinding_Get array

### DIFF
--- a/Source_Files/Lua/lua_player.cpp
+++ b/Source_Files/Lua/lua_player.cpp
@@ -411,6 +411,7 @@ const luaL_Reg Lua_HotkeyBinding_Get[] = {
 	{"joystick", Lua_HotkeyBinding_Get_Binding<type_joystick>},
 	{"key", Lua_HotkeyBinding_Get_Binding<type_keyboard>},
 	{"mouse", Lua_HotkeyBinding_Get_Binding<type_mouse>},
+	{0, 0}
 };
 
 char Lua_HotkeyBindings_Name[] = "hotkey_bindings";


### PR DESCRIPTION
A small fix preventing A1 to crash when lua scripts are used