### PR TITLE
Fix crash when killing monster ticks from M1

### DIFF
--- a/Source_Files/GameWorld/monsters.cpp
+++ b/Source_Files/GameWorld/monsters.cpp
@@ -237,9 +237,6 @@ struct damage_kick_definition damage_kick_definitions[NUMBER_OF_DAMAGE_TYPES] =
 /* import monster definition constants, structures and globals */
 #include "monster_definitions.h"
 
-// LP addition: growable list of intersected objects
-static vector<short> IntersectedObjects;
-
 /* ---------- private prototypes */
 
 static monster_definition *get_monster_definition(
@@ -1283,8 +1280,7 @@ short legal_player_move(
 	short obstacle_index= NONE;
 
 	get_monster_dimensions(monster_index, &radius, &height);	
-	
-	IntersectedObjects.clear();
+	std::vector<short> IntersectedObjects;
 	possible_intersecting_monsters(&IntersectedObjects, LOCAL_INTERSECTING_MONSTER_BUFFER_SIZE, object->polygon, true);
 	monster_count = IntersectedObjects.size();
 	for (size_t i=0;i<monster_count;++i)
@@ -1356,7 +1352,7 @@ short legal_monster_move(
 
 	get_monster_dimensions(monster_index, &radius, &height);	
 	
-	IntersectedObjects.clear();
+	std::vector<short> IntersectedObjects;
 	possible_intersecting_monsters(&IntersectedObjects, LOCAL_INTERSECTING_MONSTER_BUFFER_SIZE, object->polygon, true);
 	monster_count= IntersectedObjects.size();
 	for (size_t i=0;i<monster_count;++i)
@@ -1432,7 +1428,7 @@ void damage_monsters_in_radius(
 
 	(void) (primary_target_index);
 	
-	IntersectedObjects.clear();
+	std::vector<short> IntersectedObjects;
 	possible_intersecting_monsters(&IntersectedObjects, LOCAL_INTERSECTING_MONSTER_BUFFER_SIZE, epicenter_polygon_index, false);
 	object_count= IntersectedObjects.size();
         struct object_data *aggressor = NULL;


### PR DESCRIPTION
This seems to happen when you kill one of those tick monster from M1 and when exploding it hit other monsters.
This leads to very strange behavior where the variable containing the number of intersected objects doesn't match the vector containing those, like if the vector is being modified at some point and then it crashes trying to access an out of range value (since the for loop is based on that variable). Replacing the static vector used in each method by a local one fixes the problem.

![2021-05-24 01_46_26-AlephOne (Debugging) - Microsoft Visual Studio](https://user-images.githubusercontent.com/17474079/119280674-b2422c80-bc32-11eb-83e5-23e8d6843fe2.png)
![2021-05-24 01_45_43-AlephOne (Debugging) - Microsoft Visual Studio](https://user-images.githubusercontent.com/17474079/119280676-b3735980-bc32-11eb-9ac7-e07e0ba38233.png)
(It crashes lines 1452 on the screen)

Fix #282 