### PR TITLE
add polygon.media_light accessors

### DIFF
--- a/Source_Files/Lua/lua_map.cpp
+++ b/Source_Files/Lua/lua_map.cpp
@@ -1635,6 +1635,12 @@ static int Lua_Polygon_Get_Media(lua_State *L)
 	return 1;
 }
 
+static int Lua_Polygon_Get_Media_Light(lua_State *L)
+{
+	Lua_Light::Push(L, get_polygon_data(Lua_Polygon::Index(L, 1))->media_lightsource_index);
+	return 1;
+}
+
 static int Lua_Polygon_Get_Permutation(lua_State *L)
 {
 	polygon_data *polygon = get_polygon_data(Lua_Polygon::Index(L, 1));
@@ -1716,6 +1722,24 @@ static int Lua_Polygon_Set_Media(lua_State *L)
 	polygon->media_index = media_index;
 	return 0;
 }
+
+static int Lua_Polygon_Set_Media_Light(lua_State *L)
+{
+	short light_index;
+	if (lua_isnumber(L, 2))
+	{
+		light_index = static_cast<short>(lua_tonumber(L, 2));
+		if (light_index < 0 || light_index >= MAXIMUM_LIGHTS_PER_MAP)
+			return luaL_error(L, "media_light: invalid light index");
+	}
+	else
+	{
+		light_index = Lua_Light::Index(L, 2);
+	}
+	
+	get_polygon_data(Lua_Polygon::Index(L, 1))->media_lightsource_index = light_index;
+	return 0;
+}
 		
 static int Lua_Polygon_Set_Permutation(lua_State *L)
 {
@@ -1764,6 +1788,7 @@ const luaL_Reg Lua_Polygon_Get[] = {
 	{"floor", Lua_Polygon_Get_Floor},
 	{"lines", Lua_Polygon_Get_Lines},
 	{"media", Lua_Polygon_Get_Media},
+	{"media_light", Lua_Polygon_Get_Media_Light},
 	{"monsters", L_TableFunction<Lua_Polygon_Monsters>},
 	{"permutation", Lua_Polygon_Get_Permutation},
 	{"platform", Lua_Polygon_Get_Platform},
@@ -1779,6 +1804,7 @@ const luaL_Reg Lua_Polygon_Get[] = {
 
 const luaL_Reg Lua_Polygon_Set[] = {
 	{"media", Lua_Polygon_Set_Media},
+	{"media_light", Lua_Polygon_Set_Media_Light},
 	{"permutation", Lua_Polygon_Set_Permutation},
 	{"type", Lua_Polygon_Set_Type},
 	{"visible_on_automap", Lua_Polygon_Set_Visible_On_Automap},

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -992,7 +992,10 @@
 <dd><p class="description">high tide of media</p></dd>
       <dt>.light <span class="version">20100118</span>
 </dt>
-<dd><p class="description">light that controls this media’s tide</p></dd>
+<dd>
+<p class="description">light that controls this media’s tide</p>
+<p class="note">not to be confused with polygon.media_light, which controls how that specific polygon's media is lit </p>
+</dd>
       <dt>.low <span class="version">20100118</span>
 </dt>
 <dd><p class="description">low tide of media</p></dd>
@@ -1807,6 +1810,12 @@
 <dd><p class="description">iterates through all of this polygon’s lines</p></dd>
       <dt>.media</dt>
 <dd><p class="description">polygon media (liquid)</p></dd>
+	  <dt>.media_light <span class="version">git</span>
+</dt>
+<dd>
+<p class="description">light on polygon media</p>
+<p class="note">not to be confused with polygon.media.light, which is the light that controls the height of the media </p>
+</dd>
       <dt>:monsters()</dt>
 <dd><p class="description">iterates through all monsters in this polygon (including player monsters)</p></dd>
       <dt>.permutation</dt>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -933,6 +933,7 @@
       </variable>
       <variable name="light" version="20100118">
 		<description>light that controls this media’s tide</description>
+		<note>not to be confused with polygon.media_light, which controls how that specific polygon's media is lit</note>
 		<type>light</type>
       </variable>
       <variable name="low" version="20100118">
@@ -1861,6 +1862,11 @@
 		<description>polygon media (liquid)</description>
 		<type>media</type>
       </variable>
+	  <variable name="media_light" version="git">
+	  	<description>light on polygon media</description>
+		<note>not to be confused with polygon.media.light, which is the light that controls the height of the media</note>
+		<type>light</type>
+	  </variable>
       <function name="monsters">
 		<description>iterates through all monsters in this polygon (including player monsters)</description>
       </function>


### PR DESCRIPTION
There is currently no way to get or set the media light applied to specific polygons in Lua; this PR will fix that.