### PR TITLE
Fix teleporting in weapon effect when switching level not always visible

### DIFF
--- a/Source_Files/GameWorld/map.h
+++ b/Source_Files/GameWorld/map.h
@@ -1106,7 +1106,7 @@ void changed_polygon(short original_polygon_index, short new_polygon_index, shor
 
 short calculate_damage(struct damage_definition *damage);
 void cause_polygon_damage(short polygon_index, short monster_index);
-
+bool can_update_player_teleport();
 short calculate_level_completion_state(void);
 
 /* ---------- prototypes/MAP.C */

--- a/Source_Files/GameWorld/marathon2.cpp
+++ b/Source_Files/GameWorld/marathon2.cpp
@@ -208,6 +208,9 @@ static short sSavedPlayerObjectNextObject[MAXIMUM_NUMBER_OF_PLAYERS];
 static int32 sSavedTickCount;
 static uint16 sSavedRandomSeed;
 
+static bool levelChanged = false;
+bool can_update_player_teleport() { return !levelChanged; };
+
 
 // ZZZ: If not already in predictive mode, save off partial game-state for later restoration.
 static void
@@ -532,10 +535,11 @@ update_world()
 
 		}
 
-
+		levelChanged = false;
         // This and the following voodoo comes, effectively, from Bungie's code.
         if(theUpdateResult == kUpdateChangeLevel)
         {
+				levelChanged = true;
                 theElapsedTime = 0;
         }
 

--- a/Source_Files/GameWorld/player.cpp
+++ b/Source_Files/GameWorld/player.cpp
@@ -821,7 +821,10 @@ void update_players(ActionQueues* inActionQueuesToUse, bool inPredictive)
 				cause_polygon_damage(player->supporting_polygon_index,player->monster_index);
 			}
 
-			update_player_teleport(player_index);
+			if (can_update_player_teleport()) {
+				update_player_teleport(player_index);
+			}
+
 			update_player_media(player_index);
 			set_player_shapes(player_index, true);
 			


### PR DESCRIPTION
I submit this as a PR since there is probably better ways to fix it but I don't know enough about the code. 
So at least it should help understanding what's going on.
The problem causing this is when switching to a new level, sometimes (this is where I don't know enough about the code, ActionQueues and all that) the loop `while(canUpdate)` in `update_world` function in `marathon2.cpp` keeps looping before the screen gets rendered. And so, player's teleporting phases keep being updated in `update_player_teleport` . And once finally the `while(canUpdate)` stops looping, it's too late, the teleporting phases are done and then the teleportation in effect won't obviously shows up.

Fix #308 