### PR TITLE
Switch to LZFSE-compressed disk images

### DIFF
--- a/tools/build_dmg.sh
+++ b/tools/build_dmg.sh
@@ -59,7 +59,7 @@ make_dmg()
     version=`grep '^#define A1_DATE_VERSION' "$SRCROOT/../Source_Files/Misc/alephversion.h" | sed -e 's/\(.*\"\)\(.*\)\(\"\)/\2/g'`
     imgname="${appname// }"
     imgfile="$TARGET_BUILD_DIR/$imgname-$version-Mac.dmg"
-    hdiutil create -ov -fs HFS+ -format UDBZ -layout GPTSPUD -srcfolder "$diskdir" -volname "$appname" "$imgfile"
+    hdiutil create -ov -fs HFS+ -format ULFO -layout GPTSPUD -srcfolder "$diskdir" -volname "$appname" "$imgfile"
     if [ "$SIGNATURE" != "" ]; then
         codesign -s "$SIGNATURE" "$imgfile"
         spctl -a -t open --context context:primary-signature -v "$imgfile"


### PR DESCRIPTION
Modify build_dmg.sh to use ULFO disk image format based on LZFSE codec. ULFO images were introduced in 2015's macOS 10.11 (El Capitan). The LZFSE codec itself is open source and provides good compression with substantially better performance, especially compared to bzip2 (UDBZ). Additionally, UDBZ images have been deprecated in macOS 12 Monterey.