### PR TITLE
Add shell arguments to export films

### DIFF
--- a/Source_Files/Files/FileHandler.cpp
+++ b/Source_Files/Files/FileHandler.cpp
@@ -844,6 +844,21 @@ void FileSpecifier::SplitPath(string &base, string &part) const
 	}
 }
 
+void FileSpecifier::SetExtension(const string& ext)
+{
+	string::size_type pos = name.rfind('.');
+	if (pos != string::npos && pos != 0) {
+		name = name.substr(0, pos);
+	}
+	if (ext[0] == '.') {
+		// caller provided '.'
+		name += ext;
+	} else {
+		// caller didn't provide '.'
+		name += ('.' + ext);
+	}
+}
+
 // Fill file specifier with base name
 void FileSpecifier::ToDirectory(DirectorySpecifier &dir)
 {

--- a/Source_Files/Files/FileHandler.h
+++ b/Source_Files/Files/FileHandler.h
@@ -303,6 +303,9 @@ public:
 	// Rename file
 	bool Rename(const FileSpecifier& Destination);
 
+	// Set the file extension to ext
+	void SetExtension(const string& ext);
+
 	// Copy file specification
 	const FileSpecifier &operator=(const FileSpecifier &other);
 

--- a/Source_Files/Misc/interface.cpp
+++ b/Source_Files/Misc/interface.cpp
@@ -2078,8 +2078,14 @@ static bool begin_game(
 					break;
 
 				case _replay_from_file:
-					success= setup_for_replay_from_file(DraggedReplayFile, get_current_map_checksum());
-					user= _replay;
+					{
+						bool export_from_shell = false;
+#ifndef MAC_APP_STORE
+						export_from_shell = shell_options.record_movie;
+#endif
+						success = setup_for_replay_from_file(DraggedReplayFile, get_current_map_checksum(), false, export_from_shell);
+						user = _replay;
+					}
 					break;
 					
 				default:
@@ -2361,6 +2367,9 @@ static void finish_game(
 			exit(-1);
 		}
 	}
+
+	if (shell_options.exit_on_quit)
+		exit(0);
 
 	/* Fade out! (Pray) */ // should be interface_color_table for valkyrie, but doesn't work.
 	Music::instance()->ClearLevelMusic();

--- a/Source_Files/Misc/vbl.cpp
+++ b/Source_Files/Misc/vbl.cpp
@@ -547,7 +547,7 @@ bool setup_for_replay_from_file(
 	FileSpecifier& File,
 	uint32 map_checksum,
 	bool prompt_to_export,
-	bool export_to_file)
+	bool export_from_shell)
 {
 	bool successful= false;
 
@@ -585,12 +585,10 @@ bool setup_for_replay_from_file(
 #endif
 			if (prompt_to_export)
 				Movie::instance()->PromptForRecording();
-			else if (export_to_file)
+			else if (export_from_shell)
 			{
-				FileSpecifier moviePath;
-				std::string file;
-				FilmFileSpec.SplitPath(moviePath, file);
-				moviePath.AddPart("Untitled Movie.webm"); // TODO: FIXME
+				FileSpecifier moviePath = FilmFileSpec;
+				moviePath.SetExtension(".webm");
 
 				Movie::instance()->StartRecording(moviePath.GetPath());
 			}

--- a/Source_Files/Misc/vbl.cpp
+++ b/Source_Files/Misc/vbl.cpp
@@ -546,7 +546,8 @@ extern int movie_export_phase;
 bool setup_for_replay_from_file(
 	FileSpecifier& File,
 	uint32 map_checksum,
-	bool prompt_to_export)
+	bool prompt_to_export,
+	bool export_to_file)
 {
 	bool successful= false;
 
@@ -584,6 +585,16 @@ bool setup_for_replay_from_file(
 #endif
 			if (prompt_to_export)
 				Movie::instance()->PromptForRecording();
+			else if (export_to_file)
+			{
+				FileSpecifier moviePath;
+				std::string file;
+				FilmFileSpec.SplitPath(moviePath, file);
+				moviePath.AddPart("Untitled Movie.webm"); // TODO: FIXME
+
+				Movie::instance()->StartRecording(moviePath.GetPath());
+			}
+
 			successful= true;
 		} else {
 			/* Tell them that this map wasn't found.  They lose. */

--- a/Source_Files/Misc/vbl.h
+++ b/Source_Files/Misc/vbl.h
@@ -34,7 +34,8 @@ Jul 5, 2000 (Loren Petrich):
 #include "FileHandler.h"
 
 /* ------------ prototypes/VBL.C */
-bool setup_for_replay_from_file(FileSpecifier& File, uint32 map_checksum, bool prompt_to_export = false);
+bool setup_for_replay_from_file(FileSpecifier& File, uint32 map_checksum, bool prompt_to_export = false,
+	bool export_from_shell = false);
 bool setup_replay_from_random_resource(uint32 map_checksum);
 
 void start_recording(void);

--- a/Source_Files/shell_options.cpp
+++ b/Source_Files/shell_options.cpp
@@ -115,11 +115,13 @@ static const std::vector<ShellOptionsFlag> shell_options_flags {
 	{"j", "nojoystick", "Do not initialize joysticks", shell_options.nojoystick},
 	{"i", "insecure_lua", "", shell_options.insecure_lua},
 	{"Q", "skip-intro", "Skip intro screens", shell_options.skip_intro},
+	{"x", "exit", "Exit on quit", shell_options.exit_on_quit},
+	{"r", "record", "With a film file, encode a video of the film", shell_options.record_movie},
 	{"e", "editor", "Use editor prefs; jump directly to map", shell_options.editor}
 };
 
 static const std::vector<ShellOptionsString> shell_options_strings {
-	{"o", "output", "With -e, output to [file] and exit on quit", shell_options.output}
+	{"o", "output", "With -e, output map to [file] and exit on quit", shell_options.output}
 };
 
 bool ShellOptions::parse(int argc, char** argv)

--- a/Source_Files/shell_options.h
+++ b/Source_Files/shell_options.h
@@ -20,6 +20,8 @@ struct ShellOptions {
 	bool force_windowed;
 
 	bool skip_intro;
+	bool exit_on_quit;
+	bool record_movie;
 	bool editor;
 
 	std::string directory;


### PR DESCRIPTION
Adds two shell arguments:
`-x/-exit`: Exit Aleph One when a game is quit/a film ends.
`-r/-record`: When provided along with a film file, encode the film as a video with the same name as the film, but with a `.webm` extension.

In conjunction, these arguments could be used to help automate batch encoding of films.