### PR TITLE
Add optional "invisible" parameter to Items.new and Monsters.new

### DIFF
--- a/Source_Files/Lua/lua_monsters.cpp
+++ b/Source_Files/Lua/lua_monsters.cpp
@@ -1126,6 +1126,14 @@ int Lua_Monsters_New(lua_State *L)
 	if (monster_index == NONE)
 		return 0;
 
+	if (lua_toboolean(L, 6))
+	{
+		struct monster_data *monster= get_monster_data(monster_index);
+		object_data *object = get_object_data(monster->object_index);
+	
+		SET_OBJECT_INVISIBILITY(object, true);
+	}
+
 	Lua_Monster::Push(L, monster_index);
 	return 1;
 }

--- a/Source_Files/Lua/lua_objects.cpp
+++ b/Source_Files/Lua/lua_objects.cpp
@@ -382,6 +382,22 @@ static int Lua_Item_Get_Visible(lua_State *L)
 	return 1;
 }
 
+static int Lua_Item_Set_Visible(lua_State *L)
+{
+	int object_index = Lua_Item::Index(L, 1);
+	object_data *object = get_object_data(object_index);
+	bool should_be_visible = lua_toboolean(L, 2);
+	bool is_visible = OBJECT_IS_VISIBLE(object);
+	if (should_be_visible != is_visible) {
+		if (!is_visible) {
+			teleport_object_in(object_index);
+		} else {
+			teleport_object_out(object_index);
+		}
+	}
+	return 0;
+}
+
 const luaL_Reg Lua_Item_Get[] = {
 	{"delete", L_TableFunction<Lua_Item_Delete>},
 	{"facing", get_object_facing<Lua_Item>},
@@ -398,6 +414,7 @@ const luaL_Reg Lua_Item_Get[] = {
 
 const luaL_Reg Lua_Item_Set[] = {
 	{"facing", set_object_facing<Lua_Item>},
+	{"visible", Lua_Item_Set_Visible},
 	{0, 0}
 };
 

--- a/Source_Files/Lua/lua_objects.cpp
+++ b/Source_Files/Lua/lua_objects.cpp
@@ -439,6 +439,13 @@ int Lua_Items_New(lua_State *L)
 	if (item_index == NONE)
 		return 0;
 
+	if (lua_toboolean(L, 6))
+	{
+		struct object_data *object= get_object_data(item_index);
+		
+		SET_OBJECT_INVISIBILITY(object, true);
+	}
+
 	Lua_Item::Push(L, item_index);
 	return 1;
 }

--- a/Source_Files/Lua/lua_objects.cpp
+++ b/Source_Files/Lua/lua_objects.cpp
@@ -392,7 +392,14 @@ static int Lua_Item_Set_Visible(lua_State *L)
 		if (!is_visible) {
 			teleport_object_in(object_index);
 		} else {
+			if (L_Get_Proper_Item_Accounting(L))
+			{
+				object_was_just_destroyed(_object_is_item, object->permutation);
+			}
 			teleport_object_out(object_index);
+			remove_map_object(object_index);
+			L_Invalidate_Object(object_index);
+			MARK_SLOT_AS_FREE(object);
 		}
 	}
 	return 0;

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -749,7 +749,7 @@
 <dd><p class="description">maximum number of map objects</p></dd>
 <dt>Items()</dt>
 <dd><p class="description">iterates through all valid items</p></dd>
-<dt>Items.new(x, y, height, polygon, type)</dt>
+<dt>Items.new(x, y, height, polygon, type [, invisible] <span class="version">git</span>)</dt>
 <dd><p class="description">returns a new item</p></dd>
 <dt>Items[index]</dt>
 <dd><dl>
@@ -1055,8 +1055,11 @@
 <dd><p class="description">maximum number of monsters</p></dd>
 <dt>Monsters()</dt>
 <dd><p class="description">iterates through all valid monsters (including player monsters)</p></dd>
-<dt>Monsters.new(x, y, height, polygon, type)</dt>
-<dd><p class="description">returns a new monster</p></dd>
+<dt>Monsters.new(x, y, height, polygon, type [, invisible] <span class="version">git</span>)</dt>
+<dd>
+<p class="description">returns a new monster</p>
+<p class="note">if you want to make a monster teleport in immediately, spawn it as invisible and then activate it </p>
+</dd>
 <dt>Monsters[index]</dt>
 <dd><dl>
       <dt>:accelerate(direction, velocity, vertical_velocity) <span class="version">20081213</span>

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -768,9 +768,9 @@
       <dt>.type<span class="access"> (read-only)</span>
 </dt>
 <dd><p class="description">type of item</p></dd>
-      <dt>.visible<span class="access"> (read-only)</span> <span class="version">20220115</span>
+      <dt>.visible <span class="version">git</span>
 </dt>
-<dd><p class="description"></p></dd>
+<dd><p class="description">Changing visible from false to true makes the item teleport in. Changing visible from true to false makes the item teleport out and immediately removes it.</p></dd>
       <dt>.x<span class="access"> (read-only)</span>
 </dt>
 <dd><p class="description"></p></dd>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -2266,6 +2266,7 @@
 		<argument name="height"><type>WU</type></argument>
 		<argument name="polygon"><type>polygon</type></argument>
 		<argument name="type"><type>item_type</type></argument>
+		<argument name="invisible" version="git" required="false"><type>invisible</type></argument>
 		<return><type>item</type></return>
       </function>
     </accessor>
@@ -2324,11 +2325,13 @@
       </call>
       <function name="new">
 		<description>returns a new monster</description>
+		<note>if you want to make a monster teleport in immediately, spawn it as invisible and then activate it</note>
 		<argument name="x"><type>WU</type></argument>
 		<argument name="y"><type>WU</type></argument>
 		<argument name="height"><type>WU</type></argument>
 		<argument name="polygon"><type>polygon</type></argument>
 		<argument name="type"><type>monster_type</type></argument>
+		<argument name="invisible" version="git" required="false"><type>invisible</type></argument>
 		<return><type>monster</type></return>
       </function>
     </accessor>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -605,8 +605,9 @@
 		<description>type of item</description>
 		<type>item_type</type>
       </variable>
-      <variable name="visible" access="read-only" version="20220115">
+      <variable name="visible" version="git">
     <type>boolean</type>
+	<description>Changing visible from false to true makes the item teleport in. Changing visible from true to false makes the item teleport out and immediately removes it.</description>
       </variable>
       <variable name="x" access="read-only">
 		<type>WU</type>


### PR DESCRIPTION
Makes it possible to create new items that have not yet teleported in, which is currently impossible. Also implements a similar way to create monsters that have not yet teleported in for consistency’s sake.

(Fixes https://github.com/Aleph-One-Marathon/alephone/issues/454)