### PR TITLE
More wall texture sizes for the software renderer.

### DIFF
--- a/Source_Files/RenderMain/low_level_textures.h
+++ b/Source_Files/RenderMain/low_level_textures.h
@@ -43,13 +43,38 @@ inline uint16 & texture_random_seed()
 	return seed;
 }
 
+template<const int TEXBITS> class texture_constants
+{
+public:
+	static const int WIDTH = 1<<TEXBITS;
+	static const int HEIGHT = 1<<TEXBITS;
+	static const int SHIFT = TEXBITS;
+	static const int FRACTIONAL_BITS = FIXED_FRACTIONAL_BITS-TEXBITS;
+	static const int FRACTIONAL_ONE = 1<<FRACTIONAL_BITS;
+	static const int FREE_BITS = 32-TRIG_SHIFT-WORLD_FRACTIONAL_BITS;
+	static const int DOWNSHIFT = 32-TEXBITS;
+};
+/* ugly, ugly, ugly! -SB */
+#define TEXBITS_DISPATCH(texture, function, params) (    \
+  texture->width != texture->height ? function<7> params \
+: texture->width == 256 ? function<8> params             \
+: texture->width == 512 ? function<9> params             \
+: texture->width == 1024 ? function<10> params           \
+: function<7> params)
+#define TEXBITS_DISPATCH_2(texture, function, extra1, extra2, params) ( \
+texture->width != texture->height ? function<extra1, extra2, 7> params  \
+: texture->width == 256 ? function<extra1, extra2, 8> params            \
+: texture->width == 512 ? function<extra1, extra2, 9> params            \
+: texture->width == 1024 ? function<extra1, extra2, 10> params          \
+: function<extra1, extra2, 7> params)
+
 /* ---------- texture horizontal polygon */
 
-#define HORIZONTAL_WIDTH_SHIFT 7 /* 128 (8 for 256) */
-#define HORIZONTAL_HEIGHT_SHIFT 7 /* 128 */
-#define HORIZONTAL_FREE_BITS (32-TRIG_SHIFT-WORLD_FRACTIONAL_BITS)
-#define HORIZONTAL_WIDTH_DOWNSHIFT (32-HORIZONTAL_WIDTH_SHIFT)
-#define HORIZONTAL_HEIGHT_DOWNSHIFT (32-HORIZONTAL_HEIGHT_SHIFT)
+#define HORIZONTAL_WIDTH_SHIFT texture_constants<TEXBITS>::WIDTH_SHIFT
+#define HORIZONTAL_HEIGHT_SHIFT texture_constants<TEXBITS>::HEIGHT_SHIFT
+#define HORIZONTAL_FREE_BITS texture_constants<TEXBITS>::FREE_BITS
+#define HORIZONTAL_WIDTH_DOWNSHIFT texture_constants<TEXBITS>::DOWNSHIFT
+#define HORIZONTAL_HEIGHT_DOWNSHIFT texture_constants<TEXBITS>::DOWNSHIFT
 
 struct _horizontal_polygon_line_header
 {
@@ -66,12 +91,12 @@ struct _horizontal_polygon_line_data
 
 /* ---------- texture vertical polygon */
 
-#define VERTICAL_TEXTURE_WIDTH 128
-#define VERTICAL_TEXTURE_WIDTH_BITS 7
-#define VERTICAL_TEXTURE_WIDTH_FRACTIONAL_BITS (FIXED_FRACTIONAL_BITS-VERTICAL_TEXTURE_WIDTH_BITS)
-#define VERTICAL_TEXTURE_ONE (1<<VERTICAL_TEXTURE_WIDTH_FRACTIONAL_BITS)
+#define VERTICAL_TEXTURE_WIDTH texture_constants<TEXBITS>::WIDTH
+#define VERTICAL_TEXTURE_WIDTH_BITS TEXBITS
+#define VERTICAL_TEXTURE_WIDTH_FRACTIONAL_BITS texture_constants<TEXBITS>::FRACTIONAL_BITS
+#define VERTICAL_TEXTURE_ONE texture_constants<TEXBITS>::FRACTIONAL_ONE
 #define VERTICAL_TEXTURE_FREE_BITS FIXED_FRACTIONAL_BITS
-#define VERTICAL_TEXTURE_DOWNSHIFT (32-VERTICAL_TEXTURE_WIDTH_BITS)
+#define VERTICAL_TEXTURE_DOWNSHIFT texture_constants<TEXBITS>::DOWNSHIFT
 
 struct _vertical_polygon_data
 {
@@ -149,7 +174,7 @@ void inline write_pixel(T *dst, pixel8 pixel, T *shading_table, uint8 *opacity_t
 	}	
 }
 
-template <typename T, int sw_alpha_blend>
+template <typename T, int sw_alpha_blend, int TEXBITS>
 void texture_horizontal_polygon_lines
 (
 	struct bitmap_definition *texture,
@@ -194,7 +219,7 @@ void texture_horizontal_polygon_lines
 		
 		while ((count-= 1)>=0)
 		{
-			write_pixel<T, sw_alpha_blend, false>(write++, base_address[((source_y>>(HORIZONTAL_HEIGHT_DOWNSHIFT-7))&(0x7f<<7))+(source_x>>HORIZONTAL_WIDTH_DOWNSHIFT)], shading_table, opacity_table, rmask, gmask, bmask);
+			write_pixel<T, sw_alpha_blend, false>(write++, base_address[((source_y>>(HORIZONTAL_HEIGHT_DOWNSHIFT-TEXBITS))&(((1<<TEXBITS)-1)<<TEXBITS))+(source_x>>HORIZONTAL_WIDTH_DOWNSHIFT)], shading_table, opacity_table, rmask, gmask, bmask);
 			
 			source_x+= source_dx, source_y+= source_dy;
 		}

--- a/Source_Files/RenderMain/scottish_textures.cpp
+++ b/Source_Files/RenderMain/scottish_textures.cpp
@@ -182,11 +182,11 @@ static void *precalculation_table = NULL;
 
 /* ---------- private prototypes */
 
-static void _pretexture_horizontal_polygon_lines(struct polygon_definition *polygon,
+template<int TEXBITS> static void _pretexture_horizontal_polygon_lines(struct polygon_definition *polygon,
 	struct bitmap_definition *screen, struct view_data *view, struct _horizontal_polygon_line_data *data,
 	short y0, short *x0_table, short *x1_table, short line_count);
 
-static void _pretexture_vertical_polygon_lines(struct polygon_definition *polygon,
+template<int TEXBITS> static void _pretexture_vertical_polygon_lines(struct polygon_definition *polygon,
 	struct bitmap_definition *screen, struct view_data *view, struct _vertical_polygon_data *data,
 	short x0, short *y0_table, short *y1_table, short line_count);
 
@@ -308,9 +308,7 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 		switch (polygon->transfer_mode)
 		{
 			case _textured_transfer:
-				_pretexture_horizontal_polygon_lines(polygon, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
-					vertices[highest_vertex].y, left_table, right_table,
-					aggregate_total_line_count);
+				TEXBITS_DISPATCH(polygon->texture, _pretexture_horizontal_polygon_lines, (polygon, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count));
 				break;
 
 			case _big_landscaped_transfer:
@@ -331,8 +329,8 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 				{
 	
 					case _textured_transfer:
-						texture_horizontal_polygon_lines<pixel8, _sw_alpha_off>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
-							vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count);
+						TEXBITS_DISPATCH_2(polygon->texture, texture_horizontal_polygon_lines, pixel8, _sw_alpha_off, (polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
+							vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count));
 						break;
 					case _big_landscaped_transfer:
 						landscape_horizontal_polygon_lines<pixel8>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
@@ -358,14 +356,14 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 						if (sw_texture && !polygon->VoidPresent && sw_texture->opac_type())
 						{
 							if (graphics_preferences->software_alpha_blending == _sw_alpha_fast) {
-								texture_horizontal_polygon_lines<pixel16, _sw_alpha_fast>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count);
+								TEXBITS_DISPATCH_2(polygon->texture, texture_horizontal_polygon_lines, pixel16, _sw_alpha_fast, (polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count));
 							}
 							else if (graphics_preferences->software_alpha_blending == _sw_alpha_nice) {
-								texture_horizontal_polygon_lines<pixel16, _sw_alpha_nice>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *) precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count, sw_texture->opac_table());
+								TEXBITS_DISPATCH_2(polygon->texture, texture_horizontal_polygon_lines, pixel16, _sw_alpha_nice, (polygon->texture, screen, view, (struct _horizontal_polygon_line_data *) precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count, sw_texture->opac_table()));
 							}
 						} else {
-							texture_horizontal_polygon_lines<pixel16, _sw_alpha_off>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
-											  vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count);
+							TEXBITS_DISPATCH_2(polygon->texture, texture_horizontal_polygon_lines, pixel16, _sw_alpha_off, (polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
+											  vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count));
 						}
 					}
 					break;
@@ -394,18 +392,18 @@ void Rasterizer_SW_Class::texture_horizontal_polygon(polygon_definition& texture
 					{
 						if (graphics_preferences->software_alpha_blending == _sw_alpha_fast)
 						{
-							texture_horizontal_polygon_lines<pixel32, _sw_alpha_fast>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count);
+							TEXBITS_DISPATCH_2(polygon->texture, texture_horizontal_polygon_lines, pixel32, _sw_alpha_fast, (polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count));
 						} 
 						else if (graphics_preferences->software_alpha_blending == _sw_alpha_nice)
 						{
-							texture_horizontal_polygon_lines<pixel32, _sw_alpha_nice>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *) precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count, sw_texture->opac_table());
+							TEXBITS_DISPATCH_2(polygon->texture, texture_horizontal_polygon_lines, pixel32, _sw_alpha_nice, (polygon->texture, screen, view, (struct _horizontal_polygon_line_data *) precalculation_table, vertices[highest_vertex].y, left_table, right_table, aggregate_total_line_count, sw_texture->opac_table()));
 						}
 					}
 					else 
 					{
-						texture_horizontal_polygon_lines<pixel32, _sw_alpha_off>(polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
+						TEXBITS_DISPATCH_2(polygon->texture, texture_horizontal_polygon_lines, pixel32, _sw_alpha_off, (polygon->texture, screen, view, (struct _horizontal_polygon_line_data *)precalculation_table,
 											  vertices[highest_vertex].y, left_table, right_table,
-											  aggregate_total_line_count);
+											  aggregate_total_line_count));
 					}
 				}
 				break;
@@ -526,7 +524,7 @@ void Rasterizer_SW_Class::texture_vertical_polygon(polygon_definition& textured_
 
           if ((polygon->transfer_mode == _textured_transfer) || (polygon->transfer_mode == _static_transfer))
           {
-              _pretexture_vertical_polygon_lines(polygon, screen, view, (struct _vertical_polygon_data *)precalculation_table, vertices[highest_vertex].x, left_table, right_table, aggregate_total_line_count);
+			  TEXBITS_DISPATCH(polygon->texture, _pretexture_vertical_polygon_lines, (polygon, screen, view, (struct _vertical_polygon_data *)precalculation_table, vertices[highest_vertex].x, left_table, right_table, aggregate_total_line_count));
           }
           else VHALT_DEBUG(csprintf(temporary, "vertical_polygons dont support mode #%d", polygon->transfer_mode));
           
@@ -890,7 +888,7 @@ void Rasterizer_SW_Class::texture_rectangle(rectangle_definition& textured_recta
 
 /* starting at x0 and for line_count vertical lines between *y0 and *y1, precalculate all the
 	information _texture_vertical_polygon_lines will need to work */
-static void _pretexture_vertical_polygon_lines(
+template<int TEXBITS> static void _pretexture_vertical_polygon_lines(
 	struct polygon_definition *polygon,
 	struct bitmap_definition *screen,
 	struct view_data *view,
@@ -1012,7 +1010,7 @@ static void _pretexture_vertical_polygon_lines(
 	}
 }
 
-static void _pretexture_horizontal_polygon_lines(
+template<int TEXBITS> static void _pretexture_horizontal_polygon_lines(
 	struct polygon_definition *polygon,
 	struct bitmap_definition *screen,
 	struct view_data *view,


### PR DESCRIPTION
Support 256x256, 512x512, and 1024x1024 wall textures in the software renderer. Tested in 8-, 16-, and 32-bit modes.

Featuring `MY_MACRO_THAT_SCARES_SMALL_CHILDREN`. (I was already nauseated when I wrote it, so it couldn't make me feel any worse.)