### PR TITLE
Remove "effects" macro

### DIFF
--- a/Source_Files/Files/game_wad.cpp
+++ b/Source_Files/Files/game_wad.cpp
@@ -1899,7 +1899,7 @@ bool process_map_wad(
 		assert(count*SIZEOF_effect_data==data_length);
 		vassert(count <= MAXIMUM_EFFECTS_PER_MAP,
 			csprintf(temporary,"Number of effects %zu > limit %u",count,MAXIMUM_EFFECTS_PER_MAP));
-		unpack_effect_data(data,effects,count);
+		unpack_effect_data(data,EffectList.data(),count);
 
 		data= (uint8 *)extract_type_from_wad(wad, PROJECTILES_STRUCTURE_TAG, &data_length);
 		count= data_length/SIZEOF_projectile_data;
@@ -2475,7 +2475,7 @@ static uint8 *tag_to_global_array_and_size(
 			pack_monster_data(array,monsters,count);
 			break;
 		case EFFECTS_STRUCTURE_TAG:
-			pack_effect_data(array,effects,count);
+			pack_effect_data(array,EffectList.data(),count);
 			break;
 		case PROJECTILES_STRUCTURE_TAG:
 			pack_projectile_data(array,projectiles,count);

--- a/Source_Files/GameWorld/effects.cpp
+++ b/Source_Files/GameWorld/effects.cpp
@@ -70,7 +70,7 @@ static effect_definition *get_effect_definition(const short type);
 effect_data *get_effect_data(
 	const short effect_index)
 {
-	struct effect_data *effect = GetMemberWithBounds(effects,effect_index,MAXIMUM_EFFECTS_PER_MAP);
+	struct effect_data *effect = GetMemberWithBounds(EffectList.data(),effect_index,MAXIMUM_EFFECTS_PER_MAP);
 	
 	vassert(effect, csprintf(temporary, "effect index #%d is out of range", effect_index));
 	vassert(SLOT_IS_USED(effect), csprintf(temporary, "effect index #%d (%p) is unused", effect_index, (void*)effect));
@@ -111,7 +111,7 @@ short new_effect(
 		}
 		else
 		{
-			for (effect_index= 0,effect= effects; effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
+			for (effect_index= 0,effect = EffectList.data(); effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
 			{
 				if (SLOT_IS_FREE(effect))
 				{
@@ -156,7 +156,7 @@ void update_effects(
 	struct effect_data *effect;
 	short effect_index;
 	
-	for (effect_index= 0, effect= effects; effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
+	for (effect_index= 0, effect = EffectList.data(); effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
 	{
 		if (SLOT_IS_USED(effect))
 		{
@@ -215,7 +215,7 @@ void remove_all_nonpersistent_effects(
 	struct effect_data *effect;
 	short effect_index;
 	
-	for (effect_index= 0, effect= effects; effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
+	for (effect_index= 0, effect = EffectList.data(); effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
 	{
 		if (SLOT_IS_USED(effect))
 		{
@@ -284,7 +284,7 @@ void teleport_object_in(
 	struct effect_data *effect;
 	short effect_index;
 
-	for (effect_index= 0, effect= effects; effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
+	for (effect_index= 0, effect = EffectList.data(); effect_index<MAXIMUM_EFFECTS_PER_MAP; ++effect_index, ++effect)
 	{
 		if (SLOT_IS_USED(effect))
 		{

--- a/Source_Files/GameWorld/effects.h
+++ b/Source_Files/GameWorld/effects.h
@@ -153,7 +153,6 @@ const int SIZEOF_effect_definition = 14;
 // Turned the list of active effects into a variable array
 
 extern std::vector<effect_data> EffectList;
-#define effects (EffectList.data())
 
 // extern struct effect_data *effects;
 

--- a/Source_Files/GameWorld/map.cpp
+++ b/Source_Files/GameWorld/map.cpp
@@ -416,7 +416,7 @@ void initialize_map_for_new_level(
 	// Clear all these out -- supposed to be none of the contents of these when starting a level.
 	objlist_clear(automap_lines, AutomapLineList.size());
 	objlist_clear(automap_polygons, AutomapPolygonList.size());
-	objlist_clear(effects, EffectList.size());
+	objlist_clear(EffectList.data(), EffectList.size());
 	objlist_clear(projectiles,  ProjectileList.size());
 	objlist_clear(monsters,  MonsterList.size());
 	objlist_clear(objects,  ObjectList.size());
@@ -2072,7 +2072,7 @@ void recalculate_map_counts(
 		;
 	dynamic_world->projectile_count= static_cast<int16>(count);
 	
-	for (count=MAXIMUM_EFFECTS_PER_MAP,effect=effects+MAXIMUM_EFFECTS_PER_MAP-1;
+	for (count=MAXIMUM_EFFECTS_PER_MAP,effect=EffectList.data()+MAXIMUM_EFFECTS_PER_MAP-1;
 			count>0&&(!SLOT_IS_USED(effect));
 			--count,--effect)
 		;

--- a/Source_Files/Lua/lua_objects.cpp
+++ b/Source_Files/Lua/lua_objects.cpp
@@ -321,7 +321,7 @@ bool Lua_Effect_Valid(int32 index)
 	if (index < 0 || index >= MAXIMUM_EFFECTS_PER_MAP)
 		return false;
 
-	effect_data *effect = GetMemberWithBounds(effects, index, MAXIMUM_EFFECTS_PER_MAP);
+	effect_data *effect = GetMemberWithBounds(EffectList.data(), index, MAXIMUM_EFFECTS_PER_MAP);
 	return SLOT_IS_USED(effect);
 }
 
@@ -384,7 +384,7 @@ int Lua_Item_Delete(lua_State* L)
 	{
 		for (auto i = 0; i < MAXIMUM_EFFECTS_PER_MAP; ++i)
 		{
-			auto effect = &effects[i];
+			auto effect = &EffectList.data()[i];
 			if (SLOT_IS_USED(effect) &&
 				effect->type == _effect_teleport_object_in &&
 				effect->data == object_index)


### PR DESCRIPTION
This was breaking builds on current g++ (see https://github.com/Aleph-One-Marathon/alephone/issues/530 )