### PR TITLE
Use owner object location for teleportation effects sounds

### DIFF
--- a/Source_Files/GameWorld/effects.cpp
+++ b/Source_Files/GameWorld/effects.cpp
@@ -124,11 +124,12 @@ short new_effect(
 						effect->type= type;
 						effect->flags= 0;
 						effect->object_index= object_index;
-						effect->data= 0;
+						effect->data= NONE;
 						effect->delay= definition->delay ? global_random()%definition->delay : 0;
 						MARK_SLOT_AS_USED(effect);
 						
 						SET_OBJECT_OWNER(object, _object_is_effect);
+						object->permutation = effect_index;
 						object->sound_pitch= definition->sound_pitch;
 						if (effect->delay) SET_OBJECT_INVISIBILITY(object, true);
 						if (definition->flags&_media_effect) SET_OBJECT_IS_MEDIA_EFFECT(object);
@@ -259,6 +260,7 @@ void teleport_object_out(
 			struct effect_data *effect= get_effect_data(effect_index);
 			struct object_data *effect_object= get_object_data(effect->object_index);
 			
+			effect->data = object_index;
 			// make the effect look like the object
 			effect_object->shape= object->shape;
 			effect_object->sequence= object->sequence;

--- a/Source_Files/GameWorld/map.cpp
+++ b/Source_Files/GameWorld/map.cpp
@@ -2470,17 +2470,31 @@ bool line_has_variable_height(
 
 /* ---------- sound code */
 
+world_location3d* get_object_sound_location(short object_index) {
+
+	struct object_data* object = get_object_data(object_index);
+
+	switch (GET_OBJECT_OWNER(object)) {
+	case _object_is_monster:
+		return (world_location3d*)&get_monster_data(object->permutation)->sound_location;
+	case _object_is_effect:
+	{
+		auto object_owner_index = get_effect_data(object->permutation)->data;
+		if (object_owner_index != NONE) return get_object_sound_location(object_owner_index);
+	}
+	[[fallthrough]];
+	default:
+		return (world_location3d*)&object->location;
+	}
+}
+
 void play_object_sound(
 	short object_index,
 	short sound_code,
 	bool local_sound)
 {
 	struct object_data *object= get_object_data(object_index);
-	world_location3d *location= GET_OBJECT_OWNER(object)==_object_is_monster ?
-		(world_location3d *) &get_monster_data(object->permutation)->sound_location : 
-		(world_location3d *) &object->location;
-
-	SoundManager::instance()->PlaySound(sound_code, location, local_sound ? NONE : object_index, local_sound, object->sound_pitch);
+	SoundManager::instance()->PlaySound(sound_code, get_object_sound_location(object_index), local_sound ? NONE : object_index, local_sound, object->sound_pitch);
 }
 
 void play_polygon_sound(

--- a/Source_Files/GameWorld/map.h
+++ b/Source_Files/GameWorld/map.h
@@ -1172,6 +1172,7 @@ void animate_object(short object_index); /* assumes ∂t==1 tick */
 void animate_object(object_data* data, int16_t object_index);
 bool randomize_object_sequence(short object_index, shape_descriptor shape);
 
+world_location3d* get_object_sound_location(short object_index);
 void play_object_sound(short object_index, short sound_code, bool local_sound = false);
 void play_polygon_sound(short polygon_index, short sound_code);
 void _play_side_sound(short side_index, short sound_code, _fixed pitch, bool loop = false);

--- a/Source_Files/GameWorld/monsters.cpp
+++ b/Source_Files/GameWorld/monsters.cpp
@@ -417,6 +417,7 @@ short new_monster(
 						nearest_goal_polygon_index(location->polygon_index) : NONE;
 					monster->sound_polygon_index= object->polygon;
 					monster->sound_location= object->location;
+					monster->sound_location.z += definition->height - (definition->height >> 1);
 					MARK_SLOT_AS_USED(monster);
 					
 					/* initialize the monster’s object */


### PR DESCRIPTION
I also had to update sound_location.z on monster new because this value is only properly set on idle but it's already too late since the sound is played before first idle occurs.

Fixes #421 