### PR TITLE
Fix for Ffmpeg version 4.4+

### DIFF
--- a/Source_Files/FFmpeg/Movie.cpp
+++ b/Source_Files/FFmpeg/Movie.cpp
@@ -666,9 +666,9 @@ void Movie::EncodeVideo(bool last)
         pkt.data = av->video_buf;
         pkt.size = av->video_bufsize;
         
-        int got_packet = 0;
-        int vsize = avcodec_encode_video2(vcodec, &pkt, frame, &got_packet);
-        if (vsize == 0 && got_packet)
+        int vsize = avcodec_send_frame(vcodec, frame);
+        int got_packet = avcodec_receive_packet(vcodec, &pkt);
+        if (vsize == 0 && got_packet == 0)
         {
             if (pkt.pts != AV_NOPTS_VALUE && pkt.pts < pkt.dts)
                 pkt.pts = pkt.dts;
@@ -681,7 +681,7 @@ void Movie::EncodeVideo(bool last)
             av_interleaved_write_frame(av->fmt_ctx, &pkt);
             av_free_packet(&pkt);
         }
-        if (!last || vsize < 0 || !got_packet)
+        if (!last || vsize < 0 || got_packet < 0)
             done = true;
     }
 }

--- a/Source_Files/FFmpeg/Movie.cpp
+++ b/Source_Files/FFmpeg/Movie.cpp
@@ -655,6 +655,11 @@ void Movie::EncodeVideo(bool last)
                   av->video_frame->data, av->video_frame->linesize);
         av->video_frame->pts = av->video_counter++;
         frame = av->video_frame;
+
+        //Needed since ffmpeg version 4.4
+        frame->format = vcodec->pix_fmt;
+        frame->width = vcodec->width;
+        frame->height = vcodec->height;
     }
     
     bool done = false;

--- a/Source_Files/FFmpeg/SDL_ffmpeg.c
+++ b/Source_Files/FFmpeg/SDL_ffmpeg.c
@@ -142,8 +142,6 @@ struct SwsContext* getContext( SDL_ffmpegConversionContext **context, int inWidt
     return ctx->context;
 }
 
-uint32_t SDL_ffmpegInitWasCalled = 0;
-
 /* error handling */
 char SDL_ffmpegErrorMessage[ 512 ];
 
@@ -221,24 +219,6 @@ SDL_ffmpegFile* SDL_ffmpegCreateFile()
 \endcond
 */
 
-
-/** \brief  Initializes the SDL_ffmpeg library
-
-            This is done automatically when using SDL_ffmpegOpen or
-            SDL_ffmpegCreateFile. This means that it is usualy unnescecairy
-            to explicitly call this function
-*/
-void SDL_ffmpegInit()
-{
-    /* register all codecs */
-    if ( !SDL_ffmpegInitWasCalled )
-    {
-        SDL_ffmpegInitWasCalled = 1;
-
-        avcodec_register_all();
-        av_register_all();
-    }
-}
 
 /** \brief  Use this to free an SDL_ffmpegFile.
 
@@ -391,8 +371,6 @@ void SDL_ffmpegFreeVideoFrame( SDL_ffmpegVideoFrame* frame )
 */
 SDL_ffmpegFile* SDL_ffmpegOpen( const char* filename )
 {
-    SDL_ffmpegInit();
-
     /* open new ffmpegFile */
     SDL_ffmpegFile *file = SDL_ffmpegCreateFile();
     if ( !file ) return 0;
@@ -542,8 +520,6 @@ SDL_ffmpegFile* SDL_ffmpegOpen( const char* filename )
 */
 SDL_ffmpegFile* SDL_ffmpegCreate( const char* filename )
 {
-    SDL_ffmpegInit();
-
     SDL_ffmpegFile *file = SDL_ffmpegCreateFile();
 
     file->_ffmpeg = avformat_alloc_context();


### PR DESCRIPTION
This PR fixes export video when using new ffmpeg version 4.4.
It replaces the obsolete avcodec_encode_video2 with the updated ffmpeg function to use.
And It also removes ffmpeg functions call became unnecessary in SDL_ffmpeg.
