### PR TITLE
Add support for tests in linux and CI linux

### DIFF
--- a/.github/actions/configure-linux/action.yml
+++ b/.github/actions/configure-linux/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       
     - name: Install Dependencies 
-      run: sudo apt-get install autoconf-archive libboost-all-dev libsdl2-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libzzip-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev libpng-dev libcurl4-gnutls-dev libminiupnpc-dev libsndfile-dev libopenal-dev
+      run: sudo apt-get install autoconf-archive libboost-all-dev libsdl2-dev libsdl2-image-dev libsdl2-net-dev libsdl2-ttf-dev libzzip-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev libpng-dev libcurl4-gnutls-dev libminiupnpc-dev libsndfile-dev libopenal-dev libglu1-mesa-dev catch2
       shell: bash
       
     - name: Configure

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,44 +7,71 @@ jobs:
     if: github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name !=
       github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Configure
         uses: ./.github/actions/configure-linux
+        with:
+          configure_options: --with-catch2
+          
       - name: Build
         run: make -j $(nproc)
+        
+      - name: Install
+        run: sudo make install
+        
+      - name: Run Tests
+        uses: ./.github/actions/run-tests
+        with:
+          test_application_path: /usr/local/bin/alephone_tests
         
   linux-without-ffmpeg:
     if: github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name !=
       github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Configure
         uses: ./.github/actions/configure-linux
         with:
-          configure_options: --without-ffmpeg
+          configure_options: --without-ffmpeg --with-catch2
           
       - name: Build
         run: make -j $(nproc)
+        
+      - name: Install
+        run: sudo make install
+        
+      - name: Run Tests
+        uses: ./.github/actions/run-tests
+        with:
+          test_application_path: /usr/local/bin/alephone_tests
         
   linux-without-opengl:
     if: github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name !=
       github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Configure
         uses: ./.github/actions/configure-linux
         with:
-          configure_options: --disable-opengl
+          configure_options: --disable-opengl --with-catch2
           
       - name: Build
         run: make -j $(nproc)
-      
+        
+      - name: Install
+        run: sudo make install
+        
+      - name: Run Tests
+        uses: ./.github/actions/run-tests
+        with:
+          test_application_path: /usr/local/bin/alephone_tests
+        
   mac-osx-x64:
     if: github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name !=

--- a/Source_Files/Makefile.am
+++ b/Source_Files/Makefile.am
@@ -10,6 +10,9 @@ if MAKE_WINDOWS
 bin_PROGRAMS = AlephOne Marathon Marathon2 MarathonInfinity
 else
 bin_PROGRAMS = alephone
+if BUILD_ALEPHONE_TESTS
+bin_PROGRAMS += alephone_tests
+endif
 endif
 endif
 
@@ -33,6 +36,9 @@ alephone_LDADD = \
 standalone_hub_SOURCES = shell.h shell.cpp shell_misc.cpp shell_options.h shell_options.cpp Network/StandaloneHub/standalone_hub_main.cpp
 
 standalone_hub_LDADD = $(alephone_LDADD) Network/StandaloneHub/libstandalonehub.a
+
+alephone_tests_SOURCES = shell.h shell.cpp shell_misc.cpp shell_options.h shell_options.cpp $(top_srcdir)/tests/replay_film_test.cpp $(top_srcdir)/tests/main.cpp
+alephone_tests_LDADD = $(alephone_LDADD)
 
 AM_CPPFLAGS = -I$(top_srcdir)/Source_Files/CSeries -I$(top_srcdir)/Source_Files/Files \
   -I$(top_srcdir)/Source_Files/GameWorld -I$(top_srcdir)/Source_Files/Input \

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,7 @@ AX_ARG_WITH([curl], [cURL for HTTP communication])
 AX_ARG_WITH([zzip], [zziplib support])
 AX_ARG_WITH([png], [libpng PNG screenshot support])
 AX_ARG_WITH([miniupnpc], [miniupnpc support])
+AX_ARG_WITH([catch2], [Catch2 replay and unit tests support])
 
 dnl Check for programs.
 AC_PROG_CC
@@ -210,9 +211,9 @@ AC_DEFUN([AX_CHECK_FEATURE_LIB],
                          [AS_IF([test "x${with_$1}" = "xyes"],
                                 [AC_MSG_ERROR([${desc_$1} requested but not found])])])
                  ]) ])
-dnl AX_CHECK_FEATURE_PKG(option, define, package, lib)
+dnl AX_CHECK_FEATURE_PKG(option, define, package, lib, disabled_by_default)
 AC_DEFUN([AX_CHECK_FEATURE_PKG],
-         [ AS_IF([test "x${with_$1}" != "xno"],
+         [ AS_IF([test "x${with_$1}" != "xno" && (test "x${with_$1}" = "xyes" || test "x$5" != "xtrue" )],
                  [ PKG_CHECK_MODULES([$3], [$4],
                                      [ CPPFLAGS="${[$3]_CFLAGS} $CPPFLAGS"
                                        LIBS="${[$3]_LIBS} $LIBS"
@@ -222,7 +223,7 @@ AC_DEFUN([AX_CHECK_FEATURE_PKG],
                                             [AC_MSG_ERROR([${desc_$1} requested but not available])])])
            
                  ])
-            AM_CONDITIONAL([HAVE_$2], [test "x${have_$1}" = "xtrue"])
+            AM_CONDITIONAL([HAVE_$2], [test "x${have_$1}" = "xtrue" && test "x$5" != "xtrue"])
           ])
 
 AX_CHECK_FEATURE_PKG([sdl_image], [SDL_IMAGE],
@@ -246,6 +247,9 @@ LIBS=`echo "$LIBS" | sed -E 's|-specs=@<:@^ @:>@+||'`
 
 AX_CHECK_FEATURE_PKG([png], [PNG],
                      [PNG], [libpng])
+
+AX_CHECK_FEATURE_PKG([catch2], [CATCH2], [CATCH2], [catch2 >= 3.0.0], true)
+AM_CONDITIONAL([BUILD_ALEPHONE_TESTS], [test "x$have_catch2" = "xtrue"])
 
 AX_CHECK_FEATURE_LIB([miniupnpc], [MINIUPNPC], [miniupnpc/miniupnpc.h], [miniupnpc], [upnpDiscover])
 
@@ -299,7 +303,8 @@ AC_DEFUN([AX_PRINT_SUMMARY],
          [ AS_IF([test "x${have_$1}" = "xtrue"],
                  [AS_ECHO(["    Enabled: ${desc_$1}"])],
                  [test "x${enable_$1}" = "xno" ||
-                  test "x${with_$1}" = "xno"],
+                  test "x${with_$1}" = "xno" ||
+                  (test "x$2" = "xtrue" && test "x${with_$1}" != "xyes")],
                  [AS_ECHO(["   Disabled: ${desc_$1}"])],
                  [AS_ECHO(["  Not found: ${desc_$1}"])])
          ])
@@ -314,5 +319,6 @@ AX_PRINT_SUMMARY([curl])
 AX_PRINT_SUMMARY([zzip])
 AX_PRINT_SUMMARY([png])
 AX_PRINT_SUMMARY([miniupnpc])
+AX_PRINT_SUMMARY([catch2], true)
 AS_ECHO([""])
 AS_ECHO(["Configuration done. Now type \"make\"."])


### PR DESCRIPTION
Ubuntu 24.04 is needed on github runners for that since 22.04 does not have catch2 v3 available there and there is a lot of breaking changes between v2 & v3, headers includes are not the same, no pkg config support for v2 etc, there is no point in supporting v2.

I also had to install libglu1-mesa-dev because for some reason glu.h is not available by default while it was with the runner image 22.04. The ffmpeg version from 24.04 still compiles with just depreciation warnings (I didn't check what version it was using). 
I let Ubuntu 22.04 for the release stuff (flatpaks etc)

I set it in a way that the arg --with-catch2 must be explicitly provided in order to build the test binary or else it's disabled by default, even if catch2 v3 is installed.

There is probably better ways to update the configure/makefile without butchering them that much but I'am no expert.

What is kind of cool is that the tests running on windows couldn't support the OpenGL renderer and had to fallback to the Software one, while the linux runners on github support the OpenGL renderer and can then cover both branchs of the code.

Tests execution can already be seen just from CI checks for that Pull request.