### PR TITLE
Allowed landscape detonation in M1

### DIFF
--- a/Source_Files/GameWorld/map.h
+++ b/Source_Files/GameWorld/map.h
@@ -833,7 +833,7 @@ enum /* environment flags */
 	_environment_song_index_m1 = 0x0080, // play music
 	_environment_terminals_stop_time = 0x0100, // solo only
 	_environment_activation_ranges = 0x0200, // Marathon 1 monster activation limits
-	_environment_m1_weapons = 0x0400,    // multiple weapon pickups on TC; low gravity grenades
+	_environment_m1_weapons = 0x0400,    // multiple weapon pickups on TC; low gravity grenades; detonation on landscapes
         
 	_environment_network= 0x2000,	// these two pseudo-environments are used to prevent items 
 	_environment_single_player= 0x4000 // from arriving in the items.c code.

--- a/Source_Files/GameWorld/projectiles.cpp
+++ b/Source_Files/GameWorld/projectiles.cpp
@@ -509,7 +509,8 @@ void move_projectiles(
 								}
 								else
 								{
-									if (flags&_projectile_hit_landscape) detonation_effect = NONE;
+									// When the projecticle hits a landscape it checks game version and sets the detonation effect to none outside of M1
+									if (flags&_projectile_hit_landscape && !(static_world->environment_flags&_environment_m1_weapons)) detonation_effect = NONE;
 								}
 								
 								if (detonation_effect!=NONE) new_effect(&new_location, new_polygon_index, detonation_effect, object->facing);


### PR DESCRIPTION
Looks to fix #388 without breaking things in M2 (hopefully elsewhere but I at least tested M2) reused _environment_m1_weapons and added documentation