### PR TITLE
Expanded flexibility for bobbing option

### DIFF
--- a/Source_Files/GameWorld/weapons.cpp
+++ b/Source_Files/GameWorld/weapons.cpp
@@ -2812,13 +2812,13 @@ static void calculate_weapon_position_for_idle(
 	/* Weapons are the first thing drawn */
 	bob_height= (player->variables.step_amplitude*definition->bob_amplitude)>>FIXED_FRACTIONAL_BITS;
 	bob_height= (bob_height*table[vertical_angle])>>TRIG_SHIFT;
-	if (!graphics_preferences->screen_mode.weapon_bob) bob_height= 0;
+	if (graphics_preferences->screen_mode.bob_disable == 2) bob_height= 0;
 	if (use_elevation) bob_height+= sine_table[player->elevation]<<3;
 	*height+= bob_height;
 
 	bob_width= (player->variables.step_amplitude*definition->horizontal_amplitude)>>FIXED_FRACTIONAL_BITS;
 	bob_width= (bob_width*table[horizontal_phase>>(FIXED_FRACTIONAL_BITS-ANGULAR_BITS)])>>TRIG_SHIFT;
-	if (!graphics_preferences->screen_mode.weapon_bob) bob_width= 0;
+	if (graphics_preferences->screen_mode.bob_disable == 2) bob_width= 0;
 	*width += bob_width;
 }
 

--- a/Source_Files/GameWorld/weapons.cpp
+++ b/Source_Files/GameWorld/weapons.cpp
@@ -2812,13 +2812,13 @@ static void calculate_weapon_position_for_idle(
 	/* Weapons are the first thing drawn */
 	bob_height= (player->variables.step_amplitude*definition->bob_amplitude)>>FIXED_FRACTIONAL_BITS;
 	bob_height= (bob_height*table[vertical_angle])>>TRIG_SHIFT;
-	if (!graphics_preferences->screen_mode.camera_bob) bob_height= 0;
+	if (!graphics_preferences->screen_mode.weapon_bob) bob_height= 0;
 	if (use_elevation) bob_height+= sine_table[player->elevation]<<3;
 	*height+= bob_height;
 
 	bob_width= (player->variables.step_amplitude*definition->horizontal_amplitude)>>FIXED_FRACTIONAL_BITS;
 	bob_width= (bob_width*table[horizontal_phase>>(FIXED_FRACTIONAL_BITS-ANGULAR_BITS)])>>TRIG_SHIFT;
-	if (!graphics_preferences->screen_mode.camera_bob) bob_width= 0;
+	if (!graphics_preferences->screen_mode.weapon_bob) bob_width= 0;
 	*width += bob_width;
 }
 

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -1264,11 +1264,13 @@ static void graphics_dialog(void *arg)
 
 	table->dual_add_row(new w_static_text("*may interfere with third-party scenario effects"), d);
 
-	table->add_row(new w_spacer(), true);
-	
-	w_toggle *bob_w = new w_toggle(graphics_preferences->screen_mode.camera_bob);
-	table->dual_add(bob_w->label("Camera Bobbing"), d);
-	table->dual_add(bob_w, d);
+	w_toggle *viewbob_w = new w_toggle(graphics_preferences->screen_mode.camera_bob);
+	table->dual_add(viewbob_w->label("Camera Bobbing"), d);
+	table->dual_add(viewbob_w, d);
+
+	w_toggle *gunbob_w = new w_toggle(graphics_preferences->screen_mode.weapon_bob);
+	table->dual_add(gunbob_w->label("Weapon Bobbing"), d);
+	table->dual_add(gunbob_w, d);
 
 	table->add_row(new w_spacer(), true);
 	table->dual_add_row(new w_static_text("Heads-Up Display"), d);
@@ -1402,9 +1404,15 @@ static void graphics_dialog(void *arg)
 			changed = true;
 		}
 	    
-		bool camera_bob = bob_w->get_selection() != 0;
+		bool camera_bob = viewbob_w->get_selection() != 0;
 		if (camera_bob != graphics_preferences->screen_mode.camera_bob) {
 			graphics_preferences->screen_mode.camera_bob = camera_bob;
+			changed = true;
+		}
+
+		bool weapon_bob = gunbob_w->get_selection() != 0;
+		if (weapon_bob != graphics_preferences->screen_mode.weapon_bob) {
+			graphics_preferences->screen_mode.weapon_bob = weapon_bob;
 			changed = true;
 		}
 
@@ -3386,6 +3394,7 @@ InfoTree graphics_preferences_tree()
 	root.put_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.put_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);
 	root.put_attr("scmode_camera_bob", graphics_preferences->screen_mode.camera_bob);
+	root.put_attr("scmode_weapon_bob", graphics_preferences->screen_mode.weapon_bob);
 	root.put_attr("scmode_accel", graphics_preferences->screen_mode.acceleration);
 	root.put_attr("scmode_highres", graphics_preferences->screen_mode.high_resolution);
 	root.put_attr("scmode_draw_every_other_line", graphics_preferences->screen_mode.draw_every_other_line);
@@ -3877,6 +3886,7 @@ static void default_graphics_preferences(graphics_preferences_data *preferences)
 	preferences->screen_mode.fullscreen = true;
 	preferences->screen_mode.fix_h_not_v = true;
 	preferences->screen_mode.camera_bob = true;
+	preferences->screen_mode.weapon_bob = true;
 	preferences->screen_mode.bit_depth = 32;
 	
 	preferences->screen_mode.draw_every_other_line= false;
@@ -4359,6 +4369,7 @@ void parse_graphics_preferences(InfoTree root, std::string version)
 	root.read_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.read_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);
 	root.read_attr("scmode_camera_bob", graphics_preferences->screen_mode.camera_bob);
+	root.read_attr("scmode_weapon_bob", graphics_preferences->screen_mode.weapon_bob);
 	root.read_attr("scmode_accel", graphics_preferences->screen_mode.acceleration);
 	root.read_attr("scmode_highres", graphics_preferences->screen_mode.high_resolution);
 	root.read_attr("scmode_draw_every_other_line", graphics_preferences->screen_mode.draw_every_other_line);

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -1271,6 +1271,8 @@ static void graphics_dialog(void *arg)
 
 	table->dual_add_row(new w_static_text("*may interfere with third-party scenario effects"), d);
 
+	table->add_row(new w_spacer(), true);
+
 	w_select *bob_disable_w = new w_select(0, bob_disable_labels);
 	for (auto i = 0; bob_disable_labels[i] != NULL; ++i)
 	{

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -989,6 +989,13 @@ static const char* renderer_labels[] = {
 	"Software", "OpenGL", NULL
 };
 
+static const char *bob_disable_labels[] = {
+	"Full", "Weapon Only", "None", NULL
+};
+static const int16_t bob_disable_values[] = {
+	0, 1, 2
+};
+
 static const char* hud_scale_labels[] = {
 "Normal", "Double", "Largest", NULL
 };
@@ -1264,14 +1271,17 @@ static void graphics_dialog(void *arg)
 
 	table->dual_add_row(new w_static_text("*may interfere with third-party scenario effects"), d);
 
-	w_toggle *viewbob_w = new w_toggle(graphics_preferences->screen_mode.camera_bob);
-	table->dual_add(viewbob_w->label("Camera Bobbing"), d);
-	table->dual_add(viewbob_w, d);
-
-	w_toggle *gunbob_w = new w_toggle(graphics_preferences->screen_mode.weapon_bob);
-	table->dual_add(gunbob_w->label("Weapon Bobbing"), d);
-	table->dual_add(gunbob_w, d);
-
+	w_select *bob_disable_w = new w_select(0, bob_disable_labels);
+	for (auto i = 0; bob_disable_labels[i] != NULL; ++i)
+	{
+		if (bob_disable_values[i] == graphics_preferences->screen_mode.bob_disable)
+		{
+			bob_disable_w->set_selection(i);
+		}
+	}
+	table->dual_add(bob_disable_w->label("View Bobbing"), d);
+	table->dual_add(bob_disable_w, d);
+	
 	table->add_row(new w_spacer(), true);
 	table->dual_add_row(new w_static_text("Heads-Up Display"), d);
 	w_enabling_toggle *hud_w = new w_enabling_toggle(graphics_preferences->screen_mode.hud);
@@ -1403,16 +1413,11 @@ static void graphics_dialog(void *arg)
 			graphics_preferences->screen_mode.translucent_map = translucent_map;
 			changed = true;
 		}
-	    
-		bool camera_bob = viewbob_w->get_selection() != 0;
-		if (camera_bob != graphics_preferences->screen_mode.camera_bob) {
-			graphics_preferences->screen_mode.camera_bob = camera_bob;
-			changed = true;
-		}
-
-		bool weapon_bob = gunbob_w->get_selection() != 0;
-		if (weapon_bob != graphics_preferences->screen_mode.weapon_bob) {
-			graphics_preferences->screen_mode.weapon_bob = weapon_bob;
+		
+		auto bob_disable = bob_disable_values[bob_disable_w->get_selection()];
+		if (bob_disable != graphics_preferences->screen_mode.bob_disable)
+		{
+			graphics_preferences->screen_mode.bob_disable = bob_disable;
 			changed = true;
 		}
 
@@ -3393,8 +3398,7 @@ InfoTree graphics_preferences_tree()
 	root.put_attr("scmode_hud_scale", graphics_preferences->screen_mode.hud_scale_level);
 	root.put_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.put_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);
-	root.put_attr("scmode_camera_bob", graphics_preferences->screen_mode.camera_bob);
-	root.put_attr("scmode_weapon_bob", graphics_preferences->screen_mode.weapon_bob);
+	root.put_attr("bob_disable", graphics_preferences->screen_mode.bob_disable);
 	root.put_attr("scmode_accel", graphics_preferences->screen_mode.acceleration);
 	root.put_attr("scmode_highres", graphics_preferences->screen_mode.high_resolution);
 	root.put_attr("scmode_draw_every_other_line", graphics_preferences->screen_mode.draw_every_other_line);
@@ -3885,8 +3889,7 @@ static void default_graphics_preferences(graphics_preferences_data *preferences)
 	preferences->screen_mode.high_resolution = true;
 	preferences->screen_mode.fullscreen = true;
 	preferences->screen_mode.fix_h_not_v = true;
-	preferences->screen_mode.camera_bob = true;
-	preferences->screen_mode.weapon_bob = true;
+	preferences->screen_mode.bob_disable = 0;
 	preferences->screen_mode.bit_depth = 32;
 	
 	preferences->screen_mode.draw_every_other_line= false;
@@ -4368,8 +4371,7 @@ void parse_graphics_preferences(InfoTree root, std::string version)
 	root.read_attr("scmode_hud_scale", graphics_preferences->screen_mode.hud_scale_level);
 	root.read_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.read_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);
-	root.read_attr("scmode_camera_bob", graphics_preferences->screen_mode.camera_bob);
-	root.read_attr("scmode_weapon_bob", graphics_preferences->screen_mode.weapon_bob);
+	root.read_attr("bob_disable", graphics_preferences->screen_mode.bob_disable);
 	root.read_attr("scmode_accel", graphics_preferences->screen_mode.acceleration);
 	root.read_attr("scmode_highres", graphics_preferences->screen_mode.high_resolution);
 	root.read_attr("scmode_draw_every_other_line", graphics_preferences->screen_mode.draw_every_other_line);

--- a/Source_Files/Misc/preferences.h
+++ b/Source_Files/Misc/preferences.h
@@ -92,6 +92,8 @@ struct graphics_preferences_data
 	OGL_ConfigureData OGL_Configure;
 
 	bool double_corpse_limit;
+	
+	int16 bob_disable;
 
 	int16 software_alpha_blending;
 	int16 software_sdl_driver;

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -1238,7 +1238,7 @@ void update_world_view_camera()
 	world_view->maximum_depth_intensity = current_player->weapon_intensity;
 
 	world_view->origin = current_player->camera_location;
-	if (!graphics_preferences->screen_mode.camera_bob)
+	if (graphics_preferences->screen_mode.bob_disable)
 		world_view->origin.z -= current_player->step_height;
 	world_view->origin_polygon_index = current_player->camera_polygon_index;
 

--- a/Source_Files/shell.h
+++ b/Source_Files/shell.h
@@ -81,6 +81,7 @@ struct screen_mode_data
 	bool fix_h_not_v;
 	bool translucent_map;
 	bool camera_bob;
+	bool weapon_bob;
 
 	int fov; // 0 = use default (or MML/plugin)
 };

--- a/Source_Files/shell.h
+++ b/Source_Files/shell.h
@@ -80,8 +80,7 @@ struct screen_mode_data
 	short term_scale_level;
 	bool fix_h_not_v;
 	bool translucent_map;
-	bool camera_bob;
-	bool weapon_bob;
+	short bob_disable;
 
 	int fov; // 0 = use default (or MML/plugin)
 };


### PR DESCRIPTION
The XBLA version of Marathon 2 does not bob the camera, but does bob the weapon. I thought it'd be nice to have that as a possibility in Aleph One.