### PR TITLE
Add a system for making Lua netscripts and solo scripts configurable.

### DIFF
--- a/PBProjects/AlephOne.xcodeproj/project.pbxproj
+++ b/PBProjects/AlephOne.xcodeproj/project.pbxproj
@@ -238,6 +238,10 @@
 		27FF26611B6F170600DA0A19 /* InfoTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27FF265E1B6F170600DA0A19 /* InfoTree.cpp */; };
 		27FF26621B6F170600DA0A19 /* InfoTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27FF265E1B6F170600DA0A19 /* InfoTree.cpp */; };
 		27FF26631B6F1E0700DA0A19 /* InfoTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27FF265E1B6F170600DA0A19 /* InfoTree.cpp */; };
+		4EDBFB6F2911D5FA00BBE2C3 /* script_configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4EDBFB6E2911D5FA00BBE2C3 /* script_configuration.cpp */; };
+		4EDBFB702911D5FA00BBE2C3 /* script_configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4EDBFB6E2911D5FA00BBE2C3 /* script_configuration.cpp */; };
+		4EDBFB712911D5FA00BBE2C3 /* script_configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4EDBFB6E2911D5FA00BBE2C3 /* script_configuration.cpp */; };
+		4EDBFB722911D5FA00BBE2C3 /* script_configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4EDBFB6E2911D5FA00BBE2C3 /* script_configuration.cpp */; };
 		AE0053EE0ABE16300038507F /* OGL_Blitter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE0053ED0ABE16300038507F /* OGL_Blitter.cpp */; };
 		AE005FD40EE2D6DE007FE7C6 /* screen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AE005FD30EE2D6DE007FE7C6 /* screen.cpp */; };
 		AE0E4EC2141D148F00AAA02F /* Marathon.icns in Resources */ = {isa = PBXBuildFile; fileRef = AE0E4EC1141D148F00AAA02F /* Marathon.icns */; };
@@ -1943,6 +1947,7 @@
 		3DF290E9046F5BED00000104 /* OGL_Texture_Def.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OGL_Texture_Def.h; sourceTree = "<group>"; };
 		3DF290EF046F5C5B00000104 /* OGL_Model_Def.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OGL_Model_Def.cpp; sourceTree = "<group>"; };
 		3DF290F0046F5C5B00000104 /* OGL_Subst_Texture_Def.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OGL_Subst_Texture_Def.cpp; sourceTree = "<group>"; usesTabs = 1; };
+		4EDBFB6E2911D5FA00BBE2C3 /* script_configuration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = script_configuration.cpp; path = ../Source_Files/Misc/script_configuration.cpp; sourceTree = "<group>"; };
 		AE0053ED0ABE16300038507F /* OGL_Blitter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OGL_Blitter.cpp; sourceTree = "<group>"; };
 		AE005FD30EE2D6DE007FE7C6 /* screen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = screen.cpp; sourceTree = "<group>"; };
 		AE0E4EC1141D148F00AAA02F /* Marathon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = Marathon.icns; path = AppStore/Marathon/Marathon.icns; sourceTree = "<group>"; };
@@ -2795,6 +2800,7 @@
 				F52211C40136A6FD01000001 /* interface.cpp */,
 				F522120F0136A6FD01000001 /* preferences.cpp */,
 				AE2A50CC09C67253007681A4 /* Scenario.cpp */,
+				4EDBFB6E2911D5FA00BBE2C3 /* script_configuration.cpp */,
 				AE437C8E08779BE500038E30 /* shared_widgets.cpp */,
 				27FC2E091A7DF51E0057BF42 /* Statistics.cpp */,
 				F52212590136A6FD01000001 /* vbl.cpp */,
@@ -4536,6 +4542,7 @@
 				AE505C1C141D45E600915344 /* sdl_widgets.cpp in Sources */,
 				AE505C1D141D45E600915344 /* shell_misc.cpp in Sources */,
 				AE505C1E141D45E600915344 /* shell.cpp in Sources */,
+				4EDBFB712911D5FA00BBE2C3 /* script_configuration.cpp in Sources */,
 				AE505C1F141D45E600915344 /* vbl.cpp in Sources */,
 				AE505C20141D45E600915344 /* network_lookup_sdl.cpp in Sources */,
 				AE505C21141D45E600915344 /* network_udp.cpp in Sources */,
@@ -4764,6 +4771,7 @@
 				AEB4A1BD14296CAE00537AE7 /* sdl_widgets.cpp in Sources */,
 				AEB4A1BE14296CAE00537AE7 /* shell_misc.cpp in Sources */,
 				AEB4A1BF14296CAE00537AE7 /* shell.cpp in Sources */,
+				4EDBFB722911D5FA00BBE2C3 /* script_configuration.cpp in Sources */,
 				AEB4A1C014296CAE00537AE7 /* vbl.cpp in Sources */,
 				AEB4A1C114296CAE00537AE7 /* network_lookup_sdl.cpp in Sources */,
 				AEB4A1C214296CAE00537AE7 /* network_udp.cpp in Sources */,
@@ -4992,6 +5000,7 @@
 				AEC3C7DF09AD68AC003258E4 /* sdl_widgets.cpp in Sources */,
 				AEC3C7E009AD68AC003258E4 /* shell_misc.cpp in Sources */,
 				AEC3C7E109AD68AC003258E4 /* shell.cpp in Sources */,
+				4EDBFB6F2911D5FA00BBE2C3 /* script_configuration.cpp in Sources */,
 				AEC3C7E309AD68AC003258E4 /* vbl.cpp in Sources */,
 				AEC3C7E409AD68AC003258E4 /* network_lookup_sdl.cpp in Sources */,
 				AEC3C7E509AD68AC003258E4 /* network_udp.cpp in Sources */,
@@ -5220,6 +5229,7 @@
 				AEFD86C913EB84CF00C1E687 /* sdl_widgets.cpp in Sources */,
 				AEFD86CA13EB84CF00C1E687 /* shell_misc.cpp in Sources */,
 				AEFD86CB13EB84CF00C1E687 /* shell.cpp in Sources */,
+				4EDBFB702911D5FA00BBE2C3 /* script_configuration.cpp in Sources */,
 				AEFD86CC13EB84CF00C1E687 /* vbl.cpp in Sources */,
 				AEFD86CD13EB84CF00C1E687 /* network_lookup_sdl.cpp in Sources */,
 				AEFD86CE13EB84CF00C1E687 /* network_udp.cpp in Sources */,

--- a/Source_Files/Misc/Makefile.am
+++ b/Source_Files/Misc/Makefile.am
@@ -20,7 +20,7 @@ libmisc_a_SOURCES = ActionQueues.h alephversion.h binders.h CircularByteBuffer.h
   \
   ActionQueues.cpp CircularByteBuffer.cpp Console.cpp DefaultStringSets.cpp game_errors.cpp \
   interface.cpp \
-  Logging.cpp PlayerImage_sdl.cpp PlayerName.cpp preferences.cpp \
+  Logging.cpp PlayerImage_sdl.cpp PlayerName.cpp preferences.cpp script_configuration.cpp \
   preference_dialogs.cpp preferences_widgets_sdl.cpp Scenario.cpp sdl_dialogs.cpp $(THREAD_PRIORITY) \
   sdl_widgets.cpp shared_widgets.cpp vbl.cpp \
   Statistics.cpp \

--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -175,6 +175,10 @@ static void environment_dialog(void *arg);
 static void plugins_dialog(void *arg);
 static void keyboard_dialog(void *arg);
 //static void texture_options_dialog(void *arg);
+#ifndef MAC_APP_STORE
+extern void script_configuration_dialog(void *arg);
+extern bool script_is_configurable(w_file_chooser*);
+#endif
 
 /*
  *  Get user name
@@ -2984,7 +2988,7 @@ static void environment_dialog(void *arg)
 #ifndef MAC_APP_STORE
 	table->add_row(new w_spacer, true);
 	table->dual_add_row(new w_static_text("Solo Script"), d);
-	w_enabling_toggle* use_solo_lua_w = new w_enabling_toggle(environment_preferences->use_solo_lua);
+	w_toggle* use_solo_lua_w = new w_toggle(environment_preferences->use_solo_lua);
 	table->dual_add(use_solo_lua_w->label("Use Solo Script"), d);
 	table->dual_add(use_solo_lua_w, d);
 
@@ -2992,7 +2996,20 @@ static void environment_dialog(void *arg)
 	solo_lua_w->set_file(environment_preferences->solo_lua_file);
 	table->dual_add(solo_lua_w->label("Script File"), d);
 	table->dual_add(solo_lua_w, d);
-	use_solo_lua_w->add_dependent_widget(solo_lua_w);
+
+	table->add_row(new w_spacer, true);
+	w_button* solo_lua_config_button_w = new w_button("SOLO SCRIPT OPTIONS", script_configuration_dialog, solo_lua_w);
+	table->dual_add_row(solo_lua_config_button_w, d);
+
+	auto solo_script_enable_callback = [use_solo_lua_w, solo_lua_w, solo_lua_config_button_w]() {
+	    bool enabled = !!use_solo_lua_w->get_selection();
+	    solo_lua_w->set_enabled(enabled);
+		solo_lua_config_button_w->set_enabled(enabled && script_is_configurable(solo_lua_w));
+	};
+
+	solo_script_enable_callback();
+	use_solo_lua_w->set_selection_changed_callback([&solo_script_enable_callback](w_select*) { solo_script_enable_callback(); });
+	solo_lua_w->set_callback(solo_script_enable_callback);
 #endif
 
 	table->add_row(new w_spacer, true);
@@ -3003,7 +3020,7 @@ static void environment_dialog(void *arg)
 	table->dual_add(film_profile_w, d);
 	
 #ifndef MAC_APP_STORE
-	w_enabling_toggle* use_replay_net_lua_w = new w_enabling_toggle(environment_preferences->use_replay_net_lua);
+	w_toggle* use_replay_net_lua_w = new w_enabling_toggle(environment_preferences->use_replay_net_lua);
 	table->dual_add(use_replay_net_lua_w->label("Use Netscript in Films"), d);
 	table->dual_add(use_replay_net_lua_w, d);
 	
@@ -3011,7 +3028,20 @@ static void environment_dialog(void *arg)
 	replay_net_lua_w->set_file(network_preferences->netscript_file);
 	table->dual_add(replay_net_lua_w->label("Netscript File"), d);
 	table->dual_add(replay_net_lua_w, d);
-	use_replay_net_lua_w->add_dependent_widget(replay_net_lua_w);
+
+	table->add_row(new w_spacer, true);
+	w_button* replay_net_lua_config_button_w = new w_button("FILM NETSCRIPT OPTIONS", script_configuration_dialog, replay_net_lua_w);
+	table->dual_add_row(replay_net_lua_config_button_w, d);
+
+	auto replay_net_script_enable_callback = [use_replay_net_lua_w, replay_net_lua_w, replay_net_lua_config_button_w]() {
+	    bool enabled = !!use_replay_net_lua_w->get_selection();
+	    replay_net_lua_w->set_enabled(enabled);
+		replay_net_lua_config_button_w->set_enabled(enabled && script_is_configurable(replay_net_lua_w));
+	};
+
+	replay_net_script_enable_callback();
+	use_replay_net_lua_w->set_selection_changed_callback([&replay_net_script_enable_callback](w_select*) { replay_net_script_enable_callback(); });
+	replay_net_lua_w->set_callback(replay_net_script_enable_callback);
 #endif
 	
 	table->add_row(new w_spacer, true);

--- a/Source_Files/Misc/script_configuration.cpp
+++ b/Source_Files/Misc/script_configuration.cpp
@@ -1,0 +1,426 @@
+/*
+
+	Copyright (C) 1991-2001 and beyond by Bungie Studios, Inc.
+	and the "Aleph One" developers.
+ 
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	This license is contained in the file "COPYING",
+	which is included with this source code; it is available online at
+	http://www.gnu.org/licenses/gpl.html
+
+*/
+
+#ifndef MAC_APP_STORE
+
+#include "sdl_dialogs.h"
+#include "sdl_fonts.h"
+#include "sdl_widgets.h"
+
+#include <string_view>
+#include <sstream>
+
+namespace {
+	// string_view::starts_with is new in C++20...
+	bool starts_with(const std::string_view& haystack, const std::string_view& needle) {
+		return haystack.size() >= needle.size() && haystack.substr(0, needle.size()) == needle;
+	}
+	class LineMuncher {
+		std::string_view rest;
+		size_t line_no;
+	public:
+		LineMuncher(std::string_view rest) : rest(rest), line_no(0) {
+			// Skip the signature of ultimate evil, if we see it
+			if(starts_with(rest, "\xEF\xBB\xBF")) {
+				rest.remove_prefix(3);
+			}
+		}
+		bool yield_line(std::string_view& out_view) {
+			if(rest.empty()) return false;
+			auto newline_pos = rest.find('\n');
+			if(newline_pos == std::string_view::npos) {
+				out_view = rest;
+				rest = "";
+			}
+			else {
+				out_view = rest.substr(0, newline_pos);
+				rest = rest.substr(newline_pos+1);
+			}
+			if(out_view.size() > 0 && out_view[out_view.size()-1] == '\r')
+				out_view.remove_suffix(1);
+			++line_no;
+			return true;
+		}
+		size_t get_last_line_number() const {
+			return line_no;
+		}
+		std::string get_rest() const {
+			std::string ret(rest);
+			auto p = ret.find('\r');
+			while(p != std::string::npos) {
+				ret.erase(p);
+				p = ret.find('\r');
+			}
+			return ret;
+		}
+	};
+	class Option {
+		std::string_view instigating_line;
+	protected:
+		Option(std::string_view instigating_line) : instigating_line(instigating_line) {}
+	public:
+		virtual ~Option() {}
+	    void reoutput(std::ostringstream& out) {
+			out << instigating_line << "\n";
+			synthesize(out);
+		}
+		virtual void synthesize(std::ostringstream& out) {}
+		virtual void add_widget(table_placer* placer, dialog& d) = 0;
+		static std::unique_ptr<Option> parse(std::string_view);
+	};
+	class Spacer : public Option {
+	public:
+		virtual ~Spacer() {}
+		Spacer(std::string_view instigating_line) : Option(instigating_line) {}
+		void add_widget(table_placer* placer, dialog& d) override {
+			placer->add_row(new w_spacer);
+		}
+	};
+	class Text : public Option {
+		std::string label;
+		w_static_text* widget;
+	public:
+		virtual ~Text() {}
+		Text(std::string_view instigating_line, std::string_view label) : Option(instigating_line), label(label) {
+			widget = new w_static_text(this->label.c_str());
+		}
+		void add_widget(table_placer* placer, dialog& d) override {
+			placer->dual_add_row(widget, d);
+		}
+	};
+	class Toggle : public Option {
+		std::string variable_name;
+		std::string label;
+		w_toggle* widget;
+		w_label* label_widget;
+	public:
+		virtual ~Toggle() {}
+		Toggle(std::string_view instigating_line, std::string_view variable_name, std::string_view label, bool is_on) : Option(instigating_line), variable_name(variable_name), label(label) {
+			widget = new w_toggle(is_on);
+			label_widget = widget->label(this->label.c_str());
+		}
+		void add_widget(table_placer* placer, dialog& d) override {
+			placer->dual_add(label_widget, d);
+			placer->dual_add(widget, d);
+		}
+		void synthesize(std::ostringstream& out) override {
+			out << "local " << variable_name << " = ";
+			if(widget->get_selection())
+				out << "true\n";
+			else
+				out << "false\n";
+		}
+	};
+	class Select : public Option {
+		std::string variable_name;
+		std::string label;
+		std::vector<std::string> options;
+		std::vector<const char*> option_c_strs; // >:( -SB
+		w_select* widget;
+		w_label* label_widget;
+	public:
+		virtual ~Select() {}
+		Select(std::string_view instigating_line, std::string_view variable_name, std::string_view label, std::vector<std::string> options, size_t selection) : Option(instigating_line), variable_name(variable_name), label(label), options(options) {
+			for(auto& str : this->options) {
+				option_c_strs.push_back(str.c_str());
+			}
+			option_c_strs.push_back(nullptr);
+			widget = new w_select(selection, &option_c_strs[0]);
+			label_widget = widget->label(this->label.c_str());
+		}
+		void add_widget(table_placer* placer, dialog& d) override {
+			placer->dual_add(label_widget, d);
+			placer->dual_add(widget, d);
+		}
+		void synthesize(std::ostringstream& out) override {
+			out << "local " << variable_name << " = " << widget->get_selection()+1 << "\n";
+		}
+	};
+	void parse_failure(LineMuncher& lines, std::string error) {
+		std::ostringstream out;
+		out << "Error on line " << lines.get_last_line_number() << ": " << error;
+		alert_user(out.str().c_str());
+	}
+	void unexpected_eof(LineMuncher& lines) {
+		parse_failure(lines, "File ended without reaching \"--! end configuration\"");
+	}
+	bool parse_config_line(std::string_view rest, std::vector<std::string>& parsed, LineMuncher& lines) {
+		if(rest.size() < 5 || rest.substr(0, 4) != "--! ") {
+			parse_failure(lines, "Expected another \"--! \" line, but didn't get one");
+			return false;
+		}
+		rest.remove_prefix(4); // strip off the "--! "
+		while(!rest.empty()) {
+			std::string element;
+			while(!rest.empty()) {
+				if(rest[0] == '"') {
+					rest.remove_prefix(1);
+					while(!rest.empty() && rest[0] != '"') {
+						if(rest[0] == '\\') {
+							rest.remove_prefix(1);
+							if(rest.empty()) {
+								parse_failure(lines, "Unmatched backslash at end of line");
+								return false;
+							}
+						}
+						element.push_back(rest[0]);
+						rest.remove_prefix(1);
+					}
+					if(rest.empty()) {
+						parse_failure(lines, "Unmatched double quote (\")");
+						return false;
+					}
+					assert(rest[0] == '"');
+					rest.remove_prefix(1);
+				}
+				else if(rest[0] == '\\') {
+					rest.remove_prefix(1);
+					if(rest.empty()) {
+						parse_failure(lines, "Unmatched backslash at end of line");
+						return false;
+					}
+					element.push_back(rest[0]);
+					rest.remove_prefix(1);
+				}
+				else if(rest[0] == ' ') {
+					parsed.push_back(element);
+					element.clear();
+					rest.remove_prefix(1);
+				}
+				else {
+					element.push_back(rest[0]);
+					rest.remove_prefix(1);
+				}
+			}
+			parsed.push_back(element);
+			while(!rest.empty() && rest[0] == ' ') {
+				rest.remove_prefix(1);
+			}
+		}
+		return parsed.size() > 0;
+	}
+	bool check_lua_line(std::string_view lua_line, std::string_view variable_name, std::string_view& value) {
+		bool parsed_ok = false;
+		if(starts_with(lua_line, "local ")) {
+			lua_line.remove_prefix(6);
+			if(starts_with(lua_line, variable_name)) {
+				lua_line.remove_prefix(variable_name.size());
+				if(starts_with(lua_line, " = ")) {
+					lua_line.remove_prefix(3);
+					value = lua_line;
+					parsed_ok = true;
+				}
+			}
+		}
+		return parsed_ok;
+	}
+	// Assumes that the "end configuration" case has already been ruled out.
+	std::unique_ptr<Option> parse_option(std::string_view next_line, LineMuncher& lines) {
+		std::vector<std::string> parsed;
+		if(!parse_config_line(next_line, parsed, lines)) return nullptr;
+		assert(parsed.size() > 0);
+		if(parsed[0] == "spacer") {
+			if(parsed.size() != 1) {
+				parse_failure(lines, "\"spacer\" widget can't have any parameters.");
+				return nullptr;
+			}
+			return std::make_unique<Spacer>(next_line);
+		}
+		else if(parsed[0] == "text") {
+			if(parsed.size() != 2) {
+				parse_failure(lines, "\"text\" widget requires one parameter.");
+				return nullptr;
+			}
+			return std::make_unique<Text>(next_line, parsed[1]);
+		}
+		else if(parsed[0] == "toggle") {
+			if(parsed.size() != 3) {
+				parse_failure(lines, "\"toggle\" widget requires two parameters.");
+				return nullptr;
+			}
+			std::string_view lua_line;
+			if(!lines.yield_line(lua_line)) {
+				unexpected_eof(lines);
+				return nullptr;
+			}
+			std::string_view value;
+			if(!check_lua_line(lua_line, parsed[1], value) || (value != "true" && value != "false")) {
+				std::ostringstream out;
+				out << "This line didn't match the widget specification. "
+					"In order to be valid, the line must be exactly: "
+					"`local " << parsed[1] << " = VALUE` "
+					"where VALUE is either `true` or `false`.";
+				parse_failure(lines, out.str());
+				return nullptr;
+			}
+			return std::make_unique<Toggle>(next_line, parsed[1], parsed[2], value == "true");
+		}
+		else if(parsed[0] == "select") {
+			if(parsed.size() < 5) {
+				parse_failure(lines, "\"select\" widget requires at least five parameters.");
+				return nullptr;
+			}
+			std::string_view lua_line;
+			if(!lines.yield_line(lua_line)) {
+				unexpected_eof(lines);
+				return nullptr;
+			}
+			std::string_view value;
+			if(check_lua_line(lua_line, parsed[1], value)) {
+				char* endp;
+				unsigned long selection = strtoul(&value[0], &endp, 10);
+				if(endp == &value[value.size()] && selection > 0 && selection <= parsed.size() - 3) {
+					std::string variable_name = parsed[1];
+					std::string label = parsed[2];
+					parsed.erase(parsed.begin());
+					parsed.erase(parsed.begin());
+					parsed.erase(parsed.begin());
+					return std::make_unique<Select>(next_line, variable_name, label, parsed, selection - 1);
+				}
+			}
+			std::ostringstream out;
+			out << "This line didn't match the widget specification. "
+				"In order to be valid, the line must be exactly: "
+				"`local " << parsed[1] << " = VALUE` "
+				"where VALUE is a number between 1 and " << parsed.size() - 3 << " (the number of values).";
+			parse_failure(lines, out.str());
+			return nullptr;
+		}
+		else {
+			parse_failure(lines, "Unknown widget type. Known widget types: spacer, text, toggle, select");
+			return nullptr;
+		}
+	}
+	bool with_configurable_script(w_file_chooser* chooser, std::function<void(FileSpecifier&, LineMuncher&, std::string_view&, std::string_view&)> callback) {
+		auto file = chooser->get_file();
+		if (file.GetPath()[0] && file.Exists()) {
+			OpenedFile script_file;
+			if (file.Open(script_file)) {
+				int32 script_length;
+				script_file.GetLength(script_length);
+				std::vector<char> script_buffer(script_length);
+				if (script_file.Read(script_length, &script_buffer[0])) {
+					script_file.Close();
+					std::string_view orig_script(&script_buffer[0], script_buffer.size());
+					LineMuncher lines(orig_script);
+					std::string_view first_line;
+					if(lines.yield_line(first_line)) {
+						// string_view.starts_with isn't in C++17
+						if(starts_with(first_line, "--! configuration ")) {
+							callback(file, lines, first_line, orig_script);
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return false;
+	}
+	void real_config_dialog(FileSpecifier& fs, LineMuncher& lines, std::string_view& first_line, std::string_view& orig_script) {
+		if(first_line != "--! configuration 1.0"
+		   && !starts_with(first_line, "--! configuration 1.0 ")) {
+			alert_user(expand_app_variables("This script requires a newer version of $appName$ for configuration. Upgrade to a newer version of $appName$, or configure the script by editing it manually.").c_str());
+			return;
+		}
+
+		std::vector<std::unique_ptr<Option>> options;
+		while(true) {
+			std::string_view next_line;
+			if(!lines.yield_line(next_line)) {
+				unexpected_eof(lines);
+				return;
+			}
+			if(next_line == "--! end configuration") break;
+			auto neu = parse_option(next_line, lines);
+			if(!neu) return;
+			options.emplace_back(std::move(neu));
+		}
+		if(options.empty()) {
+			parse_failure(lines, "This script doesn't actually contain any options.");
+			return;
+		}
+
+		dialog d;
+		vertical_placer *placer = new vertical_placer;
+		w_title *w_header = new w_title("SCRIPT OPTIONS");
+		placer->dual_add(w_header, d);
+		placer->add(new w_spacer, true);
+
+		table_placer *table = new table_placer(2, get_theme_space(ITEM_WIDGET), true);
+		table->col_flags(0, placeable::kAlignRight);
+		table->col_flags(1, placeable::kAlignLeft);
+
+		for(auto& option : options) {
+			option->add_widget(table, d);
+		}
+
+		placer->add(table, true);
+
+		placer->add(new w_spacer, true);
+		horizontal_placer* button_placer = new horizontal_placer;
+		w_button* accept_w = new w_button("ACCEPT", dialog_ok, &d);
+		button_placer->dual_add(accept_w, d);
+		w_button* cancel_w = new w_button("CANCEL", dialog_cancel, &d);
+		button_placer->dual_add(cancel_w, d);
+
+		placer->add(button_placer, true);
+
+		d.set_widget_placer(placer);
+
+		if (d.run() == 0) {
+			std::ostringstream new_script;
+			new_script << first_line << "\n";
+			for(auto& option : options) {
+				option->reoutput(new_script);
+			}
+			new_script << "--! end configuration\n" << lines.get_rest();
+			std::string new_script_string = new_script.str();
+			if(new_script_string != orig_script) {
+				FileSpecifier temp;
+				temp.SetTempName(fs);
+				OpenedFile outfile;
+				if(!temp.Open(outfile, true) || !outfile.Write(new_script_string.size(), new_script_string.data())) {
+					alert_user("Unable to save changed settings.");
+					return;
+				}
+				outfile.Close();
+				fs.Delete(); // might be symlinked :| -SB
+				if(!temp.Rename(fs)) {
+					alert_user("Unable to save changed settings.");
+					return;
+				}
+			}
+		}
+	}
+}
+
+bool script_is_configurable(w_file_chooser* chooser) {
+	return with_configurable_script(chooser, [](FileSpecifier&, LineMuncher&, std::string_view&, std::string_view&) {});
+}
+
+void script_configuration_dialog(void* param) {
+	w_file_chooser* chooser = reinterpret_cast<w_file_chooser*>(param);
+	if(!with_configurable_script(chooser, real_config_dialog)) {
+		alert_user("The selected script does not contain any configuration options.");
+	}
+}
+
+#endif

--- a/Source_Files/Network/network_dialogs.h
+++ b/Source_Files/Network/network_dialogs.h
@@ -434,6 +434,10 @@ protected:
 	
 	ToggleWidget*       m_useUpnpWidget;
 	SelectorWidget*         m_latencyToleranceWidget;
+
+#ifndef MAC_APP_STORE
+	std::function<void()> netscript_script_enable_callback;
+#endif
 };
 
 

--- a/VisualStudio/AlephOne.vcxproj
+++ b/VisualStudio/AlephOne.vcxproj
@@ -454,6 +454,7 @@
     <ClCompile Include="..\Source_Files\Misc\preferences_widgets_sdl.cpp" />
     <ClCompile Include="..\Source_Files\Misc\preference_dialogs.cpp" />
     <ClCompile Include="..\Source_Files\Misc\Scenario.cpp" />
+    <ClCompile Include="..\Source_Files\Misc\script_configuration.cpp" />
     <ClCompile Include="..\Source_Files\Misc\sdl_dialogs.cpp" />
     <ClCompile Include="..\Source_Files\Misc\sdl_widgets.cpp" />
     <ClCompile Include="..\Source_Files\Misc\shared_widgets.cpp" />

--- a/VisualStudio/AlephOne.vcxproj.filters
+++ b/VisualStudio/AlephOne.vcxproj.filters
@@ -370,6 +370,9 @@
     <ClCompile Include="..\Source_Files\Misc\Scenario.cpp">
       <Filter>Misc\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source_Files\Misc\script_configuration.cpp" />
+      <Filter>Misc\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\Source_Files\Misc\sdl_dialogs.cpp">
       <Filter>Misc\Source Files</Filter>
     </ClCompile>

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -196,6 +196,7 @@
 </ol>
 </li>
 <li><a href="#example_icon">Example Icon</a></li>
+<li><a href="#configuration_dialog">Configuration Dialog</a></li>
 </ol>
 <h1>
 <a name="general"></a>General</h1>
@@ -3581,5 +3582,28 @@ Additionally, once it has read 256 valid characters, it ignores the rest of the
 string.
 ]]
       </pre>
-    </body>
+    <h1>
+<a name="configuration_dialog"></a>Configuration Dialog</h1>
+	  <p>Scripts intended for use as solo scripts or netscripts can optionally contain a specification for a configuration dialog. This can be used in case your script has lots of optional features, or might need tweaking to match some peoples' tastes. (Currently, there is no provision for configuring plugin scripts. This may change at a later date.)</p>
+	  <p>Changed settings are written back to the script file. For this and other reasons, the syntax is extremely strict. The chances for corruption must be minimized. An advantage is that the configuration values will be sent over the network with no compatibility issues. As far as the game is concerned, outside the configuration dialog, the file contains an ordinary, self-contained netscript.</p>
+	  <p>To use this feature, place a block like the following at the <b>exact top</b> of the file, with no whitespace above, below, or between:</p>
+	  <pre>--! configuration 1.0
+--! toggle var_name "This is a checkbox"
+local var_name = false
+--! toggle var2 "Variable name goes first, then label"
+local var2 = true
+--! spacer
+--! text "You can put small blank spaces using \"spacer\","
+--! text "and create readable text using \"text\". In any"
+--! text "element of a widget specification, you can"
+--! text "optionally use double quotes, or use simple"
+--! text backslash\ escapes\ as\ needed.
+--! spacer
+--! select best "Favorite opponent" Fighter Compiler Tick Juggernaut "Mother of All Hunters"
+local best = 3
+--! end configuration</pre>
+	  <p>Anything after the "end configuration" line is ignored for purposes of creating the configuration dialog.</p>
+	  <p>The variable specification after a widget must match that <b>exact</b> syntax, must match the given variable name, and must have a valid choice for that widget. "toggle" widgets can have true or false, "select" widgets must have a number between 1 and the number of options.</p>
+	  <p>You can have quite a few widgets. At least twenty will fit on the screen. Please don't!</p>
+	</body>
 </html>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -3695,4 +3695,29 @@ string.
       </pre>
     </description>
   </section>
+  <section name="Configuration Dialog" id="configuration_dialog" version="git">
+	<description>
+	  <p>Scripts intended for use as solo scripts or netscripts can optionally contain a specification for a configuration dialog. This can be used in case your script has lots of optional features, or might need tweaking to match some peoples' tastes. (Currently, there is no provision for configuring plugin scripts. This may change at a later date.)</p>
+	  <p>Changed settings are written back to the script file. For this and other reasons, the syntax is extremely strict. The chances for corruption must be minimized. An advantage is that the configuration values will be sent over the network with no compatibility issues. As far as the game is concerned, outside the configuration dialog, the file contains an ordinary, self-contained netscript.</p>
+	  <p>To use this feature, place a block like the following at the <b>exact top</b> of the file, with no whitespace above, below, or between:</p>
+	  <pre>--! configuration 1.0
+--! toggle var_name "This is a checkbox"
+local var_name = false
+--! toggle var2 "Variable name goes first, then label"
+local var2 = true
+--! spacer
+--! text "You can put small blank spaces using \"spacer\","
+--! text "and create readable text using \"text\". In any"
+--! text "element of a widget specification, you can"
+--! text "optionally use double quotes, or use simple"
+--! text backslash\ escapes\ as\ needed.
+--! spacer
+--! select best "Favorite opponent" Fighter Compiler Tick Juggernaut "Mother of All Hunters"
+local best = 3
+--! end configuration</pre>
+	  <p>Anything after the "end configuration" line is ignored for purposes of creating the configuration dialog.</p>
+	  <p>The variable specification after a widget must match that <b>exact</b> syntax, must match the given variable name, and must have a valid choice for that widget. "toggle" widgets can have true or false, "select" widgets must have a number between 1 and the number of options.</p>
+	  <p>You can have quite a few widgets. At least twenty will fit on the screen. Please don't!</p>
+	</description>
+  </section>
 </document>


### PR DESCRIPTION
This PR makes it possible for netscripts and solo scripts to have dialogs like this:

![A "script options" dialog containing six checkboxes and a selection widget.](https://cdn.discordapp.com/attachments/820543245301710848/1036931316517703692/unknown.png)

This system is designed to have the minimum possible interaction with the rest of the system. Three buttons have been added to other dialogs (to open this one), and those buttons are disabled unless you enable a script that has configuration support. Changed configuration values are written back into the script (with great care). As far as any other part of the game is concerned, a "configured" Lua script is no different from any other self-contained Lua script. Thus, network compatibility is assured, and there is no associated data hanging out elsewhere in the environment.

The syntax for the configuration dialog specification is deliberately very simple and very strict. The above dialog, taken from [A1mega](https://github.com/SolraBizna/a1mega), is implemented by having the following at the top of the script:

```lua
--! configuration 1.0
--! toggle enable_port "Allow Teleporting to Teammates"
local enable_port = false
--! toggle enable_navi "Announce Mission Completion"
local enable_navi = true
--! toggle enable_iff "Disable Friendly Fire"
local enable_iff = false
--! toggle enable_aw "Enhance Automatic Weapons"
local enable_aw = true
--! toggle enable_shld "Halo-Style Shields"
local enable_shld = true
--! toggle enable_hardcore "Hardcore Co-op Mode"
local enable_hardcore = true
--! select inventory_mode "Inventory Mode" "Normal" "Shared" "Fisto!"
local inventory_mode = 3
--! end configuration
```

If anything goes wrong during parsing, or anything looks questionable, the configuration dialog will print a (hopefully) friendly error message and refuse to do anything. In case anything goes wrong during saving, the original script is kept around until almost the last possible moment. Details of the format are documented in `Lua.html`/`Lua.xml`.

I believe the current implementation is complete and future-proof. ~~The only problem that I'm aware of is that **I have not added the new source file to the XCode project**. (Visual Studio and Automake have been made aware of the new file.)~~