### PR TITLE
Reference the main window as the parent of NFD modals

### DIFF
--- a/Source_Files/Files/FileHandler.cpp
+++ b/Source_Files/Files/FileHandler.cpp
@@ -81,6 +81,7 @@
 
 #ifdef HAVE_NFD
 #include "nfd.h"
+#include <SDL2/SDL_syswm.h>
 #endif
 
 namespace io = boost::iostreams;
@@ -1314,6 +1315,39 @@ static std::map<Typecode, std::vector<nfdu8filteritem_t>> typecode_filters {
 	{_typecode_music,    { {"Music file", "aif,ogg,wav"} }},
 	{_typecode_movie,    { {"Video file", "webm"} }} 
 };
+
+// from nativefiledialog-extended nfd_sdl2.h
+// we copied it because nfd_sdl2.h is including SDL2 headers directly and we would have to adjust the include paths
+static bool GetNativeWindowFromSDLWindowForNFD(SDL_Window* sdlWindow, nfdwindowhandle_t* nativeWindow)
+{
+	SDL_SysWMinfo info;
+	SDL_VERSION(&info.version);
+	if (!SDL_GetWindowWMInfo(sdlWindow, &info)) {
+		return false;
+	}
+	switch (info.subsystem) {
+#if defined(SDL_VIDEO_DRIVER_WINDOWS)
+	case SDL_SYSWM_WINDOWS:
+		nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_WINDOWS;
+		nativeWindow->handle = (void*)info.info.win.window;
+		return true;
+#endif
+#if defined(SDL_VIDEO_DRIVER_COCOA)
+	case SDL_SYSWM_COCOA:
+		nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_COCOA;
+		nativeWindow->handle = (void*)info.info.cocoa.window;
+		return true;
+#endif
+#if defined(SDL_VIDEO_DRIVER_X11)
+	case SDL_SYSWM_X11:
+		nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_X11;
+		nativeWindow->handle = (void*)info.info.x11.window;
+		return true;
+#endif
+	default:
+		return false;
+	}
+}
 #endif
 
 bool FileSpecifier::ReadDirectoryDialog() //needs native file dialog to work
@@ -1327,7 +1361,16 @@ bool FileSpecifier::ReadDirectoryDialog() //needs native file dialog to work
 	}
 #endif
 	nfdchar_t* outpath;
-	auto result = NFD_PickFolderU8(&outpath, nullptr);
+	nfdpickfolderu8args_t params = {};
+	if (GetNativeWindowFromSDLWindowForNFD(MainScreenWindow(), &params.parentWindow))
+	{
+		// we ignore the "window focus lost + gained" events to prevent pausing the game on "focus lost"
+		// otherwise, a user input would be necessary to resume the game
+		SDL_EventState(SDL_WINDOWEVENT, SDL_DISABLE);
+	}
+
+	auto result = NFD_PickFolderU8_With(&outpath, nullptr);
+	SDL_EventState(SDL_WINDOWEVENT, SDL_ENABLE);
 #if defined(_WIN32)
 	if (fullscreen)
 	{
@@ -1404,7 +1447,16 @@ bool FileSpecifier::ReadDialog(Typecode type, const char *prompt)
 			toggle_fullscreen(false);
 		}
 #endif
-		auto result = NFD_OpenDialogU8(&outpath, filters.data(), filters.size(), dir.GetPath());
+		nfdopendialogu8args_t params = { filters.data(), filters.size(), dir.GetPath() };
+		if (GetNativeWindowFromSDLWindowForNFD(MainScreenWindow(), &params.parentWindow))
+		{
+			// we ignore the "window focus lost + gained" events to prevent pausing the game on "focus lost"
+			// otherwise, a user input would be necessary to resume the game
+			SDL_EventState(SDL_WINDOWEVENT, SDL_DISABLE);
+		}
+
+		auto result = NFD_OpenDialogU8_With(&outpath, &params);
+		SDL_EventState(SDL_WINDOWEVENT, SDL_ENABLE);
 #if defined(_WIN32)
 		if (fullscreen)
 		{
@@ -1656,7 +1708,16 @@ bool FileSpecifier::WriteDialog(Typecode type, const char *prompt, const char *d
 			toggle_fullscreen(false);
 		}
 #endif
-		auto result = NFD_SaveDialogU8(&outpath, typecode_filters[type].data(), typecode_filters[type].size(), dir.GetPath(), default_name);
+		nfdsavedialogu8args_t params = { typecode_filters[type].data(), typecode_filters[type].size(), dir.GetPath(), default_name };
+		if (GetNativeWindowFromSDLWindowForNFD(MainScreenWindow(), &params.parentWindow))
+		{
+			// we ignore the "window focus lost + gained" events to prevent pausing the game on "focus lost"
+			// otherwise, a user input would be necessary to resume the game
+			SDL_EventState(SDL_WINDOWEVENT, SDL_DISABLE);
+		}
+
+		auto result = NFD_SaveDialogU8_With(&outpath, &params);
+		SDL_EventState(SDL_WINDOWEVENT, SDL_ENABLE);
 #if defined(_WIN32)
 		if (fullscreen)
 		{

--- a/Source_Files/Files/FileHandler.cpp
+++ b/Source_Files/Files/FileHandler.cpp
@@ -1447,7 +1447,7 @@ bool FileSpecifier::ReadDialog(Typecode type, const char *prompt)
 			toggle_fullscreen(false);
 		}
 #endif
-		nfdopendialogu8args_t params = { filters.data(), filters.size(), dir.GetPath() };
+		nfdopendialogu8args_t params = { filters.data(), static_cast<nfdfiltersize_t>(filters.size()), dir.GetPath() };
 		if (GetNativeWindowFromSDLWindowForNFD(MainScreenWindow(), &params.parentWindow))
 		{
 			// we ignore the "window focus lost + gained" events to prevent pausing the game on "focus lost"
@@ -1708,7 +1708,7 @@ bool FileSpecifier::WriteDialog(Typecode type, const char *prompt, const char *d
 			toggle_fullscreen(false);
 		}
 #endif
-		nfdsavedialogu8args_t params = { typecode_filters[type].data(), typecode_filters[type].size(), dir.GetPath(), default_name };
+		nfdsavedialogu8args_t params = { typecode_filters[type].data(), static_cast<nfdfiltersize_t>(typecode_filters[type].size()), dir.GetPath(), default_name };
 		if (GetNativeWindowFromSDLWindowForNFD(MainScreenWindow(), &params.parentWindow))
 		{
 			// we ignore the "window focus lost + gained" events to prevent pausing the game on "focus lost"

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -2277,6 +2277,10 @@ SDL_Surface *MainScreenSurface()
 {
 	return main_surface;
 }
+SDL_Window* MainScreenWindow()
+{
+	return main_screen;
+}
 void MainScreenUpdateRect(int x, int y, int w, int h)
 {
 	SDL_Rect r;

--- a/Source_Files/RenderOther/screen.h
+++ b/Source_Files/RenderOther/screen.h
@@ -270,6 +270,7 @@ float MainScreenPixelScale();
 bool MainScreenIsOpenGL();
 void MainScreenSwap();
 void MainScreenCenterMouse();
+SDL_Window* MainScreenWindow();
 SDL_Surface *MainScreenSurface();
 void MainScreenUpdateRect(int x, int y, int w, int h);
 void MainScreenUpdateRects(size_t count, const SDL_Rect *rects);


### PR DESCRIPTION
By doing so, the Aleph One window + the modal appear now as a single entry in the task bar (while they previously showed up as two distinct windows) and it's no longer possible to interact with the parent window while the modal is active. (preventing issues like the main window being accidentally hidden behind others etc)

The NFD code interfacing SDL2 with NFD has been directly copied into the Aleph One codebase since NFD directly includes SDL2 headers but our build system are expecting prefixed SDL2/ includes. The alternative would have been to patch in with a custom vcpkg port but that seemed excessive for a single 30 lines function.

This NFD parent feature currently supports windows, mac os and linux x11 for now. (with a comment noting that Wayland support will be added eventually and a draft PR https://github.com/btzy/nativefiledialog-extended/pull/153)

This PR also fixes #401 for platforms where this NFD parent feature is enabled. The problem with #401 was that when making a call to NFD to display a modal window, SDL2 will get a window lost focus event followed right after by a window gained focus event. And since we pause the game on lost focus (and don't resume on gained focus), this led to the user having to click to resume gameplay when starting a film replay. The fix is to temporarily disable window events just for the NFD calls. (with the parent feature, we can be sure that when the modal closes, the main window is in front of the user)
