### PR TITLE
ogl: properly respect filter preference when drawing hud

### DIFF
--- a/Source_Files/Lua/lua_hud_objects.cpp
+++ b/Source_Files/Lua/lua_hud_objects.cpp
@@ -49,6 +49,8 @@ LUA_HUD_OBJECTS.CPP
 #include "collection_definition.h"
 #include "FileHandler.h"
 #include "Crosshairs.h"
+#include "OGL_Textures.h"
+#include "OGL_Setup.h"
 
 #include <algorithm>
 #include <cmath>
@@ -408,12 +410,15 @@ int Lua_Images_New(lua_State *L)
     {
         int resource_id = lua_tointeger(L, -1);
 
-        // blitter from image
-#ifdef HAVE_OPENGL	
-        Image_Blitter *blitter = (get_screen_mode()->acceleration != _no_acceleration) ? new OGL_Blitter() : new Image_Blitter();
+		// blitter from image
+#ifdef HAVE_OPENGL
+		Image_Blitter *blitter = (get_screen_mode()->acceleration != _no_acceleration)
+			? new OGL_Blitter()
+			: new Image_Blitter();
 #else
-        Image_Blitter *blitter = new Image_Blitter();
+		Image_Blitter *blitter = new Image_Blitter();
 #endif
+
         if (!blitter->Load(resource_id))
         {
             lua_pushnil(L);
@@ -501,11 +506,13 @@ int Lua_Images_New(lua_State *L)
 	}
 	
 	// blitter from image
-#ifdef HAVE_OPENGL	
-        Image_Blitter *blitter = (get_screen_mode()->acceleration != _no_acceleration) ? new OGL_Blitter() : new Image_Blitter();
+#ifdef HAVE_OPENGL
+	Image_Blitter *blitter = (get_screen_mode()->acceleration != _no_acceleration)
+		? new OGL_Blitter()
+		: new Image_Blitter();
 #else
-        Image_Blitter *blitter = new Image_Blitter();
-#endif	
+	Image_Blitter *blitter = new Image_Blitter();
+#endif
 	if (!blitter->Load(image))
 	{
 		lua_pushnil(L);
@@ -963,8 +970,10 @@ int Lua_Fonts_New(lua_State *L)
 	FontSpecifier *ff = new FontSpecifier(f);
 	ff->Init();
 #ifdef HAVE_OPENGL	
-	if (alephone::Screen::instance()->openGL())
+	if (alephone::Screen::instance()->openGL()) {
+		ff->NearFilter = TxtrTypeInfoList[OGL_Txtr_HUD].NearFilter;
 		ff->OGL_Reset(true);
+	}
 #endif	
 	if (ff->LineSpacing <= 0)
 	{

--- a/Source_Files/Misc/preference_dialogs.cpp
+++ b/Source_Files/Misc/preference_dialogs.cpp
@@ -232,6 +232,8 @@ void OpenGLDialog::OpenGLPrefsByRunning ()
 	binders.insert<int> (m_nearFiltersWidget[2], &spriteNearFilterPref);
 	Int16Pref weaponNearFilterPref (graphics_preferences->OGL_Configure.TxtrConfigList[OGL_Txtr_WeaponsInHand].NearFilter);
 	binders.insert<int> (m_nearFiltersWidget[3], &weaponNearFilterPref);
+	Int16Pref hudNearFilterPref(graphics_preferences->OGL_Configure.TxtrConfigList[OGL_Txtr_HUD].NearFilter);
+	binders.insert<int> (m_nearFiltersWidget[4], &hudNearFilterPref);
 	
 	TexQualityPref wallQualityPref (graphics_preferences->OGL_Configure.TxtrConfigList [0].MaxSize, 128);
 	binders.insert<int> (m_textureQualityWidget [0], &wallQualityPref);
@@ -241,6 +243,8 @@ void OpenGLDialog::OpenGLPrefsByRunning ()
 	binders.insert<int> (m_textureQualityWidget [2], &spriteQualityPref);
 	TexQualityPref weaponQualityPref (graphics_preferences->OGL_Configure.TxtrConfigList [3].MaxSize, 256);
 	binders.insert<int> (m_textureQualityWidget [3], &weaponQualityPref);
+	TexQualityPref hudQualityPref(graphics_preferences->OGL_Configure.TxtrConfigList[4].MaxSize, 256);
+	binders.insert<int>(m_textureQualityWidget[4], &hudQualityPref);
 	TexQualityPref modelQualityPref (graphics_preferences->OGL_Configure.ModelConfig.MaxSize, 256);
 	binders.insert<int> (m_modelQualityWidget, &modelQualityPref);
 	
@@ -389,6 +393,10 @@ public:
 		general_table->dual_add(texture_quality_wa[OGL_Txtr_WeaponsInHand]->label("Weapons in Hand"), m_dialog);
 		general_table->dual_add(texture_quality_wa[OGL_Txtr_WeaponsInHand], m_dialog);
 
+		texture_quality_wa[OGL_Txtr_HUD] = new w_select_popup();
+		general_table->dual_add(texture_quality_wa[OGL_Txtr_HUD]->label("HUD / Terminals"), m_dialog);
+		general_table->dual_add(texture_quality_wa[OGL_Txtr_HUD], m_dialog);
+
 		w_select_popup *model_quality_w = new w_select_popup();
 		general_table->dual_add(model_quality_w->label("3D Model Skins"), m_dialog);
 		general_table->dual_add(model_quality_w, m_dialog);
@@ -437,7 +445,8 @@ public:
 		near_filter_labels[OGL_Txtr_Wall] = new w_label("Walls");
 		near_filter_labels[OGL_Txtr_Inhabitant] = new w_label("Sprites");
 		near_filter_labels[OGL_Txtr_Landscape] = new w_label("Landscapes");
-		near_filter_labels[OGL_Txtr_WeaponsInHand] = new w_label("Weapons in Hand / HUD");
+		near_filter_labels[OGL_Txtr_WeaponsInHand] = new w_label("Weapons in Hand");
+		near_filter_labels[OGL_Txtr_HUD] = new w_label("HUD / Terminals");
 	
 		table_placer *ftable = new table_placer(3, get_theme_space(ITEM_WIDGET));
 		
@@ -482,7 +491,8 @@ public:
 		texture_labels[OGL_Txtr_Wall] = new w_label("Walls");
 		texture_labels[OGL_Txtr_Landscape] = new w_label("Landscapes");
 		texture_labels[OGL_Txtr_Inhabitant] = new w_label("Sprites");
-		texture_labels[OGL_Txtr_WeaponsInHand] = new w_label("Weapons in Hand / HUD");
+		texture_labels[OGL_Txtr_WeaponsInHand] = new w_label("Weapons in Hand");
+		texture_labels[OGL_Txtr_HUD] = new w_label("HUD / Terminals");
 
 		m_tabs->add(general_table, true);
 		m_tabs->add(advanced_placer, true);

--- a/Source_Files/RenderMain/OGL_Setup.h
+++ b/Source_Files/RenderMain/OGL_Setup.h
@@ -166,6 +166,7 @@ enum
 	OGL_Txtr_Landscape,
 	OGL_Txtr_Inhabitant,
 	OGL_Txtr_WeaponsInHand,
+	OGL_Txtr_HUD,
 	OGL_NUMBER_OF_TEXTURE_TYPES
 };
 

--- a/Source_Files/RenderMain/OGL_Textures.cpp
+++ b/Source_Files/RenderMain/OGL_Textures.cpp
@@ -106,17 +106,7 @@ using std::max;
 
 OGL_TexturesStats gGLTxStats = {0,0,0,500000,0,0, 0};
 
-// Texture mapping
-struct TxtrTypeInfoData
-{
-	GLenum NearFilter;			// OpenGL parameter for near filter (GL_NEAREST, etc.)
-	GLenum FarFilter;			// OpenGL parameter for far filter (GL_NEAREST, etc.)
-	int Resolution;				// 0 is full-sized, 1 is half-sized, 2 is fourth-sized
-	GLenum ColorFormat;			// OpenGL parameter for stored color format (RGBA8, etc.)
-};
-
-
-static TxtrTypeInfoData TxtrTypeInfoList[OGL_NUMBER_OF_TEXTURE_TYPES];
+TxtrTypeInfoData TxtrTypeInfoList[OGL_NUMBER_OF_TEXTURE_TYPES];
 static TxtrTypeInfoData ModelSkinInfo;
 
 static bool useSGISMipmaps = false;
@@ -239,6 +229,7 @@ void TextureState::FrameTick() {
 				if (unusedFrames > 450) Reset(); // release unused sprites in 15 seconds
 				break;
 		case OGL_Txtr_WeaponsInHand:
+		case OGL_Txtr_HUD:
 				if (unusedFrames > 600) Reset(); // release weapons in hand in 20 seconds
 				break;
 		}
@@ -712,6 +703,7 @@ bool TextureManager::LoadSubstituteTexture()
 		
 	case OGL_Txtr_Inhabitant:
 	case OGL_Txtr_WeaponsInHand:
+	case OGL_Txtr_HUD:
 		// Much of the code here has been copied from elsewhere.
 		// Set these for convenience; sprites are transposed, as walls are.
 		TxtrHeight = Height;
@@ -840,6 +832,7 @@ bool TextureManager::SetupTextureGeometry()
 		
 	case OGL_Txtr_Inhabitant:
 	case OGL_Txtr_WeaponsInHand:
+	case OGL_Txtr_HUD:
 		{
 			if (npotTextures) 
 			{
@@ -1405,6 +1398,7 @@ void TextureManager::PlaceTexture(const ImageDescriptor *Image, bool normal_map)
 		
 	case OGL_Txtr_Inhabitant:
 	case OGL_Txtr_WeaponsInHand:
+	case OGL_Txtr_HUD:
 		// Sprites have both horizontal and vertical limits
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
@@ -1482,6 +1476,7 @@ void TextureManager::SetupTextureMatrix()
 	{
 	case OGL_Txtr_Wall:
 	case OGL_Txtr_WeaponsInHand:
+	case OGL_Txtr_HUD:
 	case OGL_Txtr_Inhabitant:
 		glMatrixMode(GL_TEXTURE);
 		glLoadIdentity();
@@ -1516,6 +1511,7 @@ void TextureManager::RestoreTextureMatrix()
 	{
 	case OGL_Txtr_Wall:
 	case OGL_Txtr_WeaponsInHand:
+	case OGL_Txtr_HUD:
 	case OGL_Txtr_Inhabitant:
 	case OGL_Txtr_Landscape:
 		glMatrixMode(GL_TEXTURE);

--- a/Source_Files/RenderMain/OGL_Textures.h
+++ b/Source_Files/RenderMain/OGL_Textures.h
@@ -40,6 +40,17 @@ May 3, 2003 (Br'fin (Jeremy Parsons))
 
 #ifdef HAVE_OPENGL
 
+// Texture mapping
+struct TxtrTypeInfoData
+{
+	GLenum NearFilter;			// OpenGL parameter for near filter (GL_NEAREST, etc.)
+	GLenum FarFilter;			// OpenGL parameter for far filter (GL_NEAREST, etc.)
+	int Resolution;				// 0 is full-sized, 1 is half-sized, 2 is fourth-sized
+	GLenum ColorFormat;			// OpenGL parameter for stored color format (RGBA8, etc.)
+};
+
+extern TxtrTypeInfoData TxtrTypeInfoList[];
+
 // Initialize the texture accounting
 void OGL_StartTextures();
 

--- a/Source_Files/RenderOther/FontHandler.cpp
+++ b/Source_Files/RenderOther/FontHandler.cpp
@@ -284,7 +284,7 @@ void FontSpecifier::OGL_Reset(bool IsStarting)
 	OGL_Register(this);
  	
  	glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, NearFilter);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);

--- a/Source_Files/RenderOther/FontHandler.h
+++ b/Source_Files/RenderOther/FontHandler.h
@@ -130,6 +130,7 @@ public:
 	short TxtrWidth, TxtrHeight;
 	int GetTxtrSize() {return int(TxtrWidth)*int(TxtrHeight);}
 	GLuint TxtrID;
+	GLuint NearFilter = GL_LINEAR;
 	uint32 DispList;
 	static std::set<FontSpecifier*> *m_font_registry;
 #endif

--- a/Source_Files/RenderOther/HUDRenderer_OGL.cpp
+++ b/Source_Files/RenderOther/HUDRenderer_OGL.cpp
@@ -62,11 +62,12 @@ static bool hud_pict_not_found = false;	// HUD backdrop picture not found, don't
 extern int LuaTexturePaletteSize();
 
 void OGL_DrawHUD(Rect &dest, short time_elapsed)
-{	
+{
 	// Load static HUD picture if necessary
 	if (!HUD_Blitter.Loaded() && !hud_pict_not_found) {
-        if (!HUD_Blitter.Load(INTERFACE_PANEL_BASE))
-            hud_pict_not_found = true;
+		if (!HUD_Blitter.Load(INTERFACE_PANEL_BASE)) {
+			hud_pict_not_found = true;
+		}
 	}
 
 	glPushAttrib(GL_ALL_ATTRIB_BITS);
@@ -83,6 +84,7 @@ void OGL_DrawHUD(Rect &dest, short time_elapsed)
 	if (HUD_Blitter.Loaded() && !LuaTexturePaletteSize())
 	{
 		SDL_Rect hud_dest = { dest.left, dest.top, dest.right - dest.left, dest.bottom - dest.top };
+		HUD_Blitter.nearFilter = TxtrTypeInfoList[OGL_Txtr_HUD].NearFilter;
 		HUD_Blitter.Draw(hud_dest);
 	}
 	else
@@ -135,7 +137,7 @@ void HUD_OGL_Class::DrawShape(shape_descriptor shape, screen_rectangle *dest, sc
 	get_shape_bitmap_and_shading_table(shape, &TMgr.Texture, &TMgr.ShadingTables, _shading_normal);
 	TMgr.IsShadeless = true;
 	TMgr.TransferMode = _shadeless_transfer;
-	TMgr.TextureType = OGL_Txtr_WeaponsInHand;
+	TMgr.TextureType = OGL_Txtr_HUD;
 	if (!TMgr.Setup())
 		return;
 
@@ -170,7 +172,7 @@ void HUD_OGL_Class::DrawShapeAtXY(shape_descriptor shape, short x, short y, bool
 	get_shape_bitmap_and_shading_table(shape, &TMgr.Texture, &TMgr.ShadingTables, _shading_normal);
 	TMgr.IsShadeless = true;
 	TMgr.TransferMode = _shadeless_transfer;
-	TMgr.TextureType = OGL_Txtr_WeaponsInHand;
+	TMgr.TextureType = OGL_Txtr_HUD;
 	if (!TMgr.Setup())
 		return;
 
@@ -236,6 +238,8 @@ void HUD_OGL_Class::DrawText(const char *text, screen_rectangle *dest, short fla
 
 	// Get font information
 	FontSpecifier &FontData = get_interface_font(font_id);
+
+	FontData.NearFilter = TxtrTypeInfoList[OGL_Txtr_HUD].NearFilter;
 
 	// Draw text
 	FontData.OGL_DrawText(text, *dest, flags);

--- a/Source_Files/RenderOther/OGL_Blitter.cpp
+++ b/Source_Files/RenderOther/OGL_Blitter.cpp
@@ -35,7 +35,7 @@
 const int OGL_Blitter::tile_size;
 std::set<OGL_Blitter*> *OGL_Blitter::m_blitter_registry = NULL;
 
-OGL_Blitter::OGL_Blitter() : m_textures_loaded(false)
+OGL_Blitter::OGL_Blitter(GLuint nearFilter) : m_textures_loaded(false), nearFilter(nearFilter)
 {
 	m_src.x = m_src.y = m_src.w = m_src.h = 0;
 	m_scaled_src.x = m_scaled_src.y = m_scaled_src.w = m_scaled_src.h = 0;
@@ -122,7 +122,7 @@ void OGL_Blitter::_LoadTextures()
 
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, nearFilter);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 			
 			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_tile_width, m_tile_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, t->pixels);

--- a/Source_Files/RenderOther/OGL_Blitter.h
+++ b/Source_Files/RenderOther/OGL_Blitter.h
@@ -39,14 +39,14 @@ class OGL_Blitter;
 class OGL_Blitter : public Image_Blitter
 {
 public:
-	OGL_Blitter();
+	OGL_Blitter(GLuint nearFilter = GL_LINEAR);
 	
 	void Unload();
 
 	void Draw(SDL_Surface *dst_surface, const Image_Rect& dst, const Image_Rect& src) { Draw(dst, src); }
 	void Draw(const Image_Rect& dst) { Draw(dst, crop_rect); }
 	void Draw(const Image_Rect& dst, const Image_Rect& src);
-	
+
 	~OGL_Blitter();
 			
 	static void StopTextures();
@@ -54,6 +54,8 @@ public:
 	static void WindowToScreen(int& x, int& y, bool in_game = false);
 	static int ScreenWidth();
 	static int ScreenHeight();
+
+	GLuint nearFilter;
 	
 private:
 	

--- a/Source_Files/RenderOther/OverheadMap_OGL.cpp
+++ b/Source_Files/RenderOther/OverheadMap_OGL.cpp
@@ -72,6 +72,7 @@ Jan 25, 2002 (Br'fin (Jeremy Parsons)):
 
 #include "OGL_Headers.h"
 #include "OGL_Render.h"
+#include "OGL_Textures.h"
 
 
 // rgb_color straight to OpenGL
@@ -364,7 +365,8 @@ void OverheadMap_OGL_Class::draw_text(
 	glMatrixMode(GL_MODELVIEW);
 	glPushMatrix();
 	glLoadIdentity();
-	glTranslatef(left_location.x,left_location.y,0);	
+	glTranslatef(left_location.x,left_location.y,0);
+	FontData.NearFilter = TxtrTypeInfoList[OGL_Txtr_HUD].NearFilter;
 	FontData.OGL_Render(text);
 	glPopMatrix();
 }

--- a/Source_Files/RenderOther/Shape_Blitter.cpp
+++ b/Source_Files/RenderOther/Shape_Blitter.cpp
@@ -132,8 +132,10 @@ void Shape_Blitter::OGL_Draw(const Image_Rect& dst)
             TMgr.TextureType = OGL_Txtr_Inhabitant;
             break;
         case Shape_Texture_WeaponInHand:
+			TMgr.TextureType = OGL_Txtr_WeaponsInHand;
+			break;
         case Shape_Texture_Interface:
-            TMgr.TextureType = OGL_Txtr_WeaponsInHand;
+            TMgr.TextureType = OGL_Txtr_HUD;
             break;
     }
 	if (!TMgr.Setup())
@@ -146,7 +148,7 @@ void Shape_Blitter::OGL_Draw(const Image_Rect& dst)
 	GLdouble V_Offset = TMgr.V_Offset;
     
 	// Draw shape
-	if (Wanting_sRGB && TMgr.TextureType != OGL_Txtr_WeaponsInHand)
+	if (Wanting_sRGB && TMgr.TextureType != OGL_Txtr_WeaponsInHand && TMgr.TextureType != OGL_Txtr_HUD) // also not hud just in case
 	{
 		glEnable(GL_FRAMEBUFFER_SRGB_EXT);
 		Using_sRGB = true;

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -37,6 +37,7 @@
 #include "OGL_Headers.h"
 #include "OGL_Blitter.h"
 #include "OGL_Faders.h"
+#include "OGL_Textures.h"
 #endif
 
 #include "world.h"
@@ -1503,6 +1504,7 @@ void render_screen(short ticks_elapsed)
 				Term_Blitter.Load(*Term_Buffer);
 				Term_RenderRequest = false;
 			}
+			Term_Blitter.nearFilter = TxtrTypeInfoList[OGL_Txtr_HUD].NearFilter;
 			Term_Blitter.Draw(TermRect);
 		}
 


### PR DESCRIPTION
The OpenGL renderer doesn't respect the HUD filtering preference properly. Fix works for Lua and default HUDs, tested on the M1 and M2 scenarios. Affects terminal text but not graphics. Needs more testing and tweaking, currently makes TxtrTypeInfoList and TxtrTypeInfoData public to access the filter values, and adds filter parameters to OGL_Blitter, FontSpecifier and others.