### PR TITLE
Print replay speed in FPS display

### DIFF
--- a/Source_Files/Misc/vbl.cpp
+++ b/Source_Files/Misc/vbl.cpp
@@ -246,17 +246,37 @@ void increment_replay_speed(
 	void)
 {
 	if (replay.replay_speed < MAXIMUM_REPLAY_SPEED) replay.replay_speed++;
+	if (replay.replay_speed == 0) replay.replay_speed++; // skip past 0
 }
 
 void decrement_replay_speed(
 	void)
 {
 	if (replay.replay_speed > MINIMUM_REPLAY_SPEED) replay.replay_speed--;
+	if (replay.replay_speed == 0) replay.replay_speed--; // skip past 0
 }
 
 int get_replay_speed()
 {
 	return replay.replay_speed;
+}
+
+char* get_replay_speed_string()
+{
+	char* speed= new char[sizeof("1/10x")];
+	if (replay.replay_speed == MINIMUM_REPLAY_SPEED)
+	{
+		strcpy(speed, "pause");
+	}
+	else if (replay.replay_speed < 0)
+	{
+		sprintf(speed, "1/%ix", -replay.replay_speed + 1);
+	}
+	else
+	{
+		sprintf(speed, "%ix", replay.replay_speed);
+	}
+	return speed;
 }
 
 bool game_is_being_replayed()
@@ -298,7 +318,7 @@ bool input_controller(
 					{
 						short flag_count= MAX(replay.replay_speed, 1);
 					
-						if (!pull_flags_from_recording(flag_count)) // oops. silly me.
+						if (!pull_flags_from_recording(flag_count)) // pull replay_speed flags from recording -- so speed 2 is 2x, etc.
 						{
 							if (replay.have_read_last_chunk)
 							{
@@ -307,13 +327,13 @@ bool input_controller(
 							}
 						}
 						else
-						{	
+						{
 							/* Increment the heartbeat.. */
 							heartbeat_count+= flag_count;
 						}
 	
-						/* Reset the phase-> doesn't matter if the replay speed is positive */					
-						/* +1 so that replay_speed 0 is different from replay_speed 1 */
+						/* Reset the phase-> doesn't matter if the replay speed is positive */
+						// setting phase to 1 will not slow playback, so we add 1 so speed -1 takes 2 calls to advance (1/2x), etc.
 						phase= -(replay.replay_speed) + 1;
 					}
 				}

--- a/Source_Files/Misc/vbl.cpp
+++ b/Source_Files/Misc/vbl.cpp
@@ -106,8 +106,8 @@ Feb 20, 2002 (Woody Zenfell):
 #define MAXIMUM_TIME_DIFFERENCE     15 // allowed between heartbeat_count and dynamic_world->tick_count
 #define MAXIMUM_NET_QUEUE_SIZE       8
 #define DISK_CACHE_SIZE             ((sizeof(int16)+sizeof(uint32))*100)
-#define MAXIMUM_REPLAY_SPEED         5
-#define MINIMUM_REPLAY_SPEED        -5
+#define MAXIMUM_REPLAY_SPEED         10 // 10x
+#define MINIMUM_REPLAY_SPEED        -10 // -10 = pause, -9 = 1/10x
 
 /* ---------- macros */
 

--- a/Source_Files/RenderOther/screen_shared.h
+++ b/Source_Files/RenderOther/screen_shared.h
@@ -526,13 +526,17 @@ uint16 DisplayTextWidth(const char *Text)
 	return text_width(Text, DisplayTextFont, DisplayTextStyle);
 }
 
+extern bool game_is_being_replayed();
+extern char* get_replay_speed_string();
+
 static void update_fps_display(SDL_Surface *s)
 {
 	if (displaying_fps && !player_in_terminal_mode(current_player_index))
 	{
 		uint32 ticks = machine_tick_count();
-		char fps[sizeof("1000 fps (10000 ms)")];
+		char fps[sizeof("1000 fps (10000 ms) 1/10x")];
 		char ms[sizeof("(10000 ms)")];
+		char speed[sizeof("1/10x")];
 
 		fps_counter.update();
 
@@ -542,6 +546,14 @@ static void update_fps_display(SDL_Surface *s)
 		}
 		else
 		{
+			if (game_is_being_replayed())
+			{
+				strcpy(speed, get_replay_speed_string());
+			}
+			else
+			{
+				speed[0] = '\0';
+			}
 			
 			int latency = NetGetLatency();
 			if (latency > -1)
@@ -549,7 +561,7 @@ static void update_fps_display(SDL_Surface *s)
 			else
 				ms[0] = '\0';
 			
-			sprintf(fps, "%0.f fps %s", fps_counter.get(), ms);
+			sprintf(fps, "%0.f fps %s %s", fps_counter.get(), ms, speed);
 		}
 
 		FontSpecifier& Font = GetOnScreenFont();

--- a/Source_Files/RenderOther/screen_shared.h
+++ b/Source_Files/RenderOther/screen_shared.h
@@ -547,13 +547,9 @@ static void update_fps_display(SDL_Surface *s)
 		else
 		{
 			if (game_is_being_replayed())
-			{
 				strcpy(speed, get_replay_speed_string());
-			}
 			else
-			{
 				speed[0] = '\0';
-			}
 			
 			int latency = NetGetLatency();
 			if (latency > -1)


### PR DESCRIPTION
Prints the replay playback rate (e.g. "1/2x", "2x", or "pause" if at the minimum rate) after the FPS in the FPS display during film playback.

Skips speed 0 so there aren't two settings that both play at 1x speed.

Also doubles the limits so we can go down to 1/10x or up to 10x.