### PR TITLE
Add missing feature libjpeg for sdl2-image in vcpkg.json

### DIFF
--- a/Source_Files/vcpkg.json
+++ b/Source_Files/vcpkg.json
@@ -32,7 +32,10 @@
       },
       {
          "name":"sdl2-image",
-         "version>=":"2.0.5#1"
+         "version>=":"2.0.5#1",
+         "features":[
+            "libjpeg-turbo"
+         ]
       },
       {
          "name":"sdl2-net",


### PR DESCRIPTION
I noticed while playing Eternal that some intro screen images were not showing due to the fact we were missing jpeg support for SDL2_image with vcpkg.json.