### PR TITLE
Allow to enter terminal with overhead map active

### DIFF
--- a/Source_Files/CSeries/FilmProfile.cpp
+++ b/Source_Files/CSeries/FilmProfile.cpp
@@ -44,6 +44,7 @@ static FilmProfile alephone1_7 = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally_respawn
+	false, // overhead_map_terminal
 };
 
 static FilmProfile alephone1_4 = {
@@ -90,6 +91,7 @@ static FilmProfile alephone1_4 = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally_respawn
+	false, // overhead_map_terminal
 };
 
 
@@ -137,6 +139,7 @@ static FilmProfile alephone1_3 = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally respawn
+	false, // overhead_map_terminal
 };
 
 static FilmProfile alephone1_2 = {
@@ -183,6 +186,7 @@ static FilmProfile alephone1_2 = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally respawn
+	false, // overhead_map_terminal
 };
 
 static FilmProfile alephone1_1 = {
@@ -229,6 +233,7 @@ static FilmProfile alephone1_1 = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally_respawn
+	false, // overhead_map_terminal
 };
 
 static FilmProfile alephone1_0 = {
@@ -275,6 +280,7 @@ static FilmProfile alephone1_0 = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally_respawn
+	false, // overhead_map_terminal
 };
 
 static FilmProfile marathon2 = {
@@ -321,6 +327,7 @@ static FilmProfile marathon2 = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally_respawn
+	false, // overhead_map_terminal
 };
 
 static FilmProfile marathon_infinity = {
@@ -367,6 +374,7 @@ static FilmProfile marathon_infinity = {
 	false, // network_items
 	false, // hotkey_fix
 	false, // finally_respawn
+	false, // overhead_map_terminal
 };
 
 FilmProfile film_profile = alephone1_7;

--- a/Source_Files/CSeries/FilmProfile.h
+++ b/Source_Files/CSeries/FilmProfile.h
@@ -116,6 +116,7 @@ struct FilmProfile
 	bool network_items; // early creation of players on new games to fix network items spawn
 	bool hotkey_fix; // hotkeys no longer work when player is dead or carrying the ball
 	bool finally_respawn; // the player can respawn after 15 seconds regardless of being stationary
+	bool overhead_map_terminal; // allow to enter terminals with the overhead map active
 };
 
 extern FilmProfile film_profile;

--- a/Source_Files/GameWorld/devices.cpp
+++ b/Source_Files/GameWorld/devices.cpp
@@ -756,8 +756,15 @@ static void	change_panel_state(
                                     L_Call_End_Refuel (definition->_class, player_index, panel_side_index);
 			break;
 		case _panel_is_computer_terminal:
-			if (get_game_state()==_game_in_progress && !PLAYER_HAS_MAP_OPEN(player))
+			if (get_game_state()==_game_in_progress)
 			{
+				bool is_overhead_map_active = PLAYER_HAS_MAP_OPEN(player);
+				if (is_overhead_map_active && !film_profile.overhead_map_terminal)
+					break;
+
+				SET_PLAYER_MAP_STATUS(player, false);
+				SET_PLAYER_HAD_OVERHEAD_MAP_STATUS(player, is_overhead_map_active);
+
                                 //MH: Lua script hook
                                 L_Call_Terminal_Enter(side->control_panel_permutation,player_index);
 				

--- a/Source_Files/GameWorld/player.h
+++ b/Source_Files/GameWorld/player.h
@@ -304,7 +304,8 @@ enum { /* Player flags */
 	_player_has_map_open_flag= 0x0800,	
 	_player_is_totally_dead_flag= 0x1000,
 	_player_is_zombie_flag= 0x2000,
-	_player_is_dead_flag= 0x4000
+	_player_is_dead_flag= 0x4000,
+	_player_had_overhead_map_active_flag= 0x8000
 };
 
 #define PLAYER_PERSISTANT_FLAGS (_player_doesnt_auto_switch_weapons_flag | _player_is_zombie_flag)
@@ -321,6 +322,9 @@ enum { /* Player flags */
 
 #define PLAYER_HAS_MAP_OPEN(p) ( (p)->flags & _player_has_map_open_flag )
 #define SET_PLAYER_MAP_STATUS(p,v) ((void)((v)?((p)->flags|=(uint16)_player_has_map_open_flag):((p)->flags&=(uint16)~_player_has_map_open_flag)))
+
+#define PLAYER_HAD_OVERHEAD_MAP_ACTIVE(p) ((p)->flags&_player_had_overhead_map_active_flag)
+#define SET_PLAYER_HAD_OVERHEAD_MAP_STATUS(p,v) ((void)((v)?((p)->flags|=(uint16)_player_had_overhead_map_active_flag):((p)->flags&=(uint16)~_player_had_overhead_map_active_flag)))
 
 #define PLAYER_IS_TELEPORTING(p) ((p)->flags&_player_is_teleporting_flag)
 #define SET_PLAYER_TELEPORTING_STATUS(p,v) ((void)((v)?((p)->flags|=(uint16)_player_is_teleporting_flag):((p)->flags&=(uint16)~_player_is_teleporting_flag)))

--- a/Source_Files/RenderOther/computer_interface.cpp
+++ b/Source_Files/RenderOther/computer_interface.cpp
@@ -528,14 +528,10 @@ void initialize_terminal_manager(
 void initialize_player_terminal_info(
 	short player_index)
 {
-	struct player_terminal_data *terminal= get_player_terminal_data(player_index);
-
 	//CP Addition: trap for logout!
-	if (terminal->state != _no_terminal_state)
-        {
-                L_Call_Terminal_Exit(terminal->terminal_id, player_index);
-        }
+	abort_terminal_mode(player_index);
 
+	struct player_terminal_data* terminal = get_player_terminal_data(player_index);
 	terminal->flags= 0;
 	terminal->phase = NONE; // not using a control panel.
 	terminal->state= _no_terminal_state; // And there is no line..
@@ -812,6 +808,14 @@ void abort_terminal_mode(
 	{
 		terminal->state= _no_terminal_state;
 		L_Call_Terminal_Exit(terminal->terminal_id, player_index);
+
+		if (film_profile.overhead_map_terminal)
+		{
+			auto player = get_player_data(player_index);
+			bool map_was_active = PLAYER_HAD_OVERHEAD_MAP_ACTIVE(player);
+			SET_PLAYER_MAP_STATUS(player, map_was_active);
+			SET_PLAYER_HAD_OVERHEAD_MAP_STATUS(player, false);
+		}
 	}
 }
 


### PR DESCRIPTION
Fix #534.
Will disable the map when entering a terminal and will restore it when leaving.
The fix is disabled in the PR and will have to be enabled when a new film profile comes out.