### PR TITLE
Remove quotes around AC_MSG_ERROR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ AC_CHECK_HEADERS([unistd.h pwd.h])
 dnl Check for boost functions and libraries.
 AX_BOOST_BASE([1.53.0],
               ,
-              [AC_MSG_ERROR([You need Boost 1.53.0 or higher to build Aleph One.])])
+              AC_MSG_ERROR([You need Boost 1.53.0 or higher to build Aleph One.]))
 AX_BOOST_SYSTEM
 AS_IF([ test "x$BOOST_SYSTEM_LIB" != "x" ],
       [ LIBS="$BOOST_SYSTEM_LIB $LIBS" ],


### PR DESCRIPTION
I would like to contribute to the project, but I see the build instructions are a little outdated.

I saw the `AC_MSG_ERROR` macro was quoted and that led to the following
```shell
 autoreconf -if
configure.ac:147: warning: The macro `AC_TRY_RUN' is obsolete.
configure.ac:147: You should run autoupdate.
./lib/autoconf/general.m4:2997: AC_TRY_RUN is expanded from...
/usr/share/aclocal/sdl2.m4:16: AM_PATH_SDL2 is expanded from...
configure.ac:147: the top level
configure.ac:147: warning: The macro `AC_TRY_LINK' is obsolete.
configure.ac:147: You should run autoupdate.
./lib/autoconf/general.m4:2920: AC_TRY_LINK is expanded from...
/usr/share/aclocal/sdl2.m4:16: AM_PATH_SDL2 is expanded from...
configure.ac:147: the top level
configure.ac:83: error: possibly undefined macro: AC_MSG_ERROR
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: error: /usr/local/bin/autoconf failed with exit status: 1
```

Also, the build instructions [here](https://github.com/Aleph-One-Marathon/alephone/wiki/Linux-Install-Instructions#configure) are outdated - the `autogen.sh` script was removed [here](https://github.com/Aleph-One-Marathon/alephone/commit/53823ac8e8ab344c62835155b8b10a8f328186c6). The instructions should suggest running `autoreconf --install`.

EDIT:
Though I do see `./configure` later fails anyway
```shell
./configure
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /usr/bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking whether gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of gcc... gcc3
checking how to run the C preprocessor... gcc -E
checking for g++... g++
checking whether the compiler supports GNU C++... yes
checking whether g++ accepts -g... yes
checking for g++ option to enable C++11 features... none needed
checking dependency style of g++... gcc3
checking how to run the C++ preprocessor... g++ -E
checking for g++... g++
checking whether the compiler supports GNU Objective C++... no
checking whether g++ accepts -g... no
checking dependency style of g++... gcc3
checking for ranlib... ranlib
./configure: line 6418: syntax error near unexpected token `17,'
./configure: line 6418: `AX_CXX_COMPILE_STDCXX(17, , mandatory)
```