### PR TITLE
Add Level.completion_state_override, enabling Lua to set mission states

### DIFF
--- a/Source_Files/GameWorld/marathon2.cpp
+++ b/Source_Files/GameWorld/marathon2.cpp
@@ -792,7 +792,10 @@ void changed_polygon(
 short calculate_level_completion_state(
 	void)
 {
-	short completion_state= _level_finished;
+	short completion_state = GetLuaCompletion();
+	if (completion_state != NONE) return completion_state;
+	
+	completion_state = _level_finished;
 	
 	/* if there are any monsters left on an extermination map, we haven’t finished yet */
 	if (static_world->mission_flags&_mission_extermination)

--- a/Source_Files/Lua/lua_map.cpp
+++ b/Source_Files/Lua/lua_map.cpp
@@ -69,6 +69,8 @@ char Lua_ControlPanelType_Name[] = "control_panel_type";
 
 extern short get_panel_class(short panel_type);
 
+extern short lua_completion_state_override;
+
 // no devices.h, so copy this from devices.cpp:
 
 enum // control panel sounds
@@ -3551,6 +3553,23 @@ int Lua_Level_Get_Completed(lua_State* L)
 	return 1;
 }
 
+int Lua_Level_Get_Completion_State_Override(lua_State* L)
+{
+	Lua_CompletionState::Push(L, lua_completion_state_override);
+	return 1;
+}
+
+int Lua_Level_Set_Completion_State_Override(lua_State* L)
+{
+	if(lua_isnil(L, 2)) lua_completion_state_override = NONE;
+	else
+	{
+		lua_completion_state_override = Lua_CompletionState::ToIndex(L, 2);
+	}
+
+	return 0;
+}
+
 template<int16 flag>
 static int Lua_Level_Get_Environment_Flag(lua_State *L)
 {
@@ -3609,6 +3628,7 @@ static int Lua_Level_Get_Underwater_Fog(lua_State *L)
 const luaL_Reg Lua_Level_Get[] = {
 	{"calculate_completion_state", L_TableFunction<Lua_Level_Calculate_Completion_State>},
 	{"completed", Lua_Level_Get_Completed},
+	{"completion_state_override", Lua_Level_Get_Completion_State_Override},
 	{"extermination", Lua_Level_Get_Mission_Flag<_mission_extermination>},
 	{"exploration", Lua_Level_Get_Mission_Flag<_mission_exploration>},
 	{"fog", Lua_Level_Get_Fog},
@@ -3624,6 +3644,11 @@ const luaL_Reg Lua_Level_Get[] = {
         {"stash", Lua_Level_Get_Stash},
 	{"underwater_fog", Lua_Level_Get_Underwater_Fog},
 	{"vacuum", Lua_Level_Get_Environment_Flag<_environment_vacuum>},
+	{0, 0}
+};
+
+const luaL_Reg Lua_Level_Set[] = {
+	{"completion_state_override", Lua_Level_Set_Completion_State_Override},
 	{0, 0}
 };
 
@@ -3799,7 +3824,7 @@ int Lua_Map_register(lua_State *L)
 
         Lua_Level_Stash::Register(L, 0, 0, Lua_Level_Stash_Metatable);
 
-	Lua_Level::Register(L, Lua_Level_Get);
+	Lua_Level::Register(L, Lua_Level_Get, Lua_Level_Set);
 
 	Lua_Annotation::Register(L, Lua_Annotation_Get, Lua_Annotation_Set);
 	Lua_Annotation::Valid = Lua_Annotation_Valid;

--- a/Source_Files/Lua/lua_script.cpp
+++ b/Source_Files/Lua/lua_script.cpp
@@ -1101,6 +1101,7 @@ state_map states;
 
 // globals
 std::vector<lua_camera> lua_cameras;
+short lua_completion_state_override = NONE;
 std::unordered_map<std::string, std::string> lua_stash;
 
 uint32 *action_flags;
@@ -2081,6 +2082,7 @@ void CloseLuaScript()
 
 	lua_cameras.resize(0);
         lua_stash.clear();
+	lua_completion_state_override = NONE;
 
 	LuaTexturePaletteClear();
 
@@ -2222,6 +2224,14 @@ bool UseLuaCameras()
 	}
 
 	return using_lua_cameras;
+}
+
+short GetLuaCompletion()
+{
+	if (!LuaRunning())
+		return NONE;
+
+	return lua_completion_state_override;
 }
 
 bool LuaPlayerCanWieldWeapons(short player_index)

--- a/Source_Files/Lua/lua_script.h
+++ b/Source_Files/Lua/lua_script.h
@@ -90,6 +90,8 @@ void ResetLuaMute();
 
 bool UseLuaCameras();
 
+short GetLuaCompletion();
+
 void unpack_lua_states(uint8* data, size_t length);
 size_t save_lua_states();
 void pack_lua_states(uint8* data, size_t length);

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -801,7 +801,10 @@
 <dd><p class="description">check this in Triggers.cleanup() to determine whether the player(s) teleported out</p></dd>
 <dt>.completion_state_override <span class="version">git</span>
 </dt>
-<dd><p class="description">set to a completion state to override game's built-in level completion logic, or set to nil to remove the override</p></dd>
+<dd>
+<p class="description">set to a completion state to override game's built-in level completion logic, or set to nil to remove the override</p>
+<p class="note">This variable is not stored in saved games. If you set this variable every tick from Triggers.idle(), you're fine. If you only set this variable as needed, make sure you also set it in Triggers.init(). </p>
+</dd>
 <dt>.extermination<span class="access"> (read-only)</span> <span class="version">20081213</span>
 </dt>
 <dd><p class="description">whether level has extermination flag set</p></dd>

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -799,6 +799,9 @@
 <dt>.completed<span class="access"> (read-only)</span> <span class="version">20111201</span>
 </dt>
 <dd><p class="description">check this in Triggers.cleanup() to determine whether the player(s) teleported out</p></dd>
+<dt>.completion_state_override <span class="version">git</span>
+</dt>
+<dd><p class="description">set to a completion state to override game's built-in level completion logic, or set to nil to remove the override</p></dd>
 <dt>.extermination<span class="access"> (read-only)</span> <span class="version">20081213</span>
 </dt>
 <dd><p class="description">whether level has extermination flag set</p></dd>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -664,6 +664,7 @@
       <variable name="completion_state_override" version="git">
 		<description>set to a completion state to override game's built-in level completion logic, or set to nil to remove the override</description>
 		<type>completion_state</type>
+		<note>This variable is not stored in saved games. If you set this variable every tick from Triggers.idle(), you're fine. If you only set this variable as needed, make sure you also set it in Triggers.init().</note>
       </variable>
       <variable name="extermination" access="read-only" version="20081213">
 		<description>whether level has extermination flag set</description>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -661,6 +661,10 @@
 		<description>check this in Triggers.cleanup() to determine whether the player(s) teleported out</description>
 		<type>boolean</type>
       </variable>
+      <variable name="completion_state_override" version="git">
+		<description>set to a completion state to override game's built-in level completion logic, or set to nil to remove the override</description>
+		<type>completion_state</type>
+      </variable>
       <variable name="extermination" access="read-only" version="20081213">
 		<description>whether level has extermination flag set</description>
 		<type>boolean</type>


### PR DESCRIPTION
set to nil to revert to using the game’s internal logic