### PR TITLE
Update VS solution to manage dependencies with custom nuget packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ lib*.a
 # VisualStudio specific
 Debug/
 Release/
+Source_Files/packages
 .vs/
 *.vcxproj.user
 *.aps

--- a/Source_Files/AlephOne.vcxproj
+++ b/Source_Files/AlephOne.vcxproj
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\AlephOne32.1.0.0\build\native\AlephOne32.props" Condition="Exists('packages\AlephOne32.1.0.0\build\native\AlephOne32.props') and '$(Platform)'=='Win32'" />
+  <Import Project="packages\AlephOne64.1.0.0\build\native\AlephOne64.props" Condition="Exists('packages\AlephOne64.1.0.0\build\native\AlephOne64.props') and '$(Platform)'=='x64'" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -90,13 +92,13 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(VcpkgCurrentInstalledDir)include\SDL2;$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;$(VcpkgCurrentInstalledDir)lib\manual-link\SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Strmiids.lib;mfuuid.lib;mfplat.lib;imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
@@ -106,7 +108,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(VcpkgCurrentInstalledDir)include\SDL2;$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
@@ -114,31 +116,31 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;$(VcpkgCurrentInstalledDir)lib\manual-link\SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Strmiids.lib;mfuuid.lib;mfplat.lib;imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(VcpkgCurrentInstalledDir)include\SDL2;$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>CURL_STATICLIB;BOOST_UUID_FORCE_AUTO_LINK;SPEEX;HAVE_SDL_IMAGE;HAVE_CURL;HAVE_LUA;HAVE_PNG;HAVE_ZZIP;HAVE_FFMPEG;HAVE_OPENGL;SDL;WIN32;__WIN32__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;$(VcpkgCurrentInstalledDir)lib\manual-link\SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Strmiids.lib;mfuuid.lib;mfplat.lib;imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(VcpkgCurrentInstalledDir)include\SDL2;$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)XML;$(ProjectDir)TCPMess;$(ProjectDir)Sound;$(ProjectDir)RenderOther;$(ProjectDir)RenderMain;$(ProjectDir)Network\Metaserver;$(ProjectDir)Network;$(ProjectDir)ModelView;$(ProjectDir)Misc;$(ProjectDir)Lua;$(ProjectDir)LibNAT;$(ProjectDir)Input;$(ProjectDir)GameWorld;$(ProjectDir)Files;$(ProjectDir)FFmpeg;$(ProjectDir)CSeries;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>CURL_STATICLIB;BOOST_UUID_FORCE_AUTO_LINK;SPEEX;HAVE_SDL_IMAGE;HAVE_CURL;HAVE_LUA;HAVE_PNG;HAVE_ZZIP;HAVE_FFMPEG;HAVE_OPENGL;SDL;WIN32;__WIN32__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;$(VcpkgCurrentInstalledDir)lib\manual-link\SDL2main.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Strmiids.lib;mfuuid.lib;mfplat.lib;imm32.lib;Setupapi.lib;Iphlpapi.lib;Version.lib;winmm.lib;wldap32.lib;crypt32.lib;Secur32.lib;dsound.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -657,7 +659,21 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\AlephOne64.1.0.0\build\native\AlephOne64.targets" Condition="Exists('packages\AlephOne64.1.0.0\build\native\AlephOne64.targets') and '$(Platform)'=='x64'" />
+    <Import Project="packages\AlephOne32.1.0.0\build\native\AlephOne32.targets" Condition="Exists('packages\AlephOne32.1.0.0\build\native\AlephOne32.targets') and '$(Platform)'=='Win32'" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\AlephOne64.1.0.0\build\native\AlephOne64.props') and '$(Platform)'=='x64'" Text="$([System.String]::Format('$(ErrorText)', 'packages\AlephOne64.1.0.0\build\native\AlephOne64.props'))" />
+    <Error Condition="!Exists('packages\AlephOne64.1.0.0\build\native\AlephOne64.targets') and '$(Platform)'=='x64'" Text="$([System.String]::Format('$(ErrorText)', 'packages\AlephOne64.1.0.0\build\native\AlephOne64.targets'))" />
+    <Error Condition="!Exists('packages\AlephOne32.1.0.0\build\native\AlephOne32.props') and '$(Platform)'=='Win32'" Text="$([System.String]::Format('$(ErrorText)', 'packages\AlephOne32.1.0.0\build\native\AlephOne32.props'))" />
+    <Error Condition="!Exists('packages\AlephOne32.1.0.0\build\native\AlephOne32.targets') and '$(Platform)'=='Win32'" Text="$([System.String]::Format('$(ErrorText)', 'packages\AlephOne32.1.0.0\build\native\AlephOne32.targets'))" />
+  </Target>
 </Project>

--- a/Source_Files/AlephOne.vcxproj.filters
+++ b/Source_Files/AlephOne.vcxproj.filters
@@ -1446,4 +1446,7 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Source_Files/LibNAT/LibNat.vcxproj
+++ b/Source_Files/LibNAT/LibNat.vcxproj
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\AlephOne32.1.0.0\build\native\AlephOne32.props" Condition="Exists('..\packages\AlephOne32.1.0.0\build\native\AlephOne32.props') and '$(Platform)'=='Win32'" />
+  <Import Project="..\packages\AlephOne64.1.0.0\build\native\AlephOne64.props" Condition="Exists('..\packages\AlephOne64.1.0.0\build\native\AlephOne64.props') and '$(Platform)'=='x64'" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -159,7 +161,21 @@
     <ClInclude Include="ssdp.h" />
     <ClInclude Include="utility.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\AlephOne64.1.0.0\build\native\AlephOne64.targets" Condition="Exists('..\packages\AlephOne64.1.0.0\build\native\AlephOne64.targets') and '$(Platform)'=='x64'" />
+    <Import Project="..\packages\AlephOne32.1.0.0\build\native\AlephOne32.targets" Condition="Exists('..\packages\AlephOne32.1.0.0\build\native\AlephOne32.targets') and '$(Platform)'=='Win32'" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\AlephOne64.1.0.0\build\native\AlephOne64.props') and '$(Platform)'=='x64'" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AlephOne64.1.0.0\build\native\AlephOne64.props'))" />
+    <Error Condition="!Exists('..\packages\AlephOne64.1.0.0\build\native\AlephOne64.targets') and '$(Platform)'=='x64'" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AlephOne64.1.0.0\build\native\AlephOne64.targets'))" />
+    <Error Condition="!Exists('..\packages\AlephOne32.1.0.0\build\native\AlephOne32.props') and '$(Platform)'=='Win32'" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AlephOne32.1.0.0\build\native\AlephOne32.props'))" />
+    <Error Condition="!Exists('..\packages\AlephOne32.1.0.0\build\native\AlephOne32.targets') and '$(Platform)'=='Win32'" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AlephOne32.1.0.0\build\native\AlephOne32.targets'))" />
+  </Target>
 </Project>

--- a/Source_Files/LibNAT/LibNat.vcxproj.filters
+++ b/Source_Files/LibNAT/LibNat.vcxproj.filters
@@ -66,4 +66,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Source_Files/LibNAT/packages.config
+++ b/Source_Files/LibNAT/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AlephOne32" version="1.0.0" targetFramework="native" />
+  <package id="AlephOne64" version="1.0.0" targetFramework="native" />
+</packages>

--- a/Source_Files/packages.config
+++ b/Source_Files/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AlephOne32" version="1.0.0" targetFramework="native" />
+  <package id="AlephOne64" version="1.0.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
Another update to the VS solution. All the dependencies are now managed with custom Alephone nuget packages built from vcpkg. This mean, in order to build the solution, vcpkg is no longer needed, you can just grab the visual studio solution and you are good to go. Thoses packages have been uploaded to nuger.org and are automatically downloaded and installed by the solution when you will try to compile it (yeah I know this is the purpose of nuget)
This is way more easy and we can ensure now that no update done by vcpkg will break anything, since everybody will use a "fixed in time" version we have control on.

There is two packages, one for 32 bits and one for 64. The solution will restore both even if you wanna build on only one platform though (looks like it can't be done otherwhise for c++ project). The reason there are 2 packages is due to the limitation of nuget.org that refuses packages larger than 250mb and I don't feel like hosting a private nuget server.