### PR TITLE
Respect sound restart delay on video export

### DIFF
--- a/Source_Files/FFmpeg/Movie.cpp
+++ b/Source_Files/FFmpeg/Movie.cpp
@@ -303,6 +303,11 @@ void Movie::ThrowUserError(std::string error_msg)
     alert_user(full_msg.c_str());
 }
 
+long Movie::GetCurrentAudioTimeStamp()
+{
+    return IsRecording() && av->inited && av->ffmpeg_file->audioStream ? av->ffmpeg_file->audioStream->lastTimeStamp : 0;
+}
+
 int Movie::Movie_EncodeThread(void *arg)
 {
 	reinterpret_cast<Movie *>(arg)->EncodeThread();

--- a/Source_Files/FFmpeg/Movie.h
+++ b/Source_Files/FFmpeg/Movie.h
@@ -45,6 +45,7 @@ public:
 	void StartRecording(std::string path);
 	bool IsRecording();
 	void StopRecording();
+	long GetCurrentAudioTimeStamp();
 	
 	enum FrameType {
 	  FRAME_NORMAL,

--- a/Source_Files/FFmpeg/SDL_ffmpeg.c
+++ b/Source_Files/FFmpeg/SDL_ffmpeg.c
@@ -729,6 +729,7 @@ int SDL_ffmpegAddAudioFrame( SDL_ffmpegFile *file, SDL_ffmpegAudioFrame *frame, 
                 if (pkt->dts != AV_NOPTS_VALUE) pkt->dts = av_rescale_q(pkt->dts, acodec->time_base, file->audioStream->_ffmpeg->time_base);
                 pkt->duration = av_rescale_q(pkt->duration, acodec->time_base, file->audioStream->_ffmpeg->time_base);
                 pkt->stream_index = file->audioStream->_ffmpeg->index;
+                file->audioStream->lastTimeStamp = pkt->pts + pkt->duration;
                 av_interleaved_write_frame(file->_ffmpeg, pkt);
                 av_packet_unref(pkt);
             }

--- a/Source_Files/Sound/SoundManager.h
+++ b/Source_Files/Sound/SoundManager.h
@@ -68,6 +68,7 @@ public:
 
 	void UnloadSound(short sound);
 	void UnloadAllSounds();
+	bool CanRestartSound(int baseTick);
 
 	void PlaySound(short sound_index, world_location3d *source, short identifier, _fixed pitch = _normal_frequency);
 	void PlayLocalSound(short sound_index, _fixed pitch = _normal_frequency) { PlaySound(sound_index, 0, NONE, pitch); }


### PR DESCRIPTION
In order to fix #200 by measuring restart delay with audio frame encoding timestamps while recording a video