### PR TITLE
assert that lights must have non-zero-length active and inactive periods

### DIFF
--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -1658,6 +1658,12 @@ bool process_map_wad(
 		}
 	}
 
+	// make sure no lights are malformed
+	for (count = 0; count<LightList.size(); ++count)
+	{
+		sanity_check_light(count);
+	}
+
 	/* Extract the annotations */
 	data= (uint8 *)extract_type_from_wad(wad, ANNOTATION_TAG, &data_length);
 	count = data_length/SIZEOF_map_annotation;

--- a/Source_Files/GameWorld/lightsource.cpp
+++ b/Source_Files/GameWorld/lightsource.cpp
@@ -184,6 +184,7 @@ short new_light(
 			light->intensity= light->final_intensity;
 			change_light_state(light_index, LIGHT_IS_INITIALLY_ACTIVE(data) ? _light_primary_active : _light_primary_inactive);
 					light->phase= data->phase;
+			sanity_check_light(light_index);
 			rephase_light(light_index);		
 			
 			light->intensity= lighting_function_dispatch(get_lighting_function_specification(&light->static_data, light->state)->function,
@@ -310,6 +311,23 @@ bool set_tagged_light_statuses(
 	}
 	
 	return changed;
+}
+
+void sanity_check_light(size_t light_index) 
+{
+	auto& light = LightList[light_index];
+	int total_active_period = 0;
+	total_active_period += light.static_data.primary_active.period;
+	total_active_period += light.static_data.primary_active.delta_period;
+	total_active_period += light.static_data.secondary_active.period;
+	total_active_period += light.static_data.secondary_active.delta_period;
+	assert(total_active_period > 0);
+	int total_inactive_period = 0;
+	total_inactive_period += light.static_data.primary_inactive.period;
+	total_inactive_period += light.static_data.primary_inactive.delta_period;
+	total_inactive_period += light.static_data.secondary_inactive.period;
+	total_inactive_period += light.static_data.secondary_inactive.delta_period;
+	assert(total_inactive_period > 0);
 }
 
 _fixed get_light_intensity(

--- a/Source_Files/GameWorld/lightsource.h
+++ b/Source_Files/GameWorld/lightsource.h
@@ -187,6 +187,7 @@ void update_lights(void);
 bool get_light_status(size_t light_index);
 bool set_light_status(size_t light_index, bool active);
 bool set_tagged_light_statuses(short tag, bool new_status);
+void sanity_check_light(size_t light_index);
 
 _fixed get_light_intensity(size_t light_index);
 


### PR DESCRIPTION
Currently, lights that have zero-length active or inactive periods will cause an infinite loop and freeze the engine upon map load. This PR makes it throw an assertion failure instead. (Fixes https://github.com/Aleph-One-Marathon/alephone/issues/478.)