### PR TITLE
Add lua api for the new music system

### DIFF
--- a/Source_Files/Lua/lua_mnemonics.h
+++ b/Source_Files/Lua/lua_mnemonics.h
@@ -345,13 +345,20 @@ const lang_def Lua_ItemType_Mnemonics[] = {
 	{0, 0}
 };
 
+const lang_def Lua_MusicFadeType_Mnemonics[] = {
+	{"none", 0},
+	{"linear", 1},
+	{"sinusoidal", 2},
+	{0, 0}
+};
+
 const lang_def Lua_EphemeraQuality_Mnemonics[] = {
 	{"off", 0},
 	{"low", 1},
 	{"medium", 2},
 	{"high", 3},
 	{"ultra", 4},
-        {0, 0}
+	{0, 0}
 };
 
 const lang_def Lua_LightFunction_Mnenonics[] = {

--- a/Source_Files/Lua/lua_music.cpp
+++ b/Source_Files/Lua/lua_music.cpp
@@ -1,6 +1,52 @@
 #include "lua_music.h"
 #include "Music.h"
 
+static std::vector<std::pair<uint32_t, uint32_t>> music_sequence_indexes;
+static std::vector<std::tuple<uint32_t, uint32_t, uint32_t>> music_segment_indexes;
+
+void Reset_Music_InternalIndexes()
+{
+	music_sequence_indexes.clear();
+	music_segment_indexes.clear();
+}
+
+static std::pair<uint32_t, uint32_t> Get_MusicSequence(uint32_t sequence_index)
+{
+	return music_sequence_indexes[sequence_index];
+}
+
+static uint32_t Get_LuaMusicSequence(uint32_t music_index, uint32_t sequence_index)
+{
+	auto target = std::make_pair(music_index, sequence_index);
+	auto result = std::find(music_sequence_indexes.begin(), music_sequence_indexes.end(), target);
+	return std::distance(music_sequence_indexes.begin(), result);
+}
+
+static uint32_t Add_MusicSequence(uint32_t music_index, uint32_t sequence_index)
+{
+	music_sequence_indexes.emplace_back(music_index, sequence_index);
+	return static_cast<uint32_t>(music_sequence_indexes.size() - 1);
+}
+
+static std::tuple<uint32_t, uint32_t, uint32_t> Get_MusicSegment(uint32_t segment_index)
+{
+	return music_segment_indexes[segment_index];
+}
+
+static std::optional<uint32_t> Get_LuaMusicSegment(uint32_t music_index, uint32_t sequence_index, uint32_t segment_index)
+{
+	auto target = std::make_tuple(music_index, sequence_index, segment_index);
+	auto result = std::find(music_segment_indexes.begin(), music_segment_indexes.end(), target);
+	if (result != music_segment_indexes.end()) return std::distance(music_segment_indexes.begin(), result);
+	return std::nullopt;
+}
+
+static uint32_t Add_MusicSegment(uint32_t music_index, uint32_t sequence_index, uint32_t segment_index)
+{
+	music_segment_indexes.emplace_back(music_index, sequence_index, segment_index);
+	return static_cast<uint32_t>(music_segment_indexes.size() - 1);
+}
+
 static int Lua_MusicManager_Clear(lua_State* L)
 {
 	Music::instance()->ClearLevelPlaylist();
@@ -10,7 +56,8 @@ static int Lua_MusicManager_Clear(lua_State* L)
 static int Lua_MusicManager_Fade(lua_State* L)
 {
 	int duration = lua_isnumber(L, 1) ? static_cast<int>(lua_tonumber(L, 1) * 1000) : 1000;
-	Music::instance()->Fade(0, duration, MusicPlayer::FadeType::Linear);
+	auto fadeType = lua_gettop(L) >= 2 ? static_cast<MusicPlayer::FadeType>(Lua_MusicFadeType::ToIndex(L, 2)) : MusicPlayer::FadeType::Linear;
+	Music::instance()->Fade(0, duration, fadeType);
 	Music::instance()->ClearLevelPlaylist();
 	return 0;
 }
@@ -23,12 +70,13 @@ static int Lua_Music_Fade(lua_State* L)
 	float limitVolume = static_cast<float>(lua_tonumber(L, 2));
 	int duration = lua_isnumber(L, 3) ? static_cast<int>(lua_tonumber(L, 3) * 1000) : 1000;
 	bool stopOnNoVolume = lua_isboolean(L, 4) ? static_cast<bool>(lua_toboolean(L, 4)) : true;
+	auto fadeType = lua_gettop(L) >= 5 ? static_cast<MusicPlayer::FadeType>(Lua_MusicFadeType::ToIndex(L, 5)) : MusicPlayer::FadeType::Linear;
 
 	int index = Lua_Music::Index(L, 1) + Music::reserved_music_slots;
 	auto slot = Music::instance()->GetSlot(index);
 	if (!slot) return luaL_error(L, "fade: index out of bounds");
 
-	slot->Fade(limitVolume, duration, MusicPlayer::FadeType::Linear, stopOnNoVolume);
+	slot->Fade(limitVolume, duration, fadeType, stopOnNoVolume);
 	return 0;
 }
 
@@ -38,7 +86,22 @@ static int Lua_Music_Play(lua_State* L)
 	auto slot = Music::instance()->GetSlot(index);
 	if (!slot) return luaL_error(L, "play: index out of bounds");
 
-	slot->Play();
+	uint32_t sequence_index = 0, segment_index = 0;
+
+	if (lua_gettop(L) >= 2)
+	{
+		auto [music_index, sequence_idx, segment_idx] = Get_MusicSegment(static_cast<uint32_t>(Lua_MusicSegment::Index(L, 2)));
+
+		if (music_index != index)
+		{
+			return luaL_error(L, "play: invalid operation");
+		}
+
+		sequence_index = sequence_idx;
+		segment_index = segment_idx;
+	}
+
+	slot->Play(sequence_index, segment_index);
 	return 0;
 }
 
@@ -85,6 +148,36 @@ static int Lua_Music_Volume_Set(lua_State* L)
 	return 0;
 }
 
+static int Lua_Music_AddTrack(lua_State* L)
+{
+	if (!lua_isstring(L, 2))
+		return luaL_error(L, "add_track: invalid file specifier");
+
+	std::string search_path = L_Get_Search_Path(L);
+
+	FileSpecifier file;
+	if (search_path.size())
+	{
+		if (!file.SetNameWithPath(lua_tostring(L, 2), search_path))
+			return luaL_error(L, "add_track: file not found");
+	}
+	else
+	{
+		if (!file.SetNameWithPath(lua_tostring(L, 2)))
+			return luaL_error(L, "add_track: file not found");
+	}
+
+	int index = Lua_Music::Index(L, 1) + Music::reserved_music_slots;
+	auto slot = Music::instance()->GetSlot(index);
+	if (!slot) return luaL_error(L, "add_track: index out of bounds");
+
+	auto track_index = slot->AddTrack(&file);
+	if (!track_index.has_value()) return luaL_error(L, "add_track: invalid file format");
+
+	lua_pushnumber(L, track_index.value());
+	return 1;
+}
+
 static bool Lua_Music_Valid(int16 index)
 {
 	return index >= 0 && Music::instance()->GetSlot(index + Music::reserved_music_slots);
@@ -92,29 +185,38 @@ static bool Lua_Music_Valid(int16 index)
 
 static int Lua_MusicManager_New(lua_State* L)
 {
-	if (!lua_isstring(L, 1))
-		return luaL_error(L, "new: invalid file specifier");
+	bool load_with_file = lua_type(L, 1) == LUA_TSTRING;
+	int volume_index = load_with_file ? 2 : 1;
+	int loop_index = load_with_file ? 3 : 2;
+	float volume = lua_isnumber(L, volume_index) ? static_cast<float>(lua_tonumber(L, volume_index)) : 1;
+	bool loop = lua_isboolean(L, loop_index) ? static_cast<bool>(lua_toboolean(L, loop_index)) : true;
 
-	float volume = lua_isnumber(L, 2) ? static_cast<float>(lua_tonumber(L, 2)) : 1.f;
-	bool loop = lua_isboolean(L, 3) ? static_cast<bool>(lua_toboolean(L, 3)) : true;
+	FileSpecifier music_file;
 
-	std::string search_path = L_Get_Search_Path(L);
-
-	FileSpecifier file;
-	if (search_path.size())
+	if (load_with_file)
 	{
-		if (!file.SetNameWithPath(lua_tostring(L, 1), search_path)) 
-			return luaL_error(L, "new: file not found");
-	}
-	else
-	{
-		if (!file.SetNameWithPath(lua_tostring(L, 1))) 
-			return luaL_error(L, "new: file not found");
+		std::string search_path = L_Get_Search_Path(L);
+
+		if (search_path.size())
+		{
+			if (!music_file.SetNameWithPath(lua_tostring(L, 1), search_path))
+				return luaL_error(L, "new: file not found");
+		}
+		else
+		{
+			if (!music_file.SetNameWithPath(lua_tostring(L, 1)))
+				return luaL_error(L, "new: file not found");
+		}
 	}
 
-	auto id = Music::instance()->Add({ volume, loop }, &file);
-	if (!id.has_value() || id.value() < Music::reserved_music_slots) 
-		return luaL_error(L, "new: error loading file");
+	auto id = Music::instance()->Add({ volume, loop }, load_with_file ? &music_file : nullptr);
+	if (!id.has_value()) return luaL_error(L, "new: invalid file format");
+
+	if (load_with_file) //a track loaded with a file shouldn't become a segmented track but just in case that happens, we handle it
+	{
+		Add_MusicSequence(id.value(), 0);
+		Add_MusicSegment(id.value(), 0, 0);
+	}
 
 	Lua_Music::Push(L, id.value() - Music::reserved_music_slots);
 	return 1;
@@ -176,6 +278,101 @@ static int Lua_MusicManager_Valid(lua_State* L) {
 	return top;
 }
 
+static bool Lua_MusicSequence_Valid(int16 index)
+{
+	return index >= 0 && index < music_sequence_indexes.size();
+}
+
+static int Lua_Get_MusicSequence(lua_State* L)
+{
+	Lua_MusicSequence::Push(L, Lua_Music::Index(L, 1));
+	return 1;
+}
+
+static int Lua_MusicSequence_New(lua_State* L)
+{
+	int index = Lua_Music::Index(L, 1) + Music::reserved_music_slots;
+	auto slot = Music::instance()->GetSlot(index);
+	if (!slot) return luaL_error(L, "new: index out of bounds");
+
+	auto sequence_index = slot->AddSequence();
+	if (!sequence_index.has_value()) return luaL_error(L, "new: invalid operation");
+
+	Lua_MusicSequence::Push(L, Add_MusicSequence(index, sequence_index.value()));
+	return 1;
+}
+
+static int Lua_Music_Set_Sequence_Transition(lua_State* L)
+{
+	int index = Lua_Music::Index(L, 1) + Music::reserved_music_slots;
+	auto slot = Music::instance()->GetSlot(index);
+	if (!slot) return luaL_error(L, "request_sequence_transition: index out of bounds");
+
+	auto [music_index, sequence_index] = Get_MusicSequence(static_cast<uint32_t>(Lua_MusicSequence::Index(L, 2)));
+	if (!slot->SetSequenceTransition(sequence_index))
+		return luaL_error(L, "request_sequence_transition: invalid operation");
+
+	return 0;
+}
+
+static int Lua_MusicSegment_New(lua_State* L)
+{
+	if (!lua_isnumber(L, 2))
+		return luaL_error(L, "new: incorrect argument type");
+
+	auto index = static_cast<uint32_t>(Lua_MusicSequence::Index(L, 1));
+	auto [music_index, sequence_index] = Get_MusicSequence(index);
+
+	auto slot = Music::instance()->GetSlot(music_index);
+	if (!slot) return luaL_error(L, "new: index out of bounds");
+
+	auto segment_index = slot->AddSegmentToSequence(sequence_index, lua_tonumber(L, 2));
+	if (!segment_index.has_value()) return luaL_error(L, "new: index out of bounds");
+
+	Lua_MusicSegment::Push(L, Add_MusicSegment(music_index, sequence_index, segment_index.value()));
+	return 1;
+}
+
+static bool Lua_MusicSegment_Valid(int16 index)
+{
+	return index >= 0 && index < music_segment_indexes.size();
+}
+
+static int Lua_Get_MusicSegment(lua_State* L)
+{
+	Lua_MusicSegment::Push(L, Lua_MusicSequence::Index(L, 1));
+	return 1;
+}
+
+static int Lua_MusicSegment_Add_Segment_Transition(lua_State* L)
+{
+	auto index = static_cast<uint32_t>(Lua_MusicSegment::Index(L, 1));
+	auto [music_index, sequence_index, segment_index] = Get_MusicSegment(index);
+
+	auto next_index = static_cast<uint32_t>(Lua_MusicSegment::Index(L, 2));
+	auto [next_music_index, next_sequence_index, next_segment_index] = Get_MusicSegment(next_index);
+
+	if (music_index != next_music_index)
+		return luaL_error(L, "add_transition: incompatible segment index");
+
+	auto slot = Music::instance()->GetSlot(music_index);
+	if (!slot) return luaL_error(L, "add_transition: index out of bounds");
+
+	auto fadeTypeOut = lua_gettop(L) >= 3 ? static_cast<MusicPlayer::FadeType>(Lua_MusicFadeType::ToIndex(L, 3)) : MusicPlayer::FadeType::None;
+	auto fadeTypeOutSeconds = lua_isnumber(L, 4) ? static_cast<float>(lua_tonumber(L, 4)) : 0;
+	auto fadeTypeIn = lua_gettop(L) >= 5 ? static_cast<MusicPlayer::FadeType>(Lua_MusicFadeType::ToIndex(L, 5)) : MusicPlayer::FadeType::None;
+	auto fadeTypeInSeconds = lua_isnumber(L, 6) ? static_cast<float>(lua_tonumber(L, 6)) : 0;
+	bool crossfade = lua_isboolean(L, 7) ? lua_toboolean(L, 7) : false;
+
+	MusicPlayer::Segment::Edge edge(next_segment_index, { fadeTypeOut , fadeTypeOutSeconds }, { fadeTypeIn , fadeTypeInSeconds }, crossfade);
+
+	if (!slot->SetSegmentEdge(sequence_index, segment_index, next_sequence_index, edge))
+		return luaL_error(L, "add_transition: invalid operation");
+
+	return 0;
+}
+
+
 const luaL_Reg Lua_MusicManager_Methods[] = {
 	{"new", L_TableFunction<Lua_MusicManager_New>},
 	{"clear", L_TableFunction<Lua_MusicManager_Clear>},
@@ -189,6 +386,7 @@ const luaL_Reg Lua_MusicManager_Methods[] = {
 const luaL_Reg Lua_Music_Get[] = {
 	{"volume", Lua_Music_Volume_Get},
 	{"active", Lua_Music_Active_Get},
+	{"sequences", Lua_Get_MusicSequence},
 	{0, 0}
 };
 
@@ -196,6 +394,8 @@ const luaL_Reg Lua_Music_Get_Mutable[] = {
 	{"fade", L_TableFunction<Lua_Music_Fade>},
 	{"play", L_TableFunction<Lua_Music_Play>},
 	{"stop", L_TableFunction<Lua_Music_Stop>},
+	{"add_track", L_TableFunction<Lua_Music_AddTrack>},
+	{"request_sequence_transition", L_TableFunction<Lua_Music_Set_Sequence_Transition>},
 	{0, 0}
 };
 
@@ -204,15 +404,39 @@ const luaL_Reg Lua_Music_Set[] = {
 	{0, 0}
 };
 
+const luaL_Reg Lua_MusicSequence_Get_Mutable[] = {
+	{"new", L_TableFunction<Lua_MusicSequence_New>},
+	{0, 0}
+};
+
+const luaL_Reg Lua_MusicSequence_Get[] = {
+	{"segments", Lua_Get_MusicSegment},
+	{0, 0}
+};
+
+const luaL_Reg Lua_MusicSegment_Get_Mutable[] = {
+    {"new", L_TableFunction<Lua_MusicSegment_New>},
+	{"add_transition", L_TableFunction<Lua_MusicSegment_Add_Segment_Transition>},
+	{0, 0}
+};
+
 char Lua_Music_Name[] = "music";
 char Lua_MusicManager_Name[] = "Music";
+char Lua_MusicSequence_Name[] = "music_sequence";
+char Lua_MusicSegment_Name[] = "music_segment";
+char Lua_MusicFadeTypes_Name[] = "MusicFadeTypes";
+char Lua_MusicFadeType_Name[] = "music_fade_type";
 
 int Lua_Music_register(lua_State* L, const LuaMutabilityInterface& m)
 {
 	Lua_Music::Register(L, Lua_Music_Get);
+	Lua_MusicSequence::Register(L, Lua_MusicSequence_Get);
+
 	if (m.world_mutable() || m.music_mutable())
 	{
 		Lua_Music::RegisterAdditional(L, Lua_Music_Get_Mutable, Lua_Music_Set);
+		Lua_MusicSequence::RegisterAdditional(L, Lua_MusicSequence_Get_Mutable);
+		Lua_MusicSegment::Register(L, Lua_MusicSegment_Get_Mutable);
 	}
 
 	Lua_Music::Valid = Lua_Music_Valid;
@@ -225,6 +449,14 @@ int Lua_Music_register(lua_State* L, const LuaMutabilityInterface& m)
 	{
 		Lua_MusicManager::Register(L);
 	}
+
+	constexpr int fade_type_enum_length = 3;
+
+	Lua_MusicFadeType::Register(L, 0, 0, 0, Lua_MusicFadeType_Mnemonics);
+	Lua_MusicFadeType::Valid = Lua_MusicFadeTypes::ValidRange(fade_type_enum_length);
+
+	Lua_MusicFadeTypes::Register(L);
+	Lua_MusicFadeTypes::Length = Lua_MusicFadeTypes::ConstantLength(fade_type_enum_length);
 	
 	Lua_MusicManager::Length = Lua_MusicManager::ConstantLength(16); //whatever
 	return 0;

--- a/Source_Files/Lua/lua_music.h
+++ b/Source_Files/Lua/lua_music.h
@@ -16,9 +16,22 @@ extern "C"
 extern char Lua_Music_Name[]; //music
 typedef L_Class<Lua_Music_Name> Lua_Music;
 
+extern char Lua_MusicSequence_Name[];
+typedef L_Class<Lua_MusicSequence_Name> Lua_MusicSequence;
+
+extern char Lua_MusicSegment_Name[];
+typedef L_Class<Lua_MusicSegment_Name> Lua_MusicSegment;
+
 extern char Lua_MusicManager_Name[]; //Music
 typedef L_Container<Lua_MusicManager_Name, Lua_Music> Lua_MusicManager;
 
+extern char Lua_MusicFadeType_Name[];
+typedef L_Enum<Lua_MusicFadeType_Name> Lua_MusicFadeType;
+
+extern char Lua_MusicFadeTypes_Name[];
+typedef L_EnumContainer<Lua_MusicFadeTypes_Name, Lua_MusicFadeType> Lua_MusicFadeTypes;
+
 int Lua_Music_register(lua_State* L, const LuaMutabilityInterface& m);
+void Reset_Music_InternalIndexes();
 
 #endif

--- a/Source_Files/Lua/lua_script.cpp
+++ b/Source_Files/Lua/lua_script.cpp
@@ -1297,6 +1297,7 @@ void L_Call_Init(bool fRestoringSaved)
 {
 	if (LuaRunning())
 	{
+		Reset_Music_InternalIndexes();
 		// jkvw: Seeding our better random number
 		// generator from the lousy one is clearly not
 		// ideal, but it should be good enough for our

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
-  <head>
-    <META http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Aleph One Lua Scripters’ Guide</title>
-    <style type="text/css">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Aleph One Lua Scripters’ Guide</title>
+<style type="text/css">
       <!-- 
       body {
 	  font-family: Verdana, Helvetica, sans-serif;
@@ -122,140 +122,150 @@
 
 -->
       </style>
-  </head>
-  <body>
-    <h1>Table of Contents</h1>
-    <ol>
-      <li><a href="#general">General</a><ol>
-          <li><a href="#what_is_this">What is This?</a></li>
-          <li><a href="#running_a_script">Running a Script</a></li>
-          <li><a href="#units">Units</a></li>
-          <li><a href="#sync">Net Games and Films</a></li>
-          <li><a href="#loading_collections">Loading Collections</a></li>
-          <li><a href="#persistence">Persistence</a></li>
-          <li><a href="#write_access">Solo Plugin Write Access</a></li>
-        </ol>
-      </li>
-      <li><details><summary><a href="#triggers">Triggers</a></summary><ol>
-            <li><a href="#calculate_level_completion_state">calculate_level_completion_state</a></li>
-            <li><a href="#cleanup">cleanup</a></li>
-            <li><a href="#end_refuel">end_refuel</a></li>
-            <li><a href="#got_item">got_item</a></li>
-            <li><a href="#idle">idle</a></li>
-            <li><a href="#init">init</a></li>
-            <li><a href="#item_created">item_created</a></li>
-            <li><a href="#light_activated">light_activated</a></li>
-            <li><a href="#light_switch">light_switch</a></li>
-            <li><a href="#monster_damaged">monster_damaged</a></li>
-            <li><a href="#monster_kamikazed">monster_kamikazed</a></li>
-            <li><a href="#monster_killed">monster_killed</a></li>
-            <li><a href="#pattern_buffer">pattern_buffer</a></li>
-            <li><a href="#platform_activated">platform_activated</a></li>
-            <li><a href="#platform_switch">platform_switch</a></li>
-            <li><a href="#player_damaged">player_damaged</a></li>
-            <li><a href="#player_killed">player_killed</a></li>
-            <li><a href="#player_revived">player_revived</a></li>
-            <li><a href="#postidle">postidle</a></li>
-            <li><a href="#projectile_created">projectile_created</a></li>
-            <li><a href="#projectile_detonated">projectile_detonated</a></li>
-            <li><a href="#projectile_switch">projectile_switch</a></li>
-            <li><a href="#start_refuel">start_refuel</a></li>
-            <li><a href="#tag_switch">tag_switch</a></li>
-            <li><a href="#terminal_enter">terminal_enter</a></li>
-            <li><a href="#terminal_exit">terminal_exit</a></li>
-          </ol></details></li>
-      <li><a href="#using_tables">Using Tables</a><ol>
-          <li><a href="#custom">Custom Fields</a></li>
-          <li><a href="#table_indices">Index</a></li>
-          <li><a href="#table_is">is_ Functions</a></li>
-        </ol>
-      </li>
-      <li><details><summary><a href="#tables">Tables</a></summary><ol>
-            <li><a href="#Annotations">Annotations</a></li>
-            <li><a href="#Cameras">Cameras</a></li>
-            <li><a href="#Effects">Effects</a></li>
-            <li><a href="#Endpoints">Endpoints</a></li>
-            <li><a href="#Ephemera">Ephemera</a></li>
-            <li><a href="#Game">Game</a></li>
-            <li><a href="#Goals">Goals</a></li>
-            <li><a href="#Items">Items</a></li>
-            <li><a href="#ItemStarts">ItemStarts</a></li>
-            <li><a href="#Level">Level</a></li>
-            <li><a href="#Lights">Lights</a></li>
-            <li><a href="#Lines">Lines</a></li>
-            <li><a href="#Media">Media</a></li>
-            <li><a href="#Monsters">Monsters</a></li>
-            <li><a href="#MonsterStarts">MonsterStarts</a></li>
-            <li><a href="#Music">Music</a></li>
-            <li><a href="#Platforms">Platforms</a></li>
-            <li><a href="#Players">Players</a></li>
-            <li><a href="#PlayerStarts">PlayerStarts</a></li>
-            <li><a href="#Polygons">Polygons</a></li>
-            <li><a href="#Projectiles">Projectiles</a></li>
-            <li><a href="#Scenery">Scenery</a></li>
-            <li><a href="#Sides">Sides</a></li>
-            <li><a href="#SoundObjects">SoundObjects</a></li>
-            <li><a href="#Tags">Tags</a></li>
-            <li><a href="#Terminals">Terminals</a></li>
-          </ol></details></li>
-      <li><details><summary><a href="#types">Types and Mnemonics</a></summary><ol>
-            <li><a href="#AmbientSounds">Ambient Sounds</a></li>
-            <li><a href="#Collections">Collections</a></li>
-            <li><a href="#CompletionStates">Completion States</a></li>
-            <li><a href="#ControlPanelClasses">Control Panel Classes</a></li>
-            <li><a href="#ControlPanelTypes">Control Panel Types</a></li>
-            <li><a href="#DamageTypes">Damage</a></li>
-            <li><a href="#DifficultyTypes">Difficulty</a></li>
-            <li><a href="#EffectTypes">Effects</a></li>
-            <li><a href="#EphemeraQualities">Ephemera Quality</a></li>
-            <li><a href="#FadeTypes">Faders</a></li>
-            <li><a href="#FogModes">Fog Modes</a></li>
-            <li><a href="#GameTypes">Game Types</a></li>
-            <li><a href="#ItemKinds">Item Kinds</a></li>
-            <li><a href="#ItemTypes">Item Types</a></li>
-            <li><a href="#LightFunctions">Light Functions</a></li>
-            <li><a href="#LightPresets">Light Presets</a></li>
-            <li><a href="#LightStates">Light States</a></li>
-            <li><a href="#MediaTypes">Media</a></li>
-            <li><a href="#MonsterActions">Monster Actions</a></li>
-            <li><a href="#MonsterClasses">Monster Classes</a></li>
-            <li><a href="#MonsterModes">Monster Modes</a></li>
-            <li><a href="#MonsterTypes">Monsters</a></li>
-            <li><a href="#MusicFadeTypes">Music Fade Types</a></li>
-            <li><a href="#OverlayColors">Overlay Colors</a></li>
-            <li><a href="#PlatformTypes">Platform Types</a></li>
-            <li><a href="#PlayerColors">Player and Team Colors</a></li>
-            <li><a href="#PolygonTypes">Polygons</a></li>
-            <li><a href="#ProjectileTypes">Projectiles</a></li>
-            <li><a href="#SceneryTypes">Scenery</a></li>
-            <li><a href="#ScoringModes">Scoring Modes</a></li>
-            <li><a href="#SideTypes">Side Types</a></li>
-            <li><a href="#Sounds">Sounds</a></li>
-            <li><a href="#TextureTypes">Texture Types</a></li>
-            <li><a href="#TransferModes">Transfer Modes</a></li>
-            <li><a href="#WeaponTypes">Weapons</a></li>
-          </ol></details></li>
-      <li><a href="#example_icon">Example Icon</a></li>
-    </ol>
-    <h1><a name="general"></a>General</h1>
-    <h2><a name="what_is_this"></a>What is This?</h2>
+</head>
+<body>
+<h1>Table of Contents</h1>
+<ol>
+<li>
+<a href="#general">General</a><ol>
+<li><a href="#what_is_this">What is This?</a></li>
+<li><a href="#running_a_script">Running a Script</a></li>
+<li><a href="#units">Units</a></li>
+<li><a href="#sync">Net Games and Films</a></li>
+<li><a href="#loading_collections">Loading Collections</a></li>
+<li><a href="#persistence">Persistence</a></li>
+<li><a href="#write_access">Solo Plugin Write Access</a></li>
+</ol>
+</li>
+<li><details><summary><a href="#triggers">Triggers</a></summary><ol>
+<li><a href="#calculate_level_completion_state">calculate_level_completion_state</a></li>
+<li><a href="#cleanup">cleanup</a></li>
+<li><a href="#end_refuel">end_refuel</a></li>
+<li><a href="#got_item">got_item</a></li>
+<li><a href="#idle">idle</a></li>
+<li><a href="#init">init</a></li>
+<li><a href="#item_created">item_created</a></li>
+<li><a href="#light_activated">light_activated</a></li>
+<li><a href="#light_switch">light_switch</a></li>
+<li><a href="#monster_damaged">monster_damaged</a></li>
+<li><a href="#monster_kamikazed">monster_kamikazed</a></li>
+<li><a href="#monster_killed">monster_killed</a></li>
+<li><a href="#pattern_buffer">pattern_buffer</a></li>
+<li><a href="#platform_activated">platform_activated</a></li>
+<li><a href="#platform_switch">platform_switch</a></li>
+<li><a href="#player_damaged">player_damaged</a></li>
+<li><a href="#player_killed">player_killed</a></li>
+<li><a href="#player_revived">player_revived</a></li>
+<li><a href="#postidle">postidle</a></li>
+<li><a href="#projectile_created">projectile_created</a></li>
+<li><a href="#projectile_detonated">projectile_detonated</a></li>
+<li><a href="#projectile_switch">projectile_switch</a></li>
+<li><a href="#start_refuel">start_refuel</a></li>
+<li><a href="#tag_switch">tag_switch</a></li>
+<li><a href="#terminal_enter">terminal_enter</a></li>
+<li><a href="#terminal_exit">terminal_exit</a></li>
+</ol></details></li>
+<li>
+<a href="#using_tables">Using Tables</a><ol>
+<li><a href="#custom">Custom Fields</a></li>
+<li><a href="#table_indices">Index</a></li>
+<li><a href="#table_is">is_ Functions</a></li>
+</ol>
+</li>
+<li><details><summary><a href="#tables">Tables</a></summary><ol>
+<li><a href="#Annotations">Annotations</a></li>
+<li><a href="#Cameras">Cameras</a></li>
+<li><a href="#Effects">Effects</a></li>
+<li><a href="#Endpoints">Endpoints</a></li>
+<li><a href="#Ephemera">Ephemera</a></li>
+<li><a href="#Game">Game</a></li>
+<li><a href="#Goals">Goals</a></li>
+<li><a href="#ItemStarts">ItemStarts</a></li>
+<li><a href="#Items">Items</a></li>
+<li><a href="#Level">Level</a></li>
+<li><a href="#Lights">Lights</a></li>
+<li><a href="#Lines">Lines</a></li>
+<li><a href="#Media">Media</a></li>
+<li><a href="#MonsterStarts">MonsterStarts</a></li>
+<li><a href="#Monsters">Monsters</a></li>
+<li><a href="#Music">Music</a></li>
+<li><a href="#Platforms">Platforms</a></li>
+<li><a href="#PlayerStarts">PlayerStarts</a></li>
+<li><a href="#Players">Players</a></li>
+<li><a href="#Polygons">Polygons</a></li>
+<li><a href="#Projectiles">Projectiles</a></li>
+<li><a href="#Scenery">Scenery</a></li>
+<li><a href="#Sides">Sides</a></li>
+<li><a href="#SoundObjects">SoundObjects</a></li>
+<li><a href="#Tags">Tags</a></li>
+<li><a href="#Terminals">Terminals</a></li>
+</ol></details></li>
+<li><details><summary><a href="#types">Types and Mnemonics</a></summary><ol>
+<li><a href="#AmbientSounds">Ambient Sounds</a></li>
+<li><a href="#Collections">Collections</a></li>
+<li><a href="#CompletionStates">Completion States</a></li>
+<li><a href="#ControlPanelClasses">Control Panel Classes</a></li>
+<li><a href="#ControlPanelTypes">Control Panel Types</a></li>
+<li><a href="#DamageTypes">Damage</a></li>
+<li><a href="#DifficultyTypes">Difficulty</a></li>
+<li><a href="#EffectTypes">Effects</a></li>
+<li><a href="#EphemeraQualities">Ephemera Quality</a></li>
+<li><a href="#FadeTypes">Faders</a></li>
+<li><a href="#FogModes">Fog Modes</a></li>
+<li><a href="#GameTypes">Game Types</a></li>
+<li><a href="#ItemKinds">Item Kinds</a></li>
+<li><a href="#ItemTypes">Item Types</a></li>
+<li><a href="#LightFunctions">Light Functions</a></li>
+<li><a href="#LightPresets">Light Presets</a></li>
+<li><a href="#LightStates">Light States</a></li>
+<li><a href="#MediaTypes">Media</a></li>
+<li><a href="#MonsterActions">Monster Actions</a></li>
+<li><a href="#MonsterClasses">Monster Classes</a></li>
+<li><a href="#MonsterModes">Monster Modes</a></li>
+<li><a href="#MonsterTypes">Monsters</a></li>
+<li><a href="#OverlayColors">Overlay Colors</a></li>
+<li><a href="#PlatformTypes">Platform Types</a></li>
+<li><a href="#PlayerColors">Player and Team Colors</a></li>
+<li><a href="#PolygonTypes">Polygons</a></li>
+<li><a href="#ProjectileTypes">Projectiles</a></li>
+<li><a href="#SceneryTypes">Scenery</a></li>
+<li><a href="#ScoringModes">Scoring Modes</a></li>
+<li><a href="#SideTypes">Side Types</a></li>
+<li><a href="#Sounds">Sounds</a></li>
+<li><a href="#TextureTypes">Texture Types</a></li>
+<li><a href="#TransferModes">Transfer Modes</a></li>
+<li><a href="#WeaponTypes">Weapons</a></li>
+</ol></details></li>
+<li><a href="#example_icon">Example Icon</a></li>
+</ol>
+<h1>
+<a name="general"></a>General</h1>
+<h2>
+<a name="what_is_this"></a>What is This?</h2>
 		<p>This is a reference for writing Lua scripts to work in Aleph One. It lists every trigger and table available to Lua scripts. It is expected that Lua functionality will grow in Aleph One, and as it does, so will this document. Not everything here is completely documented, and any help fixing that would be appreciated.</p>
 		<p>This is not a reference for Lua itself - see lua.org for that.</p>
-      <h2><a name="running_a_script"></a>Running a Script</h2>
+      <h2>
+<a name="running_a_script"></a>Running a Script</h2>
 		<p>There are three ways to get a script to run - by embedding it in a level, by selecting a solo script in the Environment Preferences, or by selecting a script at the gather network game dialog.</p>
 		<p>To embed a script in a level, use a tool such as Atque. Use embedded Lua scripts only for map specific features, not for modifying game types. For instance, it may be tempting to embed the latest version of the Lua CTF script in a map designed only for playing CTF; however, this would prevent the user from using a later version of CTF if it were to come out, or from using another net script that works on CTF maps. Some older scenarios use Lua scripts in TEXT resources, but this is no longer recommended since they are not transmitted in net games.</p>
 		<p>To use a solo script, check the "Use Solo Script" box in Environment Preferences, and choose the script file to use.</p>
 		<p>To use a script via the network game dialog, put then script in a text file with the extension .lua. Then, at the gather network game dialog, select "use script", then select your script file.</p>
-      <h2><a name="units"></a>Units</h2>
+      <h2>
+<a name="units"></a>Units</h2>
 		<p>The unit for distance we use is World Units (WU) These are the same values you’d see in Forge or with F10 location display, and 1/1024 of what A1 uses internally and what you’d see in Pfhorte.</p>
 		<p>Units for speed are . . . well let’s say they’re messy. :) Lua speeds are expressed in World Units per tick (a tick is 1/30 of a second). Forge claims to use WU per sec, but it actually uses 0.87890625 WU per sec (which equals 30 internal units per tick). The following example illustrates the various conversions:</p>
 		<ul>
-		  <li><b style="display: inline-block; width: 10em; text-align: right">Actual:</b> 7.5 World Units per second</li>
-		  <li><b style="display: inline-block; width: 10em; text-align: right">A1 internal:</b> 256 units per tick (7.5 * 1024 / 30)</li>
-		  <li><b style="display: inline-block; width: 10em; text-align: right">Lua:</b> 0.25 WU per tick (7.5 / 30)</li>
-		  <li><b style="display: inline-block; width: 10em; text-align: right">Forge:</b> 8.53 "WU per second" ((7.5 * 1024 / 30) / 30)</li>
+		  <li>
+<b style="display: inline-block; width: 10em; text-align: right">Actual:</b> 7.5 World Units per second</li>
+		  <li>
+<b style="display: inline-block; width: 10em; text-align: right">A1 internal:</b> 256 units per tick (7.5 * 1024 / 30)</li>
+		  <li>
+<b style="display: inline-block; width: 10em; text-align: right">Lua:</b> 0.25 WU per tick (7.5 / 30)</li>
+		  <li>
+<b style="display: inline-block; width: 10em; text-align: right">Forge:</b> 8.53 "WU per second" ((7.5 * 1024 / 30) / 30)</li>
 		</ul>
-      <h2><a name="sync"></a>Net Games and Films</h2>
+      <h2>
+<a name="sync"></a>Net Games and Films</h2>
 		<p>Aleph One net games distribute a set of player inputs, which are applied to each distributed game world or to the game world in the film being played back. There is a separate copy of the Lua script running on each player’s machine. This means that in order to prevent net games from going out of sync, or films from playing back incorrectly, each of the separately running Lua scripts needs to manipulate the world the exact same way.</p>
 		<p>For example, if one player’s Lua script creates a monster, that monsters actions in the game are controlled by the random seed established at the beginning of the game. So, the other players’ scripts must create the same monster the same way, or the net game will go out of sync.</p>
 		<p>Usually this is not a problem, as long as scripters avoid functions marked with the "local player" tag, and the two local random functions, which will return different results on different machines. The <code>global_random</code> and <code>random</code> functions will return the same number on different machines, as long as they are called the same number of times, so they are safe to use for net games.</p>
@@ -263,24 +273,28 @@
 		<p>A few accessors, such as Ephemera and Fog were designed to be used on a "local player" basis without breaking films or net. For instance, it would be safe to programmatically disable fog when a player zooms in by checking <code>Players.local_player.zoom_active</code>--because the mere presence of fog will not cause a net game or film to go out of sync. Likewise, Ephemera can be created based on the Ephemera.quality setting, which will vary from machine to machine. A script that only uses Ephemera can be turned on and off and film playback will be unaffected.</p>
 		<p>When using local-safe accessors like Ephemera and Fog, it is important to use the matching <code>random_local</code> function, because it will not affect the progression of the ordinary random functions.</p>
 		<p>If this is confusing to you, it would be safest simply to avoid using anything marked with the "local player" tag, as well as the two local random functions and Ephemera.</p>
-	  <h2><a name="loading_collections"></a>Loading Collections</h2>
+	  <h2>
+<a name="loading_collections"></a>Loading Collections</h2>
 		<p>A Lua script can ask for the engine to load collections it might otherwise not load; for instance, in order to be able to spawn defenders and compilers on a map that might not have them otherwise, add the indices for those collections to the global table CollectionsUsed:
 		</p>
-    <pre>CollectionsUsed = { 10, 16 }</pre>
-      <h2><a name="persistence"></a>Persistence</h2>
+<pre>CollectionsUsed = { 10, 16 }</pre>
+      <h2>
+<a name="persistence"></a>Persistence</h2>
 		<p>Lua scripts are only active during a single level. If the user jumps to a new level, or restores from a saved game, the script is restarted in a clean state.</p>
 		<p>It is now possible to pass data across level jumps, by using the Game.restore_passed() function. This function will restore any custom fields (see the "Custom Fields" section of "Using Tables" below) in the Players or Game tables that were set immediately prior to the last level jump. Note that in order for data to survive multiple level jumps, Game.restore_passed() must be called after each level jump. Game.restore_passed() will not restore data from saved games.</p>
 		<p>It is also possible to restore data from saved games. The Game.restore_saved() function will restore all custom fields in use at the time the game was saved.</p>
 		<p>Only numbers, strings, booleans, and tables (including Aleph One’s built-in userdata tables) can be restored.</p>
-      <h2><a name="write_access"></a>Solo Plugin Write Access</h2>
+      <h2>
+<a name="write_access"></a>Solo Plugin Write Access</h2>
 		<p>Plugins that specify solo Lua scripts can also specify write access to features (see the Plugins Guide). Legacy solo Lua plugins are automatically assigned the <code>world</code> write access feature. This means they can modify anything in the game using Lua, but only one <code>world</code> feature script can run at a time, and achievements will be disabled.</p>
 		<p>The write access features <code>music</code>, <code>fog</code>, and <code>overlays</code> can run with other non-<code>world</code> Lua plugins that do not access the same features. For example, only one <code>music</code> plugin can run at a time, but a <code>music</code> plugin and <code>fog</code> plugin could run at the same time.</p>
 		<p>The write access features <code>ephemera</code> and <code>sound</code> can run with any other non-<code>world</code> write access plugins. Remember when writing a <code>ephemera</code> plugin that other plugins (and embedded Lua) can also access ephemera, so manage accordingly.</p>
 		<p>Plugins can specify multiple non-<code>world</code> write access features, and compatibility with other plugins will be determined automatically.</p>
 		<p>All solo Lua scripts can use Players:print and print to the console.</p>
-	  <h1><a name="triggers"></a>Triggers</h1>
-    <div class="triggers">
-      <p>These are functions scripts can define which Aleph One will call at specific times or events. For example, to regenerate health:
+	  <h1>
+<a name="triggers"></a>Triggers</h1>
+<div class="triggers">
+<p>These are functions scripts can define which Aleph One will call at specific times or events. For example, to regenerate health:
 	<span class="pre">Triggers = {}
 function Triggers.idle()
   for p in Players() do 
@@ -292,2587 +306,1923 @@ end
 	</span>
 	Calling Triggers = {} at the beginning of the script removes the compatibility triggers installed for old Lua scripts, speeding up execution of new scripts.
 	</p>
-      <dl>
-        <dt>Triggers</dt>
-        <dd>
-          <dl>
-            <dt><a name="calculate_level_completion_state"></a>.calculate_level_completion_state() <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">replaces the classic completion state calculation</p>
-            </dd>
-            <dt><a name="cleanup"></a>.cleanup()</dt>
-            <dd>
-              <p class="description">at end of the level</p>
-              <p class="note">primarily this is intended as a last chance for changing netgame scores before the postgame carnage report. </p>
-            </dd>
-            <dt><a name="end_refuel"></a>.end_refuel(class, player, side)</dt>
-            <dd>
-              <p class="description">whenever a player stops using a refuel panel</p>
-            </dd>
-            <dt><a name="got_item"></a>.got_item(type, player)</dt>
-            <dd>
-              <p class="description">whenever a player picks up an item</p>
-              <p class="note">also whenever a player gets an item when a script calls .items.add() </p>
-            </dd>
-            <dt><a name="idle"></a>.idle()</dt>
-            <dd>
-              <p class="description">at each tick, before physics and such</p>
-            </dd>
-            <dt><a name="init"></a>.init(restoring_game)</dt>
-            <dd>
-              <p class="description">at beginning of level</p>
-              <ul class="args">
-                <li>restoring_game: true if restoring from a saved game</li>
-              </ul>
-            </dd>
-            <dt><a name="item_created"></a>.item_created(item)</dt>
-            <dd>
-              <p class="description">whenever an item is created and placed on the ground (or floating) somewhere</p>
-              <p class="note">does not trigger on initial item placement because the initial item placement is done before Lua becomes initialised. </p>
-            </dd>
-            <dt><a name="light_activated"></a>.light_activated(light)</dt>
-            <dd>
-              <p class="description">whenever a light is activated or deactivated</p>
-            </dd>
-            <dt><a name="light_switch"></a>.light_switch(light, player, side)</dt>
-            <dd>
-              <p class="description">whenever a player uses a light switch</p>
-              <p class="note">not called when a projectile (e.g., fists) toggles a light switch </p>
-              <p class="note">side is only valid in version 20111201 and newer </p>
-            </dd>
-            <dt><a name="monster_damaged"></a>.monster_damaged(monster, aggressor_monster, damage_type, damage_amount, projectile) <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">whenever a monster is damaged, but before it dies if applicable. The monster’s vitality may be negative when this trigger is called. Ther monster’s vitality will be tested again after this trigger returns, so a script may prevent a monster’s death</p>
-              <ul class="args">
-                <li>aggressor_monster: the monster that caused the damage (can be nil)</li>
-                <li>damage_type: e.g. "fists"</li>
-                <li>damage_amount: the amount recently subtracted from the monster’s vitality</li>
-                <li>projectile: the projectile that delivered the damage (can be nil)</li>
-              </ul>
-            </dd>
-            <dt><a name="monster_kamikazed"></a>.monster_kamikazed(monster) <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">whenever a monster kamikazes</p>
-            </dd>
-            <dt><a name="monster_killed"></a>.monster_killed(monster, aggressor_player, projectile)</dt>
-            <dd>
-              <p class="description">whenever a monster dies</p>
-              <ul class="args">
-                <li>aggressor_player: player who killed it (can be nil)</li>
-                <li>projectile: projectile that delivered the final blow (can be nil)</li>
-              </ul>
-              <p class="note">called after a monster has taken lethal damage, but before it’s removed from the monster list </p>
-              <p class="note">you can use this to find out when a monster created with new_monster dies, but a monster discovered by Polygons.monsters() may have already taken lethal damage, so you may need to check for that case when using Polygons.monsters() </p>
-            </dd>
-            <dt><a name="pattern_buffer"></a>.pattern_buffer(side, player)</dt>
-            <dd>
-              <p class="description">whenever a player uses a pattern buffer</p>
-            </dd>
-            <dt><a name="platform_activated"></a>.platform_activated(polygon)</dt>
-            <dd>
-              <p class="description">whenever a platform is activated or deactivated</p>
-            </dd>
-            <dt><a name="platform_switch"></a>.platform_switch(polygon, player, side)</dt>
-            <dd>
-              <p class="description">whenever a player uses a platform switch</p>
-              <ul class="args">
-                <li>polygon: polygon of the platform being toggled</li>
-              </ul>
-              <p class="note">not called when a projectile (e.g., fists) toggles a platform switch </p>
-              <p class="note">side is only valid in version 20111201 and newer </p>
-            </dd>
-            <dt><a name="player_damaged"></a>.player_damaged(victim, aggressor_player, aggressor_monster, damage_type, damage_amount, projectile)</dt>
-            <dd>
-              <p class="description">whenever a player has taken damage, but before he dies if applicable. The player’s suit energy or oxygen may be negative when this trigger is called; if it still is when the trigger returns, it will be set to 0. The player’s suit energy is tested again after this trigger returns, so a script may prevent a player’s death
+<dl>
+<dt>Triggers</dt>
+<dd><dl>
+<dt>
+<a name="calculate_level_completion_state"></a>.calculate_level_completion_state() <span class="version">20240712</span>
+</dt>
+<dd><p class="description">replaces the classic completion state calculation</p></dd>
+<dt>
+<a name="cleanup"></a>.cleanup()</dt>
+<dd>
+<p class="description">at end of the level</p>
+<p class="note">primarily this is intended as a last chance for changing netgame scores before the postgame carnage report. </p>
+</dd>
+<dt>
+<a name="end_refuel"></a>.end_refuel(class, player, side)</dt>
+<dd><p class="description">whenever a player stops using a refuel panel</p></dd>
+<dt>
+<a name="got_item"></a>.got_item(type, player)</dt>
+<dd>
+<p class="description">whenever a player picks up an item</p>
+<p class="note">also whenever a player gets an item when a script calls .items.add() </p>
+</dd>
+<dt>
+<a name="idle"></a>.idle()</dt>
+<dd><p class="description">at each tick, before physics and such</p></dd>
+<dt>
+<a name="init"></a>.init(restoring_game)</dt>
+<dd>
+<p class="description">at beginning of level</p>
+<ul class="args"><li>restoring_game: true if restoring from a saved game</li></ul>
+</dd>
+<dt>
+<a name="item_created"></a>.item_created(item)</dt>
+<dd>
+<p class="description">whenever an item is created and placed on the ground (or floating) somewhere</p>
+<p class="note">does not trigger on initial item placement because the initial item placement is done before Lua becomes initialised. </p>
+</dd>
+<dt>
+<a name="light_activated"></a>.light_activated(light)</dt>
+<dd><p class="description">whenever a light is activated or deactivated</p></dd>
+<dt>
+<a name="light_switch"></a>.light_switch(light, player, side)</dt>
+<dd>
+<p class="description">whenever a player uses a light switch</p>
+<p class="note">not called when a projectile (e.g., fists) toggles a light switch </p>
+<p class="note">side is only valid in version 20111201 and newer </p>
+</dd>
+<dt>
+<a name="monster_damaged"></a>.monster_damaged(monster, aggressor_monster, damage_type, damage_amount, projectile) <span class="version">20100118</span>
+</dt>
+<dd>
+<p class="description">whenever a monster is damaged, but before it dies if applicable. The monster’s vitality may be negative when this trigger is called. Ther monster’s vitality will be tested again after this trigger returns, so a script may prevent a monster’s death</p>
+<ul class="args">
+<li>aggressor_monster: the monster that caused the damage (can be nil)</li>
+<li>damage_type: e.g. "fists"</li>
+<li>damage_amount: the amount recently subtracted from the monster’s vitality</li>
+<li>projectile: the projectile that delivered the damage (can be nil)</li>
+</ul>
+</dd>
+<dt>
+<a name="monster_kamikazed"></a>.monster_kamikazed(monster) <span class="version">20240712</span>
+</dt>
+<dd><p class="description">whenever a monster kamikazes</p></dd>
+<dt>
+<a name="monster_killed"></a>.monster_killed(monster, aggressor_player, projectile)</dt>
+<dd>
+<p class="description">whenever a monster dies</p>
+<ul class="args">
+<li>aggressor_player: player who killed it (can be nil)</li>
+<li>projectile: projectile that delivered the final blow (can be nil)</li>
+</ul>
+<p class="note">called after a monster has taken lethal damage, but before it’s removed from the monster list </p>
+<p class="note">you can use this to find out when a monster created with new_monster dies, but a monster discovered by Polygons.monsters() may have already taken lethal damage, so you may need to check for that case when using Polygons.monsters() </p>
+</dd>
+<dt>
+<a name="pattern_buffer"></a>.pattern_buffer(side, player)</dt>
+<dd><p class="description">whenever a player uses a pattern buffer</p></dd>
+<dt>
+<a name="platform_activated"></a>.platform_activated(polygon)</dt>
+<dd><p class="description">whenever a platform is activated or deactivated</p></dd>
+<dt>
+<a name="platform_switch"></a>.platform_switch(polygon, player, side)</dt>
+<dd>
+<p class="description">whenever a player uses a platform switch</p>
+<ul class="args"><li>polygon: polygon of the platform being toggled</li></ul>
+<p class="note">not called when a projectile (e.g., fists) toggles a platform switch </p>
+<p class="note">side is only valid in version 20111201 and newer </p>
+</dd>
+<dt>
+<a name="player_damaged"></a>.player_damaged(victim, aggressor_player, aggressor_monster, damage_type, damage_amount, projectile)</dt>
+<dd>
+<p class="description">whenever a player has taken damage, but before he dies if applicable. The player’s suit energy or oxygen may be negative when this trigger is called; if it still is when the trigger returns, it will be set to 0. The player’s suit energy is tested again after this trigger returns, so a script may prevent a player’s death
       </p>
-              <ul class="args">
-                <li>aggressor_player: player who got the kill (can be nil)</li>
-                <li>aggressor_monster: monster that got the kill (can be nil)</li>
-                <li>damage_type: e.g. "fists"</li>
-                <li>damage_amount: the amount recently subtracted from the player. If "oxygen drain", damage_amount was assessed against player’s oxygen; otherwise against player’s suit energy</li>
-                <li>projectile: the projectile that delivered the damage (can be nil)</li>
-              </ul>
-            </dd>
-            <dt><a name="player_killed"></a>.player_killed(player, aggressor_player, action, projectile)</dt>
-            <dd>
-              <p class="description">whenever a player dies</p>
-              <ul class="args">
-                <li>aggressor_player: the player who killed player, possibly himself (suicide) (can be nil)</li>
-                <li>action: dying soft, dying hard, or dying flaming</li>
-                <li>projectile: the projectile that delivered the final blow (can be nil)</li>
-              </ul>
-            </dd>
-            <dt><a name="player_revived"></a>.player_revived(player)</dt>
-            <dd>
-              <p class="description">whenever a player revives (presumably only happens in a netgame)</p>
-            </dd>
-            <dt><a name="postidle"></a>.postidle()</dt>
-            <dd>
-              <p class="description">at each tick, after physics and such, but before rendering</p>
-            </dd>
-            <dt><a name="projectile_created"></a>.projectile_created(projectile) <span class="version">20150619</span></dt>
-            <dd>
-              <p class="description">whenever a projectile is created</p>
-            </dd>
-            <dt><a name="projectile_detonated"></a>.projectile_detonated(type, owner, polygon, x, y, z, t <span class="version">20210408</span>)</dt>
-            <dd>
-              <p class="description">whenever a projectile detonates, after it has done any area of effect damage</p>
-              <p class="note">t can be a side, polygon_floor, polygon_ceiling, monster, scenery, polygon; see Polygon:check_collision for info on how to decode. It can also be nil, in the rare case a projectile detonates without hitting something </p>
-            </dd>
-            <dt><a name="projectile_switch"></a>.projectile_switch(projectile, side) <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whenever a projectile toggles a switch</p>
-              <ul class="args">
-                <li>projectile: projectile that toggled the switch</li>
-                <li>side: side containing switch being toggled</li>
-              </ul>
-            </dd>
-            <dt><a name="start_refuel"></a>.start_refuel(class, player, side)</dt>
-            <dd>
-              <p class="description">whenever a player starts to use a refuel panel</p>
-            </dd>
-            <dt><a name="tag_switch"></a>.tag_switch(tag, player, side)</dt>
-            <dd>
-              <p class="description">whenever a player uses a tag switch</p>
-              <p class="note">not called when a projectile (e.g., fists) toggles a tag switch </p>
-              <p class="note">side is only valid in version 20111201 and newer </p>
-            </dd>
-            <dt><a name="terminal_enter"></a>.terminal_enter(terminal, player)</dt>
-            <dd>
-              <p class="description">whenever a player starts using a terminal</p>
-            </dd>
-            <dt><a name="terminal_exit"></a>.terminal_exit(terminal, player)</dt>
-            <dd>
-              <p class="description">whenever a player stops using a terminal</p>
-            </dd>
-          </dl>
-        </dd>
-      </dl>
-    </div>
-    <h1><a name="using_tables"></a>Using Tables</h1>
-    <p>There are numerous tables (technically, userdata) defined in Aleph One which scripts can use to access objects in the game. A complete list is below.</p>
+<ul class="args">
+<li>aggressor_player: player who got the kill (can be nil)</li>
+<li>aggressor_monster: monster that got the kill (can be nil)</li>
+<li>damage_type: e.g. "fists"</li>
+<li>damage_amount: the amount recently subtracted from the player. If "oxygen drain", damage_amount was assessed against player’s oxygen; otherwise against player’s suit energy</li>
+<li>projectile: the projectile that delivered the damage (can be nil)</li>
+</ul>
+</dd>
+<dt>
+<a name="player_killed"></a>.player_killed(player, aggressor_player, action, projectile)</dt>
+<dd>
+<p class="description">whenever a player dies</p>
+<ul class="args">
+<li>aggressor_player: the player who killed player, possibly himself (suicide) (can be nil)</li>
+<li>action: dying soft, dying hard, or dying flaming</li>
+<li>projectile: the projectile that delivered the final blow (can be nil)</li>
+</ul>
+</dd>
+<dt>
+<a name="player_revived"></a>.player_revived(player)</dt>
+<dd><p class="description">whenever a player revives (presumably only happens in a netgame)</p></dd>
+<dt>
+<a name="postidle"></a>.postidle()</dt>
+<dd><p class="description">at each tick, after physics and such, but before rendering</p></dd>
+<dt>
+<a name="projectile_created"></a>.projectile_created(projectile) <span class="version">20150619</span>
+</dt>
+<dd><p class="description">whenever a projectile is created</p></dd>
+<dt>
+<a name="projectile_detonated"></a>.projectile_detonated(type, owner, polygon, x, y, z, t <span class="version">20210408</span>)</dt>
+<dd>
+<p class="description">whenever a projectile detonates, after it has done any area of effect damage</p>
+<p class="note">t can be a side, polygon_floor, polygon_ceiling, monster, scenery, polygon; see Polygon:check_collision for info on how to decode. It can also be nil, in the rare case a projectile detonates without hitting something </p>
+</dd>
+<dt>
+<a name="projectile_switch"></a>.projectile_switch(projectile, side) <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description">whenever a projectile toggles a switch</p>
+<ul class="args">
+<li>projectile: projectile that toggled the switch</li>
+<li>side: side containing switch being toggled</li>
+</ul>
+</dd>
+<dt>
+<a name="start_refuel"></a>.start_refuel(class, player, side)</dt>
+<dd><p class="description">whenever a player starts to use a refuel panel</p></dd>
+<dt>
+<a name="tag_switch"></a>.tag_switch(tag, player, side)</dt>
+<dd>
+<p class="description">whenever a player uses a tag switch</p>
+<p class="note">not called when a projectile (e.g., fists) toggles a tag switch </p>
+<p class="note">side is only valid in version 20111201 and newer </p>
+</dd>
+<dt>
+<a name="terminal_enter"></a>.terminal_enter(terminal, player)</dt>
+<dd><p class="description">whenever a player starts using a terminal</p></dd>
+<dt>
+<a name="terminal_exit"></a>.terminal_exit(terminal, player)</dt>
+<dd><p class="description">whenever a player stops using a terminal</p></dd>
+</dl></dd>
+</dl>
+</div>
+<h1>
+<a name="using_tables"></a>Using Tables</h1>
+<p>There are numerous tables (technically, userdata) defined in Aleph One which scripts can use to access objects in the game. A complete list is below.</p>
     <p>Unless otherwise specified, these tables are only valid inside the trigger calls listed above. Attempting to use them in the main body of a script may cause an error in this version or a future version of Aleph One.</p>
-    <h2><a name="custom"></a>Custom Fields</h2>
-    <p>In a real Lua table, you can set any field you want. In order to help troubleshooting, Aleph One’s userdata tables will only accept the fields listed in the documentation below. However, by prepending an underscore, custom fields can be indexed. These custom fields will be associated with the object until it is destroyed.</p>
-    <pre>Players[0]._favorite_flavor = "chocolate"</pre>
-    <h2><a name="table_indices"></a>Index</h2>
-    <p>Each table has a read-only .index variable, that corresponds to the engine’s internal index.</p>
-    <pre>=Players[0].index<br>0</pre>
-    <h2><a name="table_is"></a>is_ Functions</h2>
-    <p>Aleph One installs a set of boolean functions that can be used to recognize each of the userdata table types. For example, <code>is_monster(Monsters[1])</code> returns true. Each of these functions begins with the "is_" prefix.</p>
-    <h1><a name="tables">Tables</a></h1>
-    <div class="tables">
-      <h3><a name="Annotations"></a>Annotations</h3>
-      <dl>
-        <dt># Annotations</dt>
-        <dd>
-          <p class="description">number of map annotations</p>
-        </dd>
-        <dt>Annotations()</dt>
-        <dd>
-          <p class="description">iterates through all annotations</p>
-        </dd>
-        <dt>Annotations.new(polygon, text [, x] [, y])</dt>
-        <dd>
-          <p class="description">returns a new annotation</p>
-        </dd>
-        <dt>Annotations[index]</dt>
-        <dd>
-          <dl>
+<h2>
+<a name="custom"></a>Custom Fields</h2>
+<p>In a real Lua table, you can set any field you want. In order to help troubleshooting, Aleph One’s userdata tables will only accept the fields listed in the documentation below. However, by prepending an underscore, custom fields can be indexed. These custom fields will be associated with the object until it is destroyed.</p>
+<pre>Players[0]._favorite_flavor = "chocolate"</pre>
+<h2>
+<a name="table_indices"></a>Index</h2>
+<p>Each table has a read-only .index variable, that corresponds to the engine’s internal index.</p>
+<pre>=Players[0].index<br>0</pre>
+<h2>
+<a name="table_is"></a>is_ Functions</h2>
+<p>Aleph One installs a set of boolean functions that can be used to recognize each of the userdata table types. For example, <code>is_monster(Monsters[1])</code> returns true. Each of these functions begins with the "is_" prefix.</p>
+<h1><a name="tables">Tables</a></h1>
+<div class="tables">
+<h3>
+<a name="Annotations"></a>Annotations</h3>
+<dl>
+<dt># Annotations</dt>
+<dd><p class="description">number of map annotations</p></dd>
+<dt>Annotations()</dt>
+<dd><p class="description">iterates through all annotations</p></dd>
+<dt>Annotations.new(polygon, text [, x] [, y])</dt>
+<dd><p class="description">returns a new annotation</p></dd>
+<dt>Annotations[index]</dt>
+<dd><dl>
       <dt>.polygon</dt>
-            <dd>
-              <p class="description">polygon this annotation is associated with</p>
-              <p class="note">can be nil </p>
-              <p class="note">an annotation is only shown when its polygon is visible on the overhead map </p>
-            </dd>
+<dd>
+<p class="description">polygon this annotation is associated with</p>
+<p class="note">can be nil </p>
+<p class="note">an annotation is only shown when its polygon is visible on the overhead map </p>
+</dd>
       <dt>.text</dt>
-            <dd>
-              <p class="description">annotation text (64 characters max)</p>
-            </dd>
+<dd><p class="description">annotation text (64 characters max)</p></dd>
       <dt>.x</dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
+<dd><p class="description"></p></dd>
       <dt>.y</dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Cameras"></a>Cameras</h3>
-      <dl>
-        <dt># Cameras</dt>
-        <dd>
-          <p class="description">number of cameras</p>
-        </dd>
-        <dt>Cameras()</dt>
-        <dd>
-          <p class="description">iterates through all cameras</p>
-        </dd>
-        <dt>Cameras.new()</dt>
-        <dd>
-          <p class="description">returns a new uninitialized camera</p>
-          <p class="note">make sure to add path points and angles before activating the camera </p>
-        </dd>
-        <dt>Cameras[index]</dt>
-        <dd>
-          <dl>
+<dd><p class="description"></p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Cameras"></a>Cameras</h3>
+<dl>
+<dt># Cameras</dt>
+<dd><p class="description">number of cameras</p></dd>
+<dt>Cameras()</dt>
+<dd><p class="description">iterates through all cameras</p></dd>
+<dt>Cameras.new()</dt>
+<dd>
+<p class="description">returns a new uninitialized camera</p>
+<p class="note">make sure to add path points and angles before activating the camera </p>
+</dd>
+<dt>Cameras[index]</dt>
+<dd><dl>
       <dt>:activate(player)</dt>
-            <dd>
-              <p class="description">activate camera for player</p>
-            </dd>
+<dd><p class="description">activate camera for player</p></dd>
       <dt>:clear()</dt>
-            <dd>
-              <p class="description">deletes all path points and angles</p>
-            </dd>
+<dd><p class="description">deletes all path points and angles</p></dd>
       <dt>:deactivate()</dt>
-            <dd>
-              <p class="description">deactivates camera</p>
-            </dd>
+<dd><p class="description">deactivates camera</p></dd>
       <dt>.path_angles</dt>
-            <dd>
-              <dl>
-                <dt>:new(yaw, pitch, time)</dt>
-                <dd>
-                  <p class="description">adds a path angle</p>
-                </dd>
-              </dl>
-            </dd>
+<dd><dl>
+<dt>:new(yaw, pitch, time)</dt>
+<dd><p class="description">adds a path angle</p></dd>
+</dl></dd>
       <dt>.path_points</dt>
-            <dd>
-              <dl>
-                <dt>:new(x, y, z, polygon, time)</dt>
-                <dd>
-                  <p class="description">adds a path point</p>
-                </dd>
-              </dl>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Effects"></a>Effects</h3>
-      <dl>
-        <dt># Effects</dt>
-        <dd>
-          <p class="description">maximum number of effects</p>
-        </dd>
-        <dt>Effects()</dt>
-        <dd>
-          <p class="description">iterates through all valid effects</p>
-        </dd>
-        <dt>Effects.new(x, y, height, polygon, type) <span class="version">20111201</span></dt>
-        <dd>
-          <p class="description">returns a new effect</p>
-        </dd>
-        <dt>Effects[index]</dt>
-        <dd>
-          <dl>
-      <dt>:delete() <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">removes effect from map</p>
-            </dd>
-      <dt>.facing <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">direction effect is facing</p>
-            </dd>
-      <dt>:play_sound(sound) <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">play sound coming from this effect</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">polygon the effect is in</p>
-            </dd>
-      <dt>:position(x, y, z, polygon) <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">sets position of effect</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">type of effect</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Endpoints"></a>Endpoints</h3>
-      <dl>
-        <dt># Endpoints</dt>
-        <dd>
-          <p class="description">number of endpoints in level</p>
-        </dd>
-        <dt>Endpoints()</dt>
-        <dd>
-          <p class="description">iterates through all endpoints in the level</p>
-        </dd>
-        <dt>Endpoints[index]</dt>
-        <dd>
-          <dl>
-      <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Ephemera"></a>Ephemera <span class="version">20210408</span></h3>
+<dd><dl>
+<dt>:new(x, y, z, polygon, time)</dt>
+<dd><p class="description">adds a path point</p></dd>
+</dl></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Effects"></a>Effects</h3>
+<dl>
+<dt># Effects</dt>
+<dd><p class="description">maximum number of effects</p></dd>
+<dt>Effects()</dt>
+<dd><p class="description">iterates through all valid effects</p></dd>
+<dt>Effects.new(x, y, height, polygon, type) <span class="version">20111201</span>
+</dt>
+<dd><p class="description">returns a new effect</p></dd>
+<dt>Effects[index]</dt>
+<dd><dl>
+      <dt>:delete() <span class="version">20111201</span>
+</dt>
+<dd><p class="description">removes effect from map</p></dd>
+      <dt>.facing <span class="version">20111201</span>
+</dt>
+<dd><p class="description">direction effect is facing</p></dd>
+      <dt>:play_sound(sound) <span class="version">20111201</span>
+</dt>
+<dd><p class="description">play sound coming from this effect</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">polygon the effect is in</p></dd>
+      <dt>:position(x, y, z, polygon) <span class="version">20111201</span>
+</dt>
+<dd><p class="description">sets position of effect</p></dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">type of effect</p></dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Endpoints"></a>Endpoints</h3>
+<dl>
+<dt># Endpoints</dt>
+<dd><p class="description">number of endpoints in level</p></dd>
+<dt>Endpoints()</dt>
+<dd><p class="description">iterates through all endpoints in the level</p></dd>
+<dt>Endpoints[index]</dt>
+<dd><dl>
+      <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Ephemera"></a>Ephemera <span class="version">20210408</span>
+</h3>
 		<p>Ephemera are a render-only version of Effects. They were designed to be a lightweight way to add effects such as precipitation or decals. They do not use any global random functionality, and they don’t interact at all with other objects in the world, so they are safe to turn on and off without affecting net game sync and film playback (see <a href="#sync">"Net Games and Films"</a>).</p>
 		<p>Ephemera are not saved or restored in saved games, so it is up to the Lua script to serialize them and persist them if desired; and to recreate them upon resume. Likewise, ephemera custom fields are not saved/restored using <code>Level.restored_saved()</code></p>
 		<p><em>All</em> ephemera functions are "local player"</p>
 	  <dl>
-        <dt># Ephemera</dt>
-        <dd>
-          <p class="description">maximum number of ephemera</p>
-        </dd>
-        <dt>Ephemera()</dt>
-        <dd>
-          <p class="description">iterates through all valid ephemera</p>
-        </dd>
-        <dt>Ephemera.new(x, y, z, polygon, collection, sequence, facing)</dt>
-        <dd>
-          <p class="description">returns a new ephemera</p>
-        </dd>
-        <dt>Ephemera.quality<span class="access"> (read-only)</span></dt>
-        <dd>
-          <p class="description">user’s ephemera quality setting</p>
-          <p class="note">it is up to the script’s discretion how many ephemera to create / maintain, based on this quality setting; if set to off, ephemera are not rendered regardless of how many the script creates </p>
-        </dd>
-        <dt>Ephemera[index]</dt>
-        <dd>
-          <dl>
+<dt># Ephemera</dt>
+<dd><p class="description">maximum number of ephemera</p></dd>
+<dt>Ephemera()</dt>
+<dd><p class="description">iterates through all valid ephemera</p></dd>
+<dt>Ephemera.new(x, y, z, polygon, collection, sequence, facing)</dt>
+<dd><p class="description">returns a new ephemera</p></dd>
+<dt>Ephemera.quality<span class="access"> (read-only)</span>
+</dt>
+<dd>
+<p class="description">user’s ephemera quality setting</p>
+<p class="note">it is up to the script’s discretion how many ephemera to create / maintain, based on this quality setting; if set to off, ephemera are not rendered regardless of how many the script creates </p>
+</dd>
+<dt>Ephemera[index]</dt>
+<dd><dl>
 	  <dt>.clut_index</dt>
-            <dd>
-              <p class="description">color table of this ephemera</p>
-            </dd>
+<dd><p class="description">color table of this ephemera</p></dd>
 	  <dt>.collection</dt>
-            <dd>
-              <p class="description">shape collection of this ephemera</p>
-            </dd>
+<dd><p class="description">shape collection of this ephemera</p></dd>
 	  <dt>.end_when_animation_loops</dt>
-            <dd>
-              <p class="description">if set, ephemera is removed once animation finishes</p>
-            </dd>
+<dd><p class="description">if set, ephemera is removed once animation finishes</p></dd>
 	  <dt>:delete()</dt>
-            <dd>
-              <p class="description">removes ephemera from the level</p>
-            </dd>
+<dd><p class="description">removes ephemera from the level</p></dd>
 	  <dt>.enlarged</dt>
-            <dd>
-              <p class="description">ephemera is rendered 25% bigger</p>
-            </dd>
+<dd><p class="description">ephemera is rendered 25% bigger</p></dd>
 	  <dt>.facing</dt>
-            <dd>
-              <p class="description">direction the ephemera is facing</p>
-            </dd>
+<dd><p class="description">direction the ephemera is facing</p></dd>
 	  <dt>:position(x, y, z, polygon)</dt>
-            <dd>
-              <p class="description">sets position of ephemera</p>
-            </dd>
-	  <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon this ephemera is in</p>
-            </dd>
-	  <dt>.rendered<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether this ephemera was recently rendered</p>
-              <p class="note">you can use this to skip updating ephemera that aren’t currently visible </p>
-            </dd>
+<dd><p class="description">sets position of ephemera</p></dd>
+	  <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon this ephemera is in</p></dd>
+	  <dt>.rendered<span class="access"> (read-only)</span>
+</dt>
+<dd>
+<p class="description">whether this ephemera was recently rendered</p>
+<p class="note">you can use this to skip updating ephemera that aren’t currently visible </p>
+</dd>
 	  <dt>.shape_index</dt>
-            <dd>
-              <p class="description">shape index of ephemera</p>
-              <p class="note">Anvil calls this sequence </p>
-            </dd>
+<dd>
+<p class="description">shape index of ephemera</p>
+<p class="note">Anvil calls this sequence </p>
+</dd>
 	  <dt>.tiny</dt>
-            <dd>
-              <p class="description">ephemera is rendered 50% size</p>
-            </dd>
-	  <dt>.valid<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether ephemera is still valid</p>
-            </dd>
-	  <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.z<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	</dl>
-        </dd>
-      </dl>
-      <h3><a name="Game"></a>Game</h3>
-      <dl>
-        <dt>Game</dt>
-        <dd>
-          <dl>
-            <dt>.autosave() <span class="version">20250302</span></dt>
-            <dd>
-              <p class="description">saves the game without prompting the user, if possible</p>
-              <p class="note">solo only </p>
-            </dd>
-            <dt>.dead_players_drop_items <span class="version">20150619</span></dt>
-            <dd>
-              <p class="description">whether dead players drop items</p>
-            </dd>
-            <dt>.deserialize(s) <span class="version">20200830</span></dt>
-            <dd>
-              <p class="description">deserializes s and returns the original Lua value</p>
-              <p class="note">see Game.serialize </p>
-            </dd>
-            <dt>.difficulty<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">the difficulty level</p>
-            </dd>
-            <dt>.global_random(n)</dt>
-            <dd>
-              <p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p>
-            </dd>
-            <dt>.kill_limit<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">the game kill limit, or 0 if there is none</p>
-            </dd>
-            <dt>.local_random(n)</dt>
-            <dd>
-              <p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p>
-              <p class="note">use only for local player effects (see Net Games and Films) </p>
-            </dd>
-            <dt>.monsters_replenish <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether monsters spawn or not; in a net game, this corresponds to the "Aliens" checkbox</p>
-              <p class="note">this can suppress initial monster placement, if set to false directly when the script is loaded </p>
-            </dd>
-            <dt>.nonlocal_overlays <span class="version">20200830</span></dt>
-            <dd>
-              <p class="description">When false, only the local player’s overlays are used, and only prints to the local player will be displayed. When true, the overlays and prints of whatever player is currently being viewed will apply. This defaults to false for compatibility with scripts that depend on the old behavior.</p>
-            </dd>
-            <dt>.over<span class="access"> (write-only)</span></dt>
-            <dd>
-              <p class="description">Use this variable to override the game’s default scoring behavior. If set to false, the game will not end due to a score limit. If set to true, the game ends immediately. If left unset or if set to nil, the game will end if a score limit is reached. (Note that you cannot prevent the game from ending due to a time limit.)</p>
-            </dd>
-            <dt>.player <span class="version">20250829</span></dt>
-            <dd>
-              <p class="description">In Tag games, the player who is It. In Kill the Man With the Ball or Rugby games, the player who is carrying the ball</p>
-              <p class="note">writing to this will only work in Tag games </p>
-            </dd>
-            <dt>.proper_item_accounting <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">When true, the current item counts on the map are updated properly when Lua deletes map items and changes player inventories. This defaults to false to preserve film playback with older scripts. New scripts that manipulate items should always set this to true.</p>
-            </dd>
-            <dt>.random(n)</dt>
-            <dd>
-              <p class="description">returns a random number between 0 and n-1 using a good random number generator</p>
-            </dd>
-            <dt>.random_local(n) <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">returns a random number between 0 and n-1 using a good random number generator</p>
-              <p class="note">use only for local player effects (see Net Games and Films) </p>
-            </dd>
-            <dt>.replay<span class="access"> (read-only)</span> <span class="version">20221126</span></dt>
-            <dd>
-              <p class="description">is the script being run during a film replay</p>
-              <p class="note">use sparingly; altering the world differently during a replay than during live playback will cause the replay go out of sync </p>
-            </dd>
-            <dt>.restore_passed() <span class="version">20090909</span></dt>
-            <dd>
-              <p class="description">tries to restore any Player or Game custom fields from before the last level jump; returns true if custom fields were successfully restored</p>
-              <p class="note">if successful, overwrites all existing Player or Game custom fields </p>
-            </dd>
-            <dt>.restore_saved() <span class="version">20090909</span></dt>
-            <dd>
-              <p class="description">tries to restore any custom fields from the saved game; returns true if custom fields were successfully restored</p>
-              <p class="note">if successful, overwrites all existing custom fields </p>
-            </dd>
-            <dt>.save()</dt>
-            <dd>
-              <p class="description">saves the game (as if the user had activated a pattern buffer)</p>
-              <p class="note">solo only </p>
-            </dd>
-            <dt>.scoring_mode</dt>
-            <dd>
-              <p class="description">the current scoring mode (if the gametype is "custom")</p>
-            </dd>
-            <dt>.serialize(v) <span class="version">20200830</span></dt>
-            <dd>
-              <p class="description">serializes v into a binary string</p>
-              <p class="note">only numbers, strings, booleans, and tables (including Aleph One’s built-in userdata tables) can be serialized </p>
-            </dd>
-            <dt>.ticks<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">ticks since game started</p>
-            </dd>
-            <dt>.time_remaining<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">the number of ticks until the game ends, or nil if there is no time limit</p>
-            </dd>
-            <dt>.type<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether the game is EMFH, KOTH, etc.</p>
-            </dd>
-            <dt>.version<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">the date version of the local player’s engine</p>
-              <p class="note">for example, "20071103" </p>
-            </dd>
-          </dl>
-        </dd>
-      </dl>
-      <h3><a name="Goals"></a>Goals</h3>
-      <dl>
-        <dt># Goals</dt>
-        <dd>
-          <p class="description">number of saved map objects (of all types)</p>
-        </dd>
-        <dt>Goals()</dt>
-        <dd>
-          <p class="description">iterates through all goals</p>
-        </dd>
-        <dt>Goals[index]</dt>
-        <dd>
-          <dl>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">direction goal is facing</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">polygon the goal is in</p>
-            </dd>
-      <dt>.id<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">ID number of goal</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-              <p class="note">from floor or ceiling </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Items"></a>Items</h3>
-      <dl>
-        <dt># Items</dt>
-        <dd>
-          <p class="description">maximum number of map objects</p>
-        </dd>
-        <dt>Items()</dt>
-        <dd>
-          <p class="description">iterates through all valid items</p>
-        </dd>
-        <dt>Items.new(x, y, height, polygon, type)</dt>
-        <dd>
-          <p class="description">returns a new item</p>
-        </dd>
-        <dt>Items[index]</dt>
-        <dd>
-          <dl>
+<dd><p class="description">ephemera is rendered 50% size</p></dd>
+	  <dt>.valid<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether ephemera is still valid</p></dd>
+	  <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.z<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+	</dl></dd>
+</dl>
+<h3>
+<a name="Game"></a>Game</h3>
+<dl>
+<dt>Game</dt>
+<dd><dl>
+<dt>.autosave() <span class="version">20250302</span>
+</dt>
+<dd>
+<p class="description">saves the game without prompting the user, if possible</p>
+<p class="note">solo only </p>
+</dd>
+<dt>.dead_players_drop_items <span class="version">20150619</span>
+</dt>
+<dd><p class="description">whether dead players drop items</p></dd>
+<dt>.deserialize(s) <span class="version">20200830</span>
+</dt>
+<dd>
+<p class="description">deserializes s and returns the original Lua value</p>
+<p class="note">see Game.serialize </p>
+</dd>
+<dt>.difficulty<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">the difficulty level</p></dd>
+<dt>.global_random(n)</dt>
+<dd><p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p></dd>
+<dt>.kill_limit<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">the game kill limit, or 0 if there is none</p></dd>
+<dt>.local_random(n)</dt>
+<dd>
+<p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p>
+<p class="note">use only for local player effects (see Net Games and Films) </p>
+</dd>
+<dt>.monsters_replenish <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description">whether monsters spawn or not; in a net game, this corresponds to the "Aliens" checkbox</p>
+<p class="note">this can suppress initial monster placement, if set to false directly when the script is loaded </p>
+</dd>
+<dt>.nonlocal_overlays <span class="version">20200830</span>
+</dt>
+<dd><p class="description">When false, only the local player’s overlays are used, and only prints to the local player will be displayed. When true, the overlays and prints of whatever player is currently being viewed will apply. This defaults to false for compatibility with scripts that depend on the old behavior.</p></dd>
+<dt>.over<span class="access"> (write-only)</span>
+</dt>
+<dd><p class="description">Use this variable to override the game’s default scoring behavior. If set to false, the game will not end due to a score limit. If set to true, the game ends immediately. If left unset or if set to nil, the game will end if a score limit is reached. (Note that you cannot prevent the game from ending due to a time limit.)</p></dd>
+<dt>.player <span class="version">20250829</span>
+</dt>
+<dd>
+<p class="description">In Tag games, the player who is It. In Kill the Man With the Ball or Rugby games, the player who is carrying the ball</p>
+<p class="note">writing to this will only work in Tag games </p>
+</dd>
+<dt>.proper_item_accounting <span class="version">20100118</span>
+</dt>
+<dd><p class="description">When true, the current item counts on the map are updated properly when Lua deletes map items and changes player inventories. This defaults to false to preserve film playback with older scripts. New scripts that manipulate items should always set this to true.</p></dd>
+<dt>.random(n)</dt>
+<dd><p class="description">returns a random number between 0 and n-1 using a good random number generator</p></dd>
+<dt>.random_local(n) <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">returns a random number between 0 and n-1 using a good random number generator</p>
+<p class="note">use only for local player effects (see Net Games and Films) </p>
+</dd>
+<dt>.replay<span class="access"> (read-only)</span> <span class="version">20221126</span>
+</dt>
+<dd>
+<p class="description">is the script being run during a film replay</p>
+<p class="note">use sparingly; altering the world differently during a replay than during live playback will cause the replay go out of sync </p>
+</dd>
+<dt>.restore_passed() <span class="version">20090909</span>
+</dt>
+<dd>
+<p class="description">tries to restore any Player or Game custom fields from before the last level jump; returns true if custom fields were successfully restored</p>
+<p class="note">if successful, overwrites all existing Player or Game custom fields </p>
+</dd>
+<dt>.restore_saved() <span class="version">20090909</span>
+</dt>
+<dd>
+<p class="description">tries to restore any custom fields from the saved game; returns true if custom fields were successfully restored</p>
+<p class="note">if successful, overwrites all existing custom fields </p>
+</dd>
+<dt>.save()</dt>
+<dd>
+<p class="description">saves the game (as if the user had activated a pattern buffer)</p>
+<p class="note">solo only </p>
+</dd>
+<dt>.scoring_mode</dt>
+<dd><p class="description">the current scoring mode (if the gametype is "custom")</p></dd>
+<dt>.serialize(v) <span class="version">20200830</span>
+</dt>
+<dd>
+<p class="description">serializes v into a binary string</p>
+<p class="note">only numbers, strings, booleans, and tables (including Aleph One’s built-in userdata tables) can be serialized </p>
+</dd>
+<dt>.ticks<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">ticks since game started</p></dd>
+<dt>.time_remaining<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">the number of ticks until the game ends, or nil if there is no time limit</p></dd>
+<dt>.type<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether the game is EMFH, KOTH, etc.</p></dd>
+<dt>.version<span class="access"> (read-only)</span>
+</dt>
+<dd>
+<p class="description">the date version of the local player’s engine</p>
+<p class="note">for example, "20071103" </p>
+</dd>
+</dl></dd>
+</dl>
+<h3>
+<a name="Goals"></a>Goals</h3>
+<dl>
+<dt># Goals</dt>
+<dd><p class="description">number of saved map objects (of all types)</p></dd>
+<dt>Goals()</dt>
+<dd><p class="description">iterates through all goals</p></dd>
+<dt>Goals[index]</dt>
+<dd><dl>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">direction goal is facing</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">polygon the goal is in</p></dd>
+      <dt>.id<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">ID number of goal</p></dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description"></p>
+<p class="note">from floor or ceiling </p>
+</dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="ItemStarts"></a>ItemStarts</h3>
+<dl>
+<dt># ItemStarts</dt>
+<dd><p class="description">number of map objects in the level</p></dd>
+<dt>ItemStarts()</dt>
+<dd><p class="description">iterates through all item starting locations in the level</p></dd>
+<dt>ItemStarts[index]</dt>
+<dd><dl>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">direction item is initially facing</p></dd>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether item location z is from ceiling</p></dd>
+      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether item will teleport in</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">item starting location polygon</p></dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">type of item</p></dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description"></p>
+<p class="note">from floor or ceiling </p>
+</dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Items"></a>Items</h3>
+<dl>
+<dt># Items</dt>
+<dd><p class="description">maximum number of map objects</p></dd>
+<dt>Items()</dt>
+<dd><p class="description">iterates through all valid items</p></dd>
+<dt>Items.new(x, y, height, polygon, type)</dt>
+<dd><p class="description">returns a new item</p></dd>
+<dt>Items[index]</dt>
+<dd><dl>
       <dt>:delete()</dt>
-            <dd>
-              <p class="description">removes item from map</p>
-            </dd>
+<dd><p class="description">removes item from map</p></dd>
       <dt>.facing</dt>
-            <dd>
-              <p class="description">direction item is facing</p>
-            </dd>
+<dd><p class="description">direction item is facing</p></dd>
       <dt>:play_sound(sound)</dt>
-            <dd>
-              <p class="description">play sound coming from this item</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon the item is in</p>
-            </dd>
-      <dt>:position(x, y, z, polygon) <span class="version">20090909</span></dt>
-            <dd>
-              <p class="description">sets position of item</p>
-            </dd>
-	  <dt>:teleport_in() <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">teleports item in</p>
-              <p class="note">can fail silently if there are not enough effects slots </p>
-            </dd>
-	  <dt>:teleport_out() <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">teleports item out</p>
-              <p class="note">can fail silently if there are not enough effects slots </p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">type of item</p>
-            </dd>
-      <dt>.visible <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="ItemStarts"></a>ItemStarts</h3>
-      <dl>
-        <dt># ItemStarts</dt>
-        <dd>
-          <p class="description">number of map objects in the level</p>
-        </dd>
-        <dt>ItemStarts()</dt>
-        <dd>
-          <p class="description">iterates through all item starting locations in the level</p>
-        </dd>
-        <dt>ItemStarts[index]</dt>
-        <dd>
-          <dl>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">direction item is initially facing</p>
-            </dd>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether item location z is from ceiling</p>
-            </dd>
-      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether item will teleport in</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">item starting location polygon</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">type of item</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-              <p class="note">from floor or ceiling </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Level"></a>Level</h3>
-      <dl>
-        <dt>Level</dt>
-        <dd>
-          <dl>
-            <dt>.calculate_completion_state() <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">returns whether level is finished, unfinished, or failed</p>
-              <p class="note">does not call the trigger, so it can be used in the trigger </p>
-            </dd>
-            <dt>.completed<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">check this in Triggers.cleanup() to determine whether the player(s) teleported out</p>
-            </dd>
-            <dt>.extermination<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">whether level has extermination flag set</p>
-            </dd>
-            <dt>.exploration<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">whether level has exploration flag set</p>
-            </dd>
-            <dt>.fog<br>.underwater_fog</dt>
-            <dd>
-              <dl>
-                <dt>.active<br>.present</dt>
-                <dd>
-                  <p class="description">whether fog is present</p>
-                </dd>
-                <dt>.affects_landscapes</dt>
-                <dd>
-                  <p class="description">whether fog affects landscapes</p>
-                </dd>
-                <dt>.color</dt>
-                <dd>
-                  <p class="note">values range from 0.0 to 1.0 </p>
-                  <dl>
-                    <dt>.b</dt>
-                    <dd>
-                      <p class="description">blue</p>
-                    </dd>
-                    <dt>.g</dt>
-                    <dd>
-                      <p class="description">green</p>
-                    </dd>
-                    <dt>.r</dt>
-                    <dd>
-                      <p class="description">red</p>
-                    </dd>
-                  </dl>
-                </dd>
-                <dt>.depth</dt>
-                <dd>
-                  <p class="description">fog depth in WU</p>
-                </dd>
-                <dt>.landscape_mix <span class="version">20231125</span></dt>
-                <dd>
-                  <p class="description">amount of fog to mix into landscape</p>
-                  <p class="note">values range from 0.0 to 1.0 </p>
-                </dd>
-                <dt>.mode <span class="version">20231125</span></dt>
-                <dd>
-                  <p class="description">linear, exp, or exp2</p>
-                </dd>
-                <dt>.start <span class="version">20231125</span></dt>
-                <dd>
-                  <p class="description">fog start in WU</p>
-                  <p class="note">only applies to linear fog </p>
-                </dd>
-              </dl>
-            </dd>
-            <dt>.low_gravity<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether level is low gravity</p>
-            </dd>
-            <dt>.magnetic<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether level is magnetic</p>
-            </dd>
-            <dt>.name<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">level name</p>
-            </dd>
-            <dt>.index<span class="access"> (read-only)</span> <span class="version">20150619</span></dt>
-            <dd>
-              <p class="description">level index in the map file (starting from 0)</p>
-            </dd>
-            <dt>.map_checksum<span class="access"> (read-only)</span> <span class="version">20150619</span></dt>
-            <dd>
-              <p class="description">checksum of map file</p>
-            </dd>
-            <dt>.rebellion<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether level is rebellion</p>
-            </dd>
-            <dt>.repair<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">whether level has repair flag set</p>
-            </dd>
-            <dt>.rescue<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">whether level has rescue flag set</p>
-            </dd>
-            <dt>.retrieval<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">whether level has retrieval flag set</p>
-            </dd>
-            <dt>.stash[key] <span class="version">20200830</span></dt>
-            <dd>
-              <p class="description">reads/writes values to a stash shared between all running Lua scripts</p>
-              <p class="note">keys/values must be strings </p>
-            </dd>
-            <dt>.vacuum<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether level is vacuum</p>
-            </dd>
-          </dl>
-        </dd>
-      </dl>
-      <h3><a name="Lights"></a>Lights</h3>
-      <dl>
-        <dt># Lights</dt>
-        <dd>
-          <p class="description">number of lights in level</p>
-        </dd>
-        <dt>Lights()</dt>
-        <dd>
-          <p class="description">iterates through all lights in the level</p>
-        </dd>
-        <dt>Lights.new( [light_preset])</dt>
-        <dd>
-          <p class="description">returns a new light</p>
-        </dd>
-        <dt>Lights[index]</dt>
-        <dd>
-          <dl>
+<dd><p class="description">play sound coming from this item</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon the item is in</p></dd>
+      <dt>:position(x, y, z, polygon) <span class="version">20090909</span>
+</dt>
+<dd><p class="description">sets position of item</p></dd>
+	  <dt>:teleport_in() <span class="version">20240712</span>
+</dt>
+<dd>
+<p class="description">teleports item in</p>
+<p class="note">can fail silently if there are not enough effects slots </p>
+</dd>
+	  <dt>:teleport_out() <span class="version">20240712</span>
+</dt>
+<dd>
+<p class="description">teleports item out</p>
+<p class="note">can fail silently if there are not enough effects slots </p>
+</dd>
+      <dt>.type<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of item</p></dd>
+      <dt>.visible <span class="version">20240712</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Level"></a>Level</h3>
+<dl>
+<dt>Level</dt>
+<dd><dl>
+<dt>.calculate_completion_state() <span class="version">20081213</span>
+</dt>
+<dd>
+<p class="description">returns whether level is finished, unfinished, or failed</p>
+<p class="note">does not call the trigger, so it can be used in the trigger </p>
+</dd>
+<dt>.completed<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">check this in Triggers.cleanup() to determine whether the player(s) teleported out</p></dd>
+<dt>.extermination<span class="access"> (read-only)</span> <span class="version">20081213</span>
+</dt>
+<dd><p class="description">whether level has extermination flag set</p></dd>
+<dt>.exploration<span class="access"> (read-only)</span> <span class="version">20081213</span>
+</dt>
+<dd><p class="description">whether level has exploration flag set</p></dd>
+<dt>.fog<br>.underwater_fog</dt>
+<dd><dl>
+<dt>.active<br>.present</dt>
+<dd><p class="description">whether fog is present</p></dd>
+<dt>.affects_landscapes</dt>
+<dd><p class="description">whether fog affects landscapes</p></dd>
+<dt>.color</dt>
+<dd>
+<p class="note">values range from 0.0 to 1.0 </p>
+<dl>
+<dt>.b</dt>
+<dd><p class="description">blue</p></dd>
+<dt>.g</dt>
+<dd><p class="description">green</p></dd>
+<dt>.r</dt>
+<dd><p class="description">red</p></dd>
+</dl>
+</dd>
+<dt>.depth</dt>
+<dd><p class="description">fog depth in WU</p></dd>
+<dt>.landscape_mix <span class="version">20231125</span>
+</dt>
+<dd>
+<p class="description">amount of fog to mix into landscape</p>
+<p class="note">values range from 0.0 to 1.0 </p>
+</dd>
+<dt>.mode <span class="version">20231125</span>
+</dt>
+<dd><p class="description">linear, exp, or exp2</p></dd>
+<dt>.start <span class="version">20231125</span>
+</dt>
+<dd>
+<p class="description">fog start in WU</p>
+<p class="note">only applies to linear fog </p>
+</dd>
+</dl></dd>
+<dt>.low_gravity<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether level is low gravity</p></dd>
+<dt>.magnetic<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether level is magnetic</p></dd>
+<dt>.name<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">level name</p></dd>
+<dt>.index<span class="access"> (read-only)</span> <span class="version">20150619</span>
+</dt>
+<dd><p class="description">level index in the map file (starting from 0)</p></dd>
+<dt>.map_checksum<span class="access"> (read-only)</span> <span class="version">20150619</span>
+</dt>
+<dd><p class="description">checksum of map file</p></dd>
+<dt>.rebellion<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether level is rebellion</p></dd>
+<dt>.repair<span class="access"> (read-only)</span> <span class="version">20081213</span>
+</dt>
+<dd><p class="description">whether level has repair flag set</p></dd>
+<dt>.rescue<span class="access"> (read-only)</span> <span class="version">20081213</span>
+</dt>
+<dd><p class="description">whether level has rescue flag set</p></dd>
+<dt>.retrieval<span class="access"> (read-only)</span> <span class="version">20081213</span>
+</dt>
+<dd><p class="description">whether level has retrieval flag set</p></dd>
+<dt>.stash[key] <span class="version">20200830</span>
+</dt>
+<dd>
+<p class="description">reads/writes values to a stash shared between all running Lua scripts</p>
+<p class="note">keys/values must be strings </p>
+</dd>
+<dt>.vacuum<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether level is vacuum</p></dd>
+</dl></dd>
+</dl>
+<h3>
+<a name="Lights"></a>Lights</h3>
+<dl>
+<dt># Lights</dt>
+<dd><p class="description">number of lights in level</p></dd>
+<dt>Lights()</dt>
+<dd><p class="description">iterates through all lights in the level</p></dd>
+<dt>Lights.new( [light_preset])</dt>
+<dd><p class="description">returns a new light</p></dd>
+<dt>Lights[index]</dt>
+<dd><dl>
       <dt>.active</dt>
-            <dd>
-              <p class="description">whether light is active</p>
-            </dd>
-      <dt>.tag <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">tag of light</p>
-            </dd>
-      <dt>.initial_phase <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">phase the light starts with</p>
-            </dd>
-      <dt>.initially_active <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">whether the light was initially active</p>
-            </dd>
-      <dt>.intensity<span class="access"> (read-only)</span> <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">current intensity for this light (range: 0-1)</p>
-            </dd>
+<dd><p class="description">whether light is active</p></dd>
+      <dt>.tag <span class="version">20100118</span>
+</dt>
+<dd><p class="description">tag of light</p></dd>
+      <dt>.initial_phase <span class="version">20100118</span>
+</dt>
+<dd><p class="description">phase the light starts with</p></dd>
+      <dt>.initially_active <span class="version">20100118</span>
+</dt>
+<dd><p class="description">whether the light was initially active</p></dd>
+      <dt>.intensity<span class="access"> (read-only)</span> <span class="version">20100118</span>
+</dt>
+<dd><p class="description">current intensity for this light (range: 0-1)</p></dd>
       <dt>
     .states[light_type]</dt>
-            <dd>
-              <dl>
-                <dt>.delta_intensity <span class="version">20100118</span></dt>
-                <dd>
-                  <p class="description">random intensity change for this state</p>
-                </dd>
-                <dt>.delta_period <span class="version">20100118</span></dt>
-                <dd>
-                  <p class="description">random period change for this state</p>
-                </dd>
-                <dt>.intensity <span class="version">20100118</span></dt>
-                <dd>
-                  <p class="description">intensity for this state</p>
-                </dd>
-                <dt>.light_function <span class="version">20100118</span></dt>
-                <dd>
-                  <p class="description">light function for this state</p>
-                </dd>
-                <dt>.period <span class="version">20100118</span></dt>
-                <dd>
-                  <p class="description">period for this state</p>
-                </dd>
-              </dl>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Lines"></a>Lines</h3>
-      <dl>
-        <dt># Lines</dt>
-        <dd>
-          <p class="description">number of lines in level</p>
-        </dd>
-        <dt>Lines()</dt>
-        <dd>
-          <p class="description">iterates through all lines in the level</p>
-        </dd>
-        <dt>Lines[index]</dt>
-        <dd>
-          <dl>
-      <dt>.clockwise_polygon<span class="access"> (read-only)</span><br>.cw_polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon on clockwise side of line</p>
-            </dd>
-      <dt>.clockwise_side<span class="access"> (read-only)</span><br>.cw_side<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">clockwise side of line</p>
-            </dd>
-      <dt>.counterclockwise_polygon<span class="access"> (read-only)</span><br>.ccw_polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon on counterclockwise side of line</p>
-            </dd>
-      <dt>.counterclockwise_side<span class="access"> (read-only)</span><br>.ccw_side<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">counterclockwise side of line</p>
-            </dd>
-	  <dt>.decorative <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">projectiles always pass the transparent sides of decorative lines</p>
-            </dd>
+<dd><dl>
+<dt>.delta_intensity <span class="version">20100118</span>
+</dt>
+<dd><p class="description">random intensity change for this state</p></dd>
+<dt>.delta_period <span class="version">20100118</span>
+</dt>
+<dd><p class="description">random period change for this state</p></dd>
+<dt>.intensity <span class="version">20100118</span>
+</dt>
+<dd><p class="description">intensity for this state</p></dd>
+<dt>.light_function <span class="version">20100118</span>
+</dt>
+<dd><p class="description">light function for this state</p></dd>
+<dt>.period <span class="version">20100118</span>
+</dt>
+<dd><p class="description">period for this state</p></dd>
+</dl></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Lines"></a>Lines</h3>
+<dl>
+<dt># Lines</dt>
+<dd><p class="description">number of lines in level</p></dd>
+<dt>Lines()</dt>
+<dd><p class="description">iterates through all lines in the level</p></dd>
+<dt>Lines[index]</dt>
+<dd><dl>
+      <dt>.clockwise_polygon<span class="access"> (read-only)</span><br>.cw_polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon on clockwise side of line</p></dd>
+      <dt>.clockwise_side<span class="access"> (read-only)</span><br>.cw_side<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">clockwise side of line</p></dd>
+      <dt>.counterclockwise_polygon<span class="access"> (read-only)</span><br>.ccw_polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon on counterclockwise side of line</p></dd>
+      <dt>.counterclockwise_side<span class="access"> (read-only)</span><br>.ccw_side<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">counterclockwise side of line</p></dd>
+	  <dt>.decorative <span class="version">20210408</span>
+</dt>
+<dd><p class="description">projectiles always pass the transparent sides of decorative lines</p></dd>
       <dt>
     .endpoints[n]</dt>
-            <dd>
-              <p class="description">returns line endpoint n</p>
-            </dd>
-      <dt>.has_transparent_side<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">whether one of the line’s sides has a transparent texture</p>
-            </dd>
-      <dt>.highest_adjacent_floor<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">height of higher adjacent polygon floor</p>
-            </dd>
-      <dt>.length<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">the length of this line</p>
-              <p class="note">this might not be accurate, if someone used Chisel’s stretch plugin </p>
-            </dd>
-      <dt>.lowest_adjacent_ceiling<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">height of lower adjacent polygon ceiling</p>
-            </dd>
-      <dt>.solid<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">whether line is solid</p>
-            </dd>
-      <dt>.visible_on_automap <span class="version">20150619</span></dt>
-            <dd>
-              <p class="description">whether line is revealed on local player’s automap</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Media"></a>Media</h3>
-      <dl>
-        <dt># Media</dt>
-        <dd>
-          <p class="description">number of media (liquids) on the level</p>
-        </dd>
-        <dt>Media()</dt>
-        <dd>
-          <p class="description">iterates through all media on the level</p>
-        </dd>
-        <dt>Media.new() <span class="version">20210408</span></dt>
-        <dd>
-          <p class="description">returns a new liquid</p>
-        </dd>
-        <dt>Media[index]</dt>
-        <dd>
-          <dl>
-      <dt>.direction <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">direction of media</p>
-            </dd>
-      <dt>.height<span class="access"> (read-only)</span> <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">height of media</p>
-            </dd>
-      <dt>.high <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">high tide of media</p>
-            </dd>
-      <dt>.light <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">light that controls this media’s tide</p>
-            </dd>
-      <dt>.low <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">low tide of media</p>
-            </dd>
-      <dt>.speed <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">speed of media</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">type of media</p>
-            </dd>
-      <dt>.type <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">type of media</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Monsters"></a>Monsters</h3>
-      <dl>
-        <dt># Monsters</dt>
-        <dd>
-          <p class="description">maximum number of monsters</p>
-        </dd>
-        <dt>Monsters()</dt>
-        <dd>
-          <p class="description">iterates through all valid monsters (including player monsters)</p>
-        </dd>
-        <dt>Monsters.new(x, y, height, polygon, type)</dt>
-        <dd>
-          <p class="description">returns a new monster</p>
-        </dd>
-        <dt>Monsters[index]</dt>
-        <dd>
-          <dl>
-      <dt>:accelerate(direction, velocity, vertical_velocity) <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">accelerates monster</p>
-            </dd>
-      <dt>.action<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">current AI action of the monster</p>
-            </dd>
+<dd><p class="description">returns line endpoint n</p></dd>
+      <dt>.has_transparent_side<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">whether one of the line’s sides has a transparent texture</p></dd>
+      <dt>.highest_adjacent_floor<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">height of higher adjacent polygon floor</p></dd>
+      <dt>.length<span class="access"> (read-only)</span>
+</dt>
+<dd>
+<p class="description">the length of this line</p>
+<p class="note">this might not be accurate, if someone used Chisel’s stretch plugin </p>
+</dd>
+      <dt>.lowest_adjacent_ceiling<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">height of lower adjacent polygon ceiling</p></dd>
+      <dt>.solid<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">whether line is solid</p></dd>
+      <dt>.visible_on_automap <span class="version">20150619</span>
+</dt>
+<dd><p class="description">whether line is revealed on local player’s automap</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Media"></a>Media</h3>
+<dl>
+<dt># Media</dt>
+<dd><p class="description">number of media (liquids) on the level</p></dd>
+<dt>Media()</dt>
+<dd><p class="description">iterates through all media on the level</p></dd>
+<dt>Media.new() <span class="version">20210408</span>
+</dt>
+<dd><p class="description">returns a new liquid</p></dd>
+<dt>Media[index]</dt>
+<dd><dl>
+      <dt>.direction <span class="version">20100118</span>
+</dt>
+<dd><p class="description">direction of media</p></dd>
+      <dt>.height<span class="access"> (read-only)</span> <span class="version">20100118</span>
+</dt>
+<dd><p class="description">height of media</p></dd>
+      <dt>.high <span class="version">20100118</span>
+</dt>
+<dd><p class="description">high tide of media</p></dd>
+      <dt>.light <span class="version">20100118</span>
+</dt>
+<dd><p class="description">light that controls this media’s tide</p></dd>
+      <dt>.low <span class="version">20100118</span>
+</dt>
+<dd><p class="description">low tide of media</p></dd>
+      <dt>.speed <span class="version">20100118</span>
+</dt>
+<dd><p class="description">speed of media</p></dd>
+      <dt>.type<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of media</p></dd>
+      <dt>.type <span class="version">20100118</span>
+</dt>
+<dd><p class="description">type of media</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="MonsterStarts"></a>MonsterStarts</h3>
+<dl>
+<dt># MonsterStarts</dt>
+<dd><p class="description">number of map objects in the level</p></dd>
+<dt>MonsterStarts()</dt>
+<dd><p class="description">iterates through all monster starting locations in the level</p></dd>
+<dt>MonsterStarts[index]</dt>
+<dd><dl>
+      <dt>.blind<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether monster is activated by sight</p></dd>
+      <dt>.deaf<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether monster is activated by sound</p></dd>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">direction monster is initially facing</p></dd>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether monster location z is from ceiling</p></dd>
+      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether monster will teleport in when activated</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">monster starting location polygon</p></dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">type of monster</p></dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description"></p>
+<p class="note">from floor or ceiling </p>
+</dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Monsters"></a>Monsters</h3>
+<dl>
+<dt># Monsters</dt>
+<dd><p class="description">maximum number of monsters</p></dd>
+<dt>Monsters()</dt>
+<dd><p class="description">iterates through all valid monsters (including player monsters)</p></dd>
+<dt>Monsters.new(x, y, height, polygon, type)</dt>
+<dd><p class="description">returns a new monster</p></dd>
+<dt>Monsters[index]</dt>
+<dd><dl>
+      <dt>:accelerate(direction, velocity, vertical_velocity) <span class="version">20081213</span>
+</dt>
+<dd><p class="description">accelerates monster</p></dd>
+      <dt>.action<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">current AI action of the monster</p></dd>
       <dt>.active</dt>
-            <dd>
-              <p class="description">whether monster has been activated</p>
-            </dd>
+<dd><p class="description">whether monster has been activated</p></dd>
       <dt>:attack(target)</dt>
-            <dd>
-              <p class="description">instructs monster to attack target</p>
-            </dd>
-	  <dt>.blind <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">monster is blind</p>
-              <p class="note">only valid before monster activates </p>
-            </dd>
+<dd><p class="description">instructs monster to attack target</p></dd>
+	  <dt>.blind <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">monster is blind</p>
+<p class="note">only valid before monster activates </p>
+</dd>
       <dt>:damage(amount [, type])</dt>
-            <dd>
-              <p class="description">damages monster</p>
-              <p class="note">if no type is specified, fist damage is dealt </p>
-            </dd>
-	  <dt>.deaf <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">monster is deaf</p>
-              <p class="note">only valid before monster activates </p>
-            </dd>
-	  <dt>:delete() <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">deletes monster</p>
-            </dd>
-      <dt>.external_velocity <span class="version">20090909</span></dt>
-            <dd>
-              <p class="description">monster’s current external velocity (always in the opposite direction of facing)</p>
-            </dd>
+<dd>
+<p class="description">damages monster</p>
+<p class="note">if no type is specified, fist damage is dealt </p>
+</dd>
+	  <dt>.deaf <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">monster is deaf</p>
+<p class="note">only valid before monster activates </p>
+</dd>
+	  <dt>:delete() <span class="version">20210408</span>
+</dt>
+<dd><p class="description">deletes monster</p></dd>
+      <dt>.external_velocity <span class="version">20090909</span>
+</dt>
+<dd><p class="description">monster’s current external velocity (always in the opposite direction of facing)</p></dd>
       <dt>.facing<br>.yaw</dt>
-            <dd>
-              <p class="description">direction the monster is facing</p>
-            </dd>
+<dd><p class="description">direction the monster is facing</p></dd>
       <dt>.life<br>.vitality</dt>
-            <dd>
-              <p class="description">the monster’s vitality</p>
-              <p class="note">monsters that haven’t spawned or teleported in yet don’t have vitality </p>
-            </dd>
-      <dt>.mode<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">current AI mode of the monster</p>
-            </dd>
+<dd>
+<p class="description">the monster’s vitality</p>
+<p class="note">monsters that haven’t spawned or teleported in yet don’t have vitality </p>
+</dd>
+      <dt>.mode<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">current AI mode of the monster</p></dd>
       <dt>:move_by_path(polygon)</dt>
-            <dd>
-              <p class="description">instructs monster to move to polygon</p>
-              <p class="note">monsters get distracted easily en route </p>
-              <p class="note">once it gets there, it probably won’t choose to stay </p>
-            </dd>
-      <dt>.player<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">if monster is a player monster, the player; otherwise, nil</p>
-            </dd>
+<dd>
+<p class="description">instructs monster to move to polygon</p>
+<p class="note">monsters get distracted easily en route </p>
+<p class="note">once it gets there, it probably won’t choose to stay </p>
+</dd>
+      <dt>.player<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">if monster is a player monster, the player; otherwise, nil</p></dd>
       <dt>:play_sound(sound)</dt>
-            <dd>
-              <p class="description">plays sound coming from this monster</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon this monster is in</p>
-            </dd>
+<dd><p class="description">plays sound coming from this monster</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon this monster is in</p></dd>
       <dt>:position(x, y, z, polygon)</dt>
-            <dd>
-              <p class="description">sets position of monster</p>
-            </dd>
-	  <dt>.teleports_out <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">monster teleports out when deactivated</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">type of monster</p>
-            </dd>
-      <dt>.valid<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether monster is still valid</p>
-            </dd>
-      <dt>.vertical_velocity <span class="version">20090909</span></dt>
-            <dd>
-              <p class="description">monster’s current vertical external velocity</p>
-            </dd>
+<dd><p class="description">sets position of monster</p></dd>
+	  <dt>.teleports_out <span class="version">20210408</span>
+</dt>
+<dd><p class="description">monster teleports out when deactivated</p></dd>
+      <dt>.type<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of monster</p></dd>
+      <dt>.valid<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether monster is still valid</p></dd>
+      <dt>.vertical_velocity <span class="version">20090909</span>
+</dt>
+<dd><p class="description">monster’s current vertical external velocity</p></dd>
       <dt>.visible</dt>
-            <dd>
-              <p class="description">whether monster is visible (e.g. has teleported in)</p>
-              <p class="note">this has nothing to do with whether monsters are cloaked (like invisible S’pht) or not </p>
-              <p class="note">only writable before the monster is activated </p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="MonsterStarts"></a>MonsterStarts</h3>
-      <dl>
-        <dt># MonsterStarts</dt>
-        <dd>
-          <p class="description">number of map objects in the level</p>
-        </dd>
-        <dt>MonsterStarts()</dt>
-        <dd>
-          <p class="description">iterates through all monster starting locations in the level</p>
-        </dd>
-        <dt>MonsterStarts[index]</dt>
-        <dd>
-          <dl>
-      <dt>.blind<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether monster is activated by sight</p>
-            </dd>
-      <dt>.deaf<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether monster is activated by sound</p>
-            </dd>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">direction monster is initially facing</p>
-            </dd>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether monster location z is from ceiling</p>
-            </dd>
-      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether monster will teleport in when activated</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">monster starting location polygon</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">type of monster</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-              <p class="note">from floor or ceiling </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Music"></a>Music</h3>
-      <dl>
-        <dt># Music</dt>
-        <dd>
-          <p class="description">maximum number of music channels active simultaneously</p>
-        </dd>
-        <dt>Music()</dt>
-        <dd>
-          <p class="description">iterates through all the music channels</p>
-        </dd>
-        <dt>Music.new( [track] [, volume] [, loop]) <span class="version">20231125</span></dt>
-        <dd>
-          <p class="description">returns a new music channel</p>
-          <p class="note">the track file parameter should be omitted for segmented music and add_track should be used instead </p>
-          <p class="note">volume is decimal [0 - 1] and is 1 if not specified </p>
-          <p class="note">loop is enabled by default </p>
-        </dd>
-        <dt>Music.clear()</dt>
-        <dd>
-          <p class="description">clears the level playlist</p>
-        </dd>
-        <dt>Music.fade(duration [, fade_type])</dt>
-        <dd>
-          <p class="description">fades out the currently playing track and clears the playlist</p>
-          <p class="note">fade_type is the fading function, see MusicFadeTypes for values, default is linear </p>
-        </dd>
-        <dt>Music.play(track1 [, track2] [, ...])</dt>
-        <dd>
-          <p class="description">appends all of the specified tracks to the end of the playlist</p>
-        </dd>
-        <dt>Music.stop()</dt>
-        <dd>
-          <p class="description">stops level music and clears the playlist</p>
-        </dd>
-        <dt>Music.valid(track1 [, track2] [, ...])</dt>
-        <dd>
-          <p class="description">for every track passed, return true if it exists and is playable and false otherwise</p>
-        </dd>
-        <dt>Music[index]</dt>
-        <dd>
-          <dl>
-	  <dt>:play( [segment]) <span class="version">20231125</span></dt>
-            <dd>
-              <p class="description">plays the music</p>
-              <p class="note">for tracks containing multiple segments, an optional starting segment can be provided </p>
-              <p class="note">if the music was stopped, restarts it </p>
-            </dd>
-	  <dt>:stop() <span class="version">20231125</span></dt>
-            <dd>
-              <p class="description">stops the music</p>
-            </dd>
-	  <dt>:fade(volume [, duration] [, stop_after_fade] [, fade_type]) <span class="version">20231125</span></dt>
-            <dd>
-              <p class="description">fades the music</p>
-              <p class="note">it will fade in until volume is reached. volume is decimal [0 - 1] </p>
-              <p class="note">duration unit is seconds and is 1 if not specified </p>
-              <p class="note">stop_after_fade is disabled by default, if set to true if the volume reaches 0 while fading the music will automatically stop </p>
-              <p class="note">fade_type is the fading function, see MusicFadeTypes for values, default is linear </p>
-            </dd>
-	  <dt>:add_track(track) <span class="version">git</span></dt>
-            <dd>
-              <p class="description">adds an audio track used to create music segments</p>
-              <p class="note">returns a unique identifier for the track, usable to create segments </p>
-            </dd>
-	  <dt>:request_sequence_transition(sequence) <span class="version">git</span></dt>
-            <dd>
-              <p class="description">requests a transition from the currently playing sequence to the specified one</p>
-              <p class="note">the transition will happen at the end of the currently playing segment and as long as a segment transition is configured between it and one from the requested sequence </p>
-            </dd>
-	  <dt>.volume <span class="version">20231125</span></dt>
-            <dd>
-              <p class="description">the volume of the music</p>
-              <p class="note">volume is decimal [0 - 1] </p>
-            </dd>
-	  <dt>.active<span class="access"> (read-only)</span> <span class="version">20231125</span></dt>
-            <dd>
-              <p class="description">returns true if the music is still playing</p>
-            </dd>
-	  <dt>.sequences <span class="version">git</span></dt>
-            <dd>
-              <dl>
-                <dt>:new()</dt>
-                <dd>
-                  <p class="description">creates a new empty sequence for the music channel and returns it</p>
-                  <p class="note">sequences can be seen as a set of segments configured to play in a specific order composing a track </p>
-                  <p class="note">sequences must be created and configured before the music channel starts playing otherwise they  will not be applied unless the music is stopped and restarted </p>
-                </dd>
-                <dt>.segments</dt>
-                <dd>
-                  <dl>
-                    <dt>:new(track_identifier)</dt>
-                    <dd>
-                      <p class="description">creates a new music segment with the specified track, adds it to the sequence and returns it</p>
-                      <p class="note">track_identifier is the unique identifier returned by the music add_track function </p>
-                      <p class="note">this function can be called multiple times with the same track identifier if multiple segments from the same track file are required </p>
-                      <p class="note">the order in which segments are created has no influence on the order in which they are played, see the add_transition function for that </p>
-                    </dd>
-                    <dt>:add_transition(segment [, fade_out_type] [, fade_out_duration] [, fade_in_type] [, fade_in_duration] [, cross_fade])</dt>
-                    <dd>
-                      <p class="description">specifies the next segment to play once the current one has finished and configures the transition</p>
-                      <p class="note">see MusicFadeTypes for the available fading functions, the default is none which means a seamless transition </p>
-                      <p class="note">the fades duration unit is seconds and is 0 if not specified </p>
-                      <p class="note">cross_fade is a boolean flag set to false if not specified </p>
-                      <p class="note">segment transitions across different sequences must also be configured to allow sequence transitions </p>
-                      <p class="note">the entire segment ordering system is handled through this function, if a full track must loop, the last segment of a sequence must transition to the first one of the same sequence </p>
-                      <p class="note">transition configuration must be completed before the music channel starts playing otherwise it will not be applied unless the music is stopped and restarted </p>
-                    </dd>
-                  </dl>
-                </dd>
-              </dl>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Platforms"></a>Platforms</h3>
-      <dl>
-        <dt># Platforms</dt>
-        <dd>
-          <p class="description">number of platforms on the level</p>
-        </dd>
-        <dt>Platforms()</dt>
-        <dd>
-          <p class="description">iterates through all platforms in the level</p>
-        </dd>
-        <dt>Platforms[index]</dt>
-        <dd>
-          <dl>
-	  <dt>.activates_adjacent_platforms_at_each_level <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">platform will activate adjacent platforms at each elevation it comes to (ie.,at floor level and ceiling level)</p>
-            </dd>
-	  <dt>.activates_adjacent_platforms_when_activating <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">when activating, this platform activates adjacent platforms</p>
-            </dd>
-	   <dt>.activates_adjacent_platforms_when_deactivating <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">when deactivating, this platform activates adjacent platforms</p>
-            </dd>
-	  <dt>.activates_light <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">activates floor and ceiling lightsources while activating</p>
-            </dd>
-	  <dt>.activates_only_once <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">cannot be activated a second time</p>
-            </dd>
+<dd>
+<p class="description">whether monster is visible (e.g. has teleported in)</p>
+<p class="note">this has nothing to do with whether monsters are cloaked (like invisible S’pht) or not </p>
+<p class="note">only writable before the monster is activated </p>
+</dd>
+      <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Music"></a>Music</h3>
+<dl>
+<dt># Music</dt>
+<dd><p class="description">maximum number of music channels active simultaneously</p></dd>
+<dt>Music()</dt>
+<dd><p class="description">iterates through all the music channels</p></dd>
+<dt>Music.new(track [, volume] [, loop]) <span class="version">20231125</span>
+</dt>
+<dd>
+<p class="description">returns a new music channel</p>
+<p class="note">volume is decimal [0 - 1] and is 1 if not specified </p>
+<p class="note">loop is enabled by default </p>
+</dd>
+<dt>Music.clear()</dt>
+<dd><p class="description">clears the level playlist</p></dd>
+<dt>Music.fade(duration)</dt>
+<dd><p class="description">fades out the currently playing track and clears the playlist</p></dd>
+<dt>Music.play(track1 [, track2] [, ...])</dt>
+<dd><p class="description">appends all of the specified tracks to the end of the playlist</p></dd>
+<dt>Music.stop()</dt>
+<dd><p class="description">stops level music and clears the playlist</p></dd>
+<dt>Music.valid(track1 [, track2] [, ...])</dt>
+<dd><p class="description">for every track passed, return true if it exists and is playable and false otherwise</p></dd>
+<dt>Music[index]</dt>
+<dd><dl>
+	  <dt>:play() <span class="version">20231125</span>
+</dt>
+<dd>
+<p class="description">plays the music</p>
+<p class="note">if the music was stopped, restarts it </p>
+</dd>
+	  <dt>:stop() <span class="version">20231125</span>
+</dt>
+<dd><p class="description">stops the music</p></dd>
+	  <dt>:fade(volume [, duration] [, stop_after_fade]) <span class="version">20231125</span>
+</dt>
+<dd>
+<p class="description">fades the music</p>
+<p class="note">it will fade in until volume is reached. volume is decimal [0 - 1] </p>
+<p class="note">duration unit is seconds and is 1 if not specified </p>
+<p class="note">stop_after_fade is disabled by default, if set to true if the volume reaches 0 while fading the music will automatically stop </p>
+</dd>
+	  <dt>.volume <span class="version">20231125</span>
+</dt>
+<dd>
+<p class="description">the volume of the music</p>
+<p class="note">volume is decimal [0 - 1] </p>
+</dd>
+	  <dt>.active<span class="access"> (read-only)</span> <span class="version">20231125</span>
+</dt>
+<dd><p class="description">returns true if the music is still playing</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Platforms"></a>Platforms</h3>
+<dl>
+<dt># Platforms</dt>
+<dd><p class="description">number of platforms on the level</p></dd>
+<dt>Platforms()</dt>
+<dd><p class="description">iterates through all platforms in the level</p></dd>
+<dt>Platforms[index]</dt>
+<dd><dl>
+	  <dt>.activates_adjacent_platforms_at_each_level <span class="version">20210408</span>
+</dt>
+<dd><p class="description">platform will activate adjacent platforms at each elevation it comes to (ie.,at floor level and ceiling level)</p></dd>
+	  <dt>.activates_adjacent_platforms_when_activating <span class="version">20210408</span>
+</dt>
+<dd><p class="description">when activating, this platform activates adjacent platforms</p></dd>
+	   <dt>.activates_adjacent_platforms_when_deactivating <span class="version">20210408</span>
+</dt>
+<dd><p class="description">when deactivating, this platform activates adjacent platforms</p></dd>
+	  <dt>.activates_light <span class="version">20210408</span>
+</dt>
+<dd><p class="description">activates floor and ceiling lightsources while activating</p></dd>
+	  <dt>.activates_only_once <span class="version">20210408</span>
+</dt>
+<dd><p class="description">cannot be activated a second time</p></dd>
       <dt>.active</dt>
-            <dd>
-              <p class="description">whether platform is currently active</p>
-            </dd>
-	  <dt>.cannot_be_externally_deactivated <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">when active, can only be deactivated by itself</p>
-            </dd>
+<dd><p class="description">whether platform is currently active</p></dd>
+	  <dt>.cannot_be_externally_deactivated <span class="version">20210408</span>
+</dt>
+<dd><p class="description">when active, can only be deactivated by itself</p></dd>
       <dt>.ceiling_height</dt>
-            <dd>
-              <p class="description">current ceiling height of platform</p>
-            </dd>
-	  <dt>.comes_from_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">platform lowers from ceiling</p>
-            </dd>
-	  <dt>.comes_from_floor<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">platform rises from floor</p>
-            </dd>
+<dd><p class="description">current ceiling height of platform</p></dd>
+	  <dt>.comes_from_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">platform lowers from ceiling</p></dd>
+	  <dt>.comes_from_floor<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">platform rises from floor</p></dd>
       <dt>.contracting</dt>
-            <dd>
-              <p class="description">direction platform is moving or will move when active</p>
-            </dd>
-	  <dt>.contracts_slower <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">will move slower when contracting than when extending</p>
-            </dd>
-	  <dt>.deactivates_adjacent_platforms_when_activating <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">when activating, this platform deactivates adjacent platforms</p>
-            </dd>
-	  <dt>.deactivates_adjacent_platforms_when_deactivating <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">when deactivating, this platform deactivates adjacent platforms</p>
-            </dd>
-	  <dt>.deactivates_at_each_level <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">this platform will deactivate each time it reaches a discrete level</p>
-            </dd>
-	  <dt>.deactivates_at_initial_level <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">this platform will deactivate upon returning to its initial position</p>
-            </dd>
-	  <dt>.deactivates_light <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">deactivates floor and ceiling lightsources while deactivating</p>
-            </dd>
-	  <dt>.delays_before_activation <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">whether or not the platform begins with the maximum delay before moving</p>
-            </dd>
-	  <dt>.does_not_activate_parent <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">does not reactive its parent (the platform which activated it)</p>
-            </dd>
-      <dt>.door <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">platform is a door</p>
-            </dd>
+<dd><p class="description">direction platform is moving or will move when active</p></dd>
+	  <dt>.contracts_slower <span class="version">20210408</span>
+</dt>
+<dd><p class="description">will move slower when contracting than when extending</p></dd>
+	  <dt>.deactivates_adjacent_platforms_when_activating <span class="version">20210408</span>
+</dt>
+<dd><p class="description">when activating, this platform deactivates adjacent platforms</p></dd>
+	  <dt>.deactivates_adjacent_platforms_when_deactivating <span class="version">20210408</span>
+</dt>
+<dd><p class="description">when deactivating, this platform deactivates adjacent platforms</p></dd>
+	  <dt>.deactivates_at_each_level <span class="version">20210408</span>
+</dt>
+<dd><p class="description">this platform will deactivate each time it reaches a discrete level</p></dd>
+	  <dt>.deactivates_at_initial_level <span class="version">20210408</span>
+</dt>
+<dd><p class="description">this platform will deactivate upon returning to its initial position</p></dd>
+	  <dt>.deactivates_light <span class="version">20210408</span>
+</dt>
+<dd><p class="description">deactivates floor and ceiling lightsources while deactivating</p></dd>
+	  <dt>.delays_before_activation <span class="version">20210408</span>
+</dt>
+<dd><p class="description">whether or not the platform begins with the maximum delay before moving</p></dd>
+	  <dt>.does_not_activate_parent <span class="version">20210408</span>
+</dt>
+<dd><p class="description">does not reactive its parent (the platform which activated it)</p></dd>
+      <dt>.door <span class="version">20100118</span>
+</dt>
+<dd><p class="description">platform is a door</p></dd>
       <dt>.extending</dt>
-            <dd>
-              <p class="description">direction platform is moving or will move when active</p>
-            </dd>
-	  <dt>.extends_floor_to_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">there is no empty space when the platform is fully extended</p>
-            </dd>
+<dd><p class="description">direction platform is moving or will move when active</p></dd>
+	  <dt>.extends_floor_to_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">there is no empty space when the platform is fully extended</p></dd>
       <dt>.floor_height</dt>
-            <dd>
-              <p class="description">current floor height of platform</p>
-            </dd>
-	  <dt>.initially_active<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">otherwise inactive</p>
-            </dd>
-	  <dt>.has_been_activated <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">in case platform can only be activated once</p>
-            </dd>
-	  <dt>.initially_extended<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">high for floor platforms, low for ceiling platforms, closed for two-way platforms</p>
-            </dd>
-      <dt>.locked <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">platform is locked</p>
-              <p class="note">this flag doesn’t actually do anything </p>
-            </dd>
-      <dt>.maximum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">greatest height a platform's ceiling can ever rise</p>
-            </dd>
-      <dt>.maximum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">greatest height a platform's floor can ever rise</p>
-            </dd>
-      <dt>.minimum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">least height a platform's ceiling must rise</p>
-            </dd>
-      <dt>.minimum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">least height a platform's floor must rise</p>
-            </dd>
+<dd><p class="description">current floor height of platform</p></dd>
+	  <dt>.initially_active<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">otherwise inactive</p></dd>
+	  <dt>.has_been_activated <span class="version">20210408</span>
+</dt>
+<dd><p class="description">in case platform can only be activated once</p></dd>
+	  <dt>.initially_extended<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">high for floor platforms, low for ceiling platforms, closed for two-way platforms</p></dd>
+      <dt>.locked <span class="version">20100118</span>
+</dt>
+<dd>
+<p class="description">platform is locked</p>
+<p class="note">this flag doesn’t actually do anything </p>
+</dd>
+      <dt>.maximum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
+</dt>
+<dd><p class="description">greatest height a platform's ceiling can ever rise</p></dd>
+      <dt>.maximum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
+</dt>
+<dd><p class="description">greatest height a platform's floor can ever rise</p></dd>
+      <dt>.minimum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
+</dt>
+<dd><p class="description">least height a platform's ceiling must rise</p></dd>
+      <dt>.minimum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
+</dt>
+<dd><p class="description">least height a platform's floor must rise</p></dd>
       <dt>.monster_controllable</dt>
-            <dd>
-              <p class="description">whether platform can be controlled by monsters</p>
-            </dd>
+<dd><p class="description">whether platform can be controlled by monsters</p></dd>
       <dt>.player_controllable</dt>
-            <dd>
-              <p class="description">whether platform can be controlled by players</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon of this platform</p>
-            </dd>
-	  <dt>.reverses_direction_when_obstructed <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">platform reverses direction when obstructed</p>
-            </dd>
-      <dt>.secret <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">platform is secret</p>
-              <p class="note">secret platforms aren’t shown on the overhead map </p>
-            </dd>
+<dd><p class="description">whether platform can be controlled by players</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon of this platform</p></dd>
+	  <dt>.reverses_direction_when_obstructed <span class="version">20210408</span>
+</dt>
+<dd><p class="description">platform reverses direction when obstructed</p></dd>
+      <dt>.secret <span class="version">20100118</span>
+</dt>
+<dd>
+<p class="description">platform is secret</p>
+<p class="note">secret platforms aren’t shown on the overhead map </p>
+</dd>
       <dt>.speed</dt>
-            <dd>
-              <p class="description">platform speed</p>
-            </dd>
-	  <dt>.tag <span class="version">20221126</span></dt>
-            <dd>
-              <p class="description">tag of platform</p>
-            </dd>
-      <dt>.type <span class="version">20100118</span></dt>
-            <dd>
-              <p class="description">type of this platform</p>
-              <p class="note">the only thing the engine uses type for is the platform’s sound </p>
-            </dd>
-	  <dt>.uses_native_polygon_heights<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">uses native polygon heights during automatic min,max calculation</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Players"></a>Players</h3>
-      <dl>
-        <dt># Players</dt>
-        <dd>
-          <p class="description">number of players in the game</p>
-        </dd>
-        <dt>Players()</dt>
-        <dd>
-          <p class="description">iterates through all players in the game</p>
-        </dd>
-        <dt>Players.print(message)</dt>
-        <dd>
-          <p class="description">prints message to all players’ screens</p>
-        </dd>
-        <dt>Players.local_player<span class="access"> (read-only)</span> <span class="version">20200830</span></dt>
-        <dd>
-          <p class="description">the local player</p>
-          <p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
-        </dd>
-        <dt>Players[index]</dt>
-        <dd>
-          <dl>
+<dd><p class="description">platform speed</p></dd>
+	  <dt>.tag <span class="version">20221126</span>
+</dt>
+<dd><p class="description">tag of platform</p></dd>
+      <dt>.type <span class="version">20100118</span>
+</dt>
+<dd>
+<p class="description">type of this platform</p>
+<p class="note">the only thing the engine uses type for is the platform’s sound </p>
+</dd>
+	  <dt>.uses_native_polygon_heights<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">uses native polygon heights during automatic min,max calculation</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="PlayerStarts"></a>PlayerStarts</h3>
+<dl>
+<dt># PlayerStarts</dt>
+<dd><p class="description">number of map objects in the level</p></dd>
+<dt>PlayerStarts()</dt>
+<dd><p class="description">iterates through all player starting locations in the level</p></dd>
+<dt>PlayerStarts[index]</dt>
+<dd><dl>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">player starting location facing</p></dd>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether player starting location z is from ceiling</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">polygon player starting location is in</p></dd>
+      <dt>.team<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">which team starts at this player starting location</p></dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description"></p>
+<p class="note">from floor or ceiling </p>
+</dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Players"></a>Players</h3>
+<dl>
+<dt># Players</dt>
+<dd><p class="description">number of players in the game</p></dd>
+<dt>Players()</dt>
+<dd><p class="description">iterates through all players in the game</p></dd>
+<dt>Players.print(message)</dt>
+<dd><p class="description">prints message to all players’ screens</p></dd>
+<dt>Players.local_player<span class="access"> (read-only)</span> <span class="version">20200830</span>
+</dt>
+<dd>
+<p class="description">the local player</p>
+<p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
+</dd>
+<dt>Players[index]</dt>
+<dd><dl>
       <dt>:accelerate(direction, velocity, vertical_velocity)</dt>
-            <dd>
-              <p class="description">accelerates player</p>
-            </dd>
+<dd><p class="description">accelerates player</p></dd>
       <dt>.action_flags</dt>
-            <dd>
-              <p class="note">only valid when read/written in idle() </p>
-              <p class="note">disabled when the player is viewing a terminal </p>
-              <p class="note">latched action flags are only true the first tick the key is held down </p>
-              <dl>
-                <dt>.action_trigger</dt>
-                <dd>
-                  <p class="description">respawns, or activates platforms/doors/control panels</p>
-                  <p class="note">latched </p>
-                </dd>
-                <dt>.aux_trigger <span class="version">20231125</span></dt>
-                <dd>
-                  <p class="description">formerly microphone button; now dedicated to Lua scripts</p>
-                </dd>
-                <dt>.cycle_weapons_backward</dt>
-                <dd>
-                  <p class="description">switches to previous weapon</p>
-                  <p class="note">latched </p>
-                </dd>
-                <dt>.cycle_weapons_forward</dt>
-                <dd>
-                  <p class="description">switches to next weapon</p>
-                  <p class="note">latched </p>
-                </dd>
-                <dt>.left_trigger</dt>
-                <dd>
-                  <p class="description">fires primary trigger</p>
-                </dd>
-                <dt>.right_trigger</dt>
-                <dd>
-                  <p class="description">fires secondary trigger</p>
-                </dd>
-                <dt>.toggle_map</dt>
-                <dd>
-                  <p class="description">toggles the overhead map</p>
-                  <p class="note">latched </p>
-                </dd>
-              </dl>
-            </dd>
+<dd>
+<p class="note">only valid when read/written in idle() </p>
+<p class="note">disabled when the player is viewing a terminal </p>
+<p class="note">latched action flags are only true the first tick the key is held down </p>
+<dl>
+<dt>.action_trigger</dt>
+<dd>
+<p class="description">respawns, or activates platforms/doors/control panels</p>
+<p class="note">latched </p>
+</dd>
+<dt>.aux_trigger <span class="version">20231125</span>
+</dt>
+<dd><p class="description">formerly microphone button; now dedicated to Lua scripts</p></dd>
+<dt>.cycle_weapons_backward</dt>
+<dd>
+<p class="description">switches to previous weapon</p>
+<p class="note">latched </p>
+</dd>
+<dt>.cycle_weapons_forward</dt>
+<dd>
+<p class="description">switches to next weapon</p>
+<p class="note">latched </p>
+</dd>
+<dt>.left_trigger</dt>
+<dd><p class="description">fires primary trigger</p></dd>
+<dt>.right_trigger</dt>
+<dd><p class="description">fires secondary trigger</p></dd>
+<dt>.toggle_map</dt>
+<dd>
+<p class="description">toggles the overhead map</p>
+<p class="note">latched </p>
+</dd>
+</dl>
+</dd>
       <dt>:activate_terminal(terminal)</dt>
-            <dd>
-              <p class="description">activates terminal</p>
-            </dd>
+<dd><p class="description">activates terminal</p></dd>
       <dt>.color</dt>
-            <dd>
-              <p class="description">color of player (shirt color, if teams are enabled)</p>
-            </dd>
+<dd><p class="description">color of player (shirt color, if teams are enabled)</p></dd>
       <dt>.compass</dt>
-            <dd>
-              <dl>
-                <dt>:all_off()</dt>
-                <dd>
-                  <p class="description">turns all compass quadrants off, disables beacon</p>
-                </dd>
-                <dt>:all_on()</dt>
-                <dd>
-                  <p class="description">turns all compass quadrants on, disables beacon</p>
-                </dd>
-                <dt>.beacon</dt>
-                <dd>
-                  <p class="description">whether to use the beacon</p>
-                </dd>
-                <dt>.lua</dt>
-                <dd>
-                  <p class="description">whether Lua is controlling the compass</p>
-                </dd>
-                <dt>.ne<br>.northeast</dt>
-                <dd>
-                  <p class="description">whether north east compass quadrant is active</p>
-                </dd>
-                <dt>.nw<br>.northwest</dt>
-                <dd>
-                  <p class="description">whether north west compass quadrant is active</p>
-                </dd>
-                <dt>.se<br>.southeast</dt>
-                <dd>
-                  <p class="description">whether south east compass quadrant is active</p>
-                </dd>
-                <dt>.sw<br>.southwest</dt>
-                <dd>
-                  <p class="description">whether south west compass quadrant is active</p>
-                </dd>
-                <dt>.x</dt>
-                <dd>
-                  <p class="description">beacon location</p>
-                </dd>
-                <dt>.y</dt>
-                <dd>
-                  <p class="description">beacon location</p>
-                </dd>
-              </dl>
-            </dd>
+<dd><dl>
+<dt>:all_off()</dt>
+<dd><p class="description">turns all compass quadrants off, disables beacon</p></dd>
+<dt>:all_on()</dt>
+<dd><p class="description">turns all compass quadrants on, disables beacon</p></dd>
+<dt>.beacon</dt>
+<dd><p class="description">whether to use the beacon</p></dd>
+<dt>.lua</dt>
+<dd><p class="description">whether Lua is controlling the compass</p></dd>
+<dt>.ne<br>.northeast</dt>
+<dd><p class="description">whether north east compass quadrant is active</p></dd>
+<dt>.nw<br>.northwest</dt>
+<dd><p class="description">whether north west compass quadrant is active</p></dd>
+<dt>.se<br>.southeast</dt>
+<dd><p class="description">whether south east compass quadrant is active</p></dd>
+<dt>.sw<br>.southwest</dt>
+<dd><p class="description">whether south west compass quadrant is active</p></dd>
+<dt>.x</dt>
+<dd><p class="description">beacon location</p></dd>
+<dt>.y</dt>
+<dd><p class="description">beacon location</p></dd>
+</dl></dd>
       <dt>.crosshairs</dt>
-            <dd>
-              <dl>
-                <dt>.active<span class="access"> (local player)</span></dt>
-                <dd>
-                  <p class="description">whether crosshairs are visible</p>
-                  <p class="note">if you wish to stop the user from toggling the crosshairs, you must set the state every tick </p>
-                </dd>
-              </dl>
-            </dd>
+<dd><dl>
+<dt>.active<span class="access"> (local player)</span>
+</dt>
+<dd>
+<p class="description">whether crosshairs are visible</p>
+<p class="note">if you wish to stop the user from toggling the crosshairs, you must set the state every tick </p>
+</dd>
+</dl></dd>
       <dt>:damage(amount [, type])</dt>
-            <dd>
-              <p class="description">inflicts damage on player</p>
-              <ul class="args">
-                <li>type: if unspecified, crush damage is delt</li>
-              </ul>
-            </dd>
-      <dt>.dead<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether player is dead</p>
-            </dd>
+<dd>
+<p class="description">inflicts damage on player</p>
+<ul class="args"><li>type: if unspecified, crush damage is delt</li></ul>
+</dd>
+      <dt>.dead<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether player is dead</p></dd>
       <dt>.deaths</dt>
-            <dd>
-              <p class="description">deaths not caused by players</p>
-            </dd>
+<dd><p class="description">deaths not caused by players</p></dd>
       <dt>.direction<br>.yaw</dt>
-            <dd>
-              <p class="description">direction player is facing</p>
-              <p class="note">this is the direction in which this player will run; for their aim, use .head_direction </p>
-            </dd>
+<dd>
+<p class="description">direction player is facing</p>
+<p class="note">this is the direction in which this player will run; for their aim, use .head_direction </p>
+</dd>
       <dt>.disconnected</dt>
-            <dd>
-              <p class="description">whether player dropped out of the game</p>
-            </dd>
+<dd><p class="description">whether player dropped out of the game</p></dd>
       <dt>.energy<br>.life</dt>
-            <dd>
-              <p class="description">amount of suit energy player has (150 is normal red health)</p>
-            </dd>
+<dd><p class="description">amount of suit energy player has (150 is normal red health)</p></dd>
       <dt>.elevation<br>.pitch</dt>
-            <dd>
-              <p class="description">angle player is looking up or down</p>
-            </dd>
+<dd><p class="description">angle player is looking up or down</p></dd>
       <dt>.external_velocity</dt>
-            <dd>
-              <dl>
-                <dt>.i<br>.x</dt>
-                <dd>
-                  <p class="description">
-                  </p>
-                </dd>
-                <dt>.j<br>.y</dt>
-                <dd>
-                  <p class="description">
-                  </p>
-                </dd>
-                <dt>.k<br>.z</dt>
-                <dd>
-                  <p class="description">
-                  </p>
-                </dd>
-              </dl>
-            </dd>
+<dd><dl>
+<dt>.i<br>.x</dt>
+<dd><p class="description"></p></dd>
+<dt>.j<br>.y</dt>
+<dd><p class="description"></p></dd>
+<dt>.k<br>.z</dt>
+<dd><p class="description"></p></dd>
+</dl></dd>
       <dt>.extravision_duration</dt>
-            <dd>
-              <p class="description">extravision time remaining</p>
-            </dd>
-      <dt>.feet_below_media<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether player is standing in liquid</p>
-            </dd>
+<dd><p class="description">extravision time remaining</p></dd>
+      <dt>.feet_below_media<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether player is standing in liquid</p></dd>
       <dt>:fade_screen(type)</dt>
-            <dd>
-              <p class="description">fades player’s screen</p>
-            </dd>
+<dd><p class="description">fades player’s screen</p></dd>
       <dt>:find_action_key_target()</dt>
-            <dd>
-              <p class="description">if player is in range of a platform or control panel, returns a platform or side; otherwise returns nil</p>
-              <p class="note">you can check the type of the return with is_polygon() and is_side() </p>
-            </dd>
+<dd>
+<p class="description">if player is in range of a platform or control panel, returns a platform or side; otherwise returns nil</p>
+<p class="note">you can check the type of the return with is_polygon() and is_side() </p>
+</dd>
       <dt>:find_target( [penetrate_media] <span class="version">20220115</span>)</dt>
-            <dd>
-              <p class="description">returns t, x, y, z, polygon, where t is the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the target is the surface of a liquid, and penetrate_media is false) the player is looking at; and x, y, z, and polygon are the point the player is looking at</p>
-              <p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
-              <p class="note">this function will not work under liquid unless penetrate_media is true </p>
-            </dd>
-	  <dt>.has_map_open<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">whether player has overhead map open</p>
-            </dd>
-      <dt>.head_below_media<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether player is completely below liquid</p>
-            </dd>
-      <dt>.head_direction <span class="version">20200830</span></dt>
-            <dd>
-              <p class="description">direction in which player is looking</p>
-              <p class="note">while glancing, this differs from .direction </p>
-            </dd>
-	  <dt>.hotkey <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">pressed hotkey, from 1-12, or 0 for no hotkey</p>
-              <p class="note">only valid when read/written in idle() </p>
-              <p class="note">hotkeys aren’t latched, and can only be transmitted every 3 ticks </p>
-              <p class="note">to check for a continously pressed hotkey, or to implement your own latch, count down from 2 before checking it again </p>
-              <p class="note">hotkeys override cycle weapon backward/forward; these flags will be false for 3 ticks after a hotkey is pressed </p>
-            </dd>
+<dd>
+<p class="description">returns t, x, y, z, polygon, where t is the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the target is the surface of a liquid, and penetrate_media is false) the player is looking at; and x, y, z, and polygon are the point the player is looking at</p>
+<p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
+<p class="note">this function will not work under liquid unless penetrate_media is true </p>
+</dd>
+	  <dt>.has_map_open<span class="access"> (read-only)</span> <span class="version">20220115</span>
+</dt>
+<dd><p class="description">whether player has overhead map open</p></dd>
+      <dt>.head_below_media<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether player is completely below liquid</p></dd>
+      <dt>.head_direction <span class="version">20200830</span>
+</dt>
+<dd>
+<p class="description">direction in which player is looking</p>
+<p class="note">while glancing, this differs from .direction </p>
+</dd>
+	  <dt>.hotkey <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">pressed hotkey, from 1-12, or 0 for no hotkey</p>
+<p class="note">only valid when read/written in idle() </p>
+<p class="note">hotkeys aren’t latched, and can only be transmitted every 3 ticks </p>
+<p class="note">to check for a continously pressed hotkey, or to implement your own latch, count down from 2 before checking it again </p>
+<p class="note">hotkeys override cycle weapon backward/forward; these flags will be false for 3 ticks after a hotkey is pressed </p>
+</dd>
 	  <dt>
-    .hotkey_bindings[n] <span class="version">20210408</span><span class="access"> (local player)</span></dt>
-            <dd>
-              <p class="description">keys or buttons the player has bound to hotkeys 1-12</p>
-              <dl>
-                <dt>.joystick<span class="access"> (read-only)</span></dt>
-                <dd>
-                  <p class="description">joystick button binding</p>
-                </dd>
-                <dt>.key<span class="access"> (read-only)</span></dt>
-                <dd>
-                  <p class="description">key binding</p>
-                </dd>
-                <dt>.mouse<span class="access"> (read-only)</span></dt>
-                <dd>
-                  <p class="description">mouse button binding</p>
-                </dd>
-              </dl>
-            </dd>
+    .hotkey_bindings[n] <span class="version">20210408</span><span class="access"> (local player)</span>
+</dt>
+<dd>
+<p class="description">keys or buttons the player has bound to hotkeys 1-12</p>
+<dl>
+<dt>.joystick<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">joystick button binding</p></dd>
+<dt>.key<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">key binding</p></dd>
+<dt>.mouse<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">mouse button binding</p></dd>
+</dl>
+</dd>
       <dt>.infravision_duration</dt>
-            <dd>
-              <p class="description">infravision time remaining</p>
-            </dd>
+<dd><p class="description">infravision time remaining</p></dd>
       <dt>.internal_velocity</dt>
-            <dd>
-              <dl>
-                <dt>.forward<span class="access"> (read-only)</span></dt>
-                <dd>
-                  <p class="description">player’s forward velocity</p>
-                </dd>
-                <dt>.perpendicular<span class="access"> (read-only)</span></dt>
-                <dd>
-                  <p class="description">player’s perpendicular (sidestep) velocity</p>
-                </dd>
-              </dl>
-            </dd>
+<dd><dl>
+<dt>.forward<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">player’s forward velocity</p></dd>
+<dt>.perpendicular<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">player’s perpendicular (sidestep) velocity</p></dd>
+</dl></dd>
       <dt>.invincibility_duration</dt>
-            <dd>
-              <p class="description">invincibility time remaining</p>
-            </dd>
+<dd><p class="description">invincibility time remaining</p></dd>
       <dt>.invisibility_duration</dt>
-            <dd>
-              <p class="description">invisibility time remaining</p>
-              <p class="note">player will become subtly invisible if this is set higher than the standard invisibility duration (70 seconds) </p>
-            </dd>
+<dd>
+<p class="description">invisibility time remaining</p>
+<p class="note">player will become subtly invisible if this is set higher than the standard invisibility duration (70 seconds) </p>
+</dd>
       <dt>
     .items[item_type]
   </dt>
-            <dd>
-              <p class="description">how many of item the player is carrying</p>
-            </dd>
-      <dt>.local_<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">true if this player is the local player</p>
-              <p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
-            </dd>
+<dd><p class="description">how many of item the player is carrying</p></dd>
+      <dt>.local_<span class="access"> (read-only)</span>
+</dt>
+<dd>
+<p class="description">true if this player is the local player</p>
+<p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
+</dd>
       <dt>
     .kills[slain_player]
   </dt>
-            <dd>
-              <p class="description">kill count against slain_player</p>
-            </dd>
-      <dt>.monster<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">monster that corresponds to player</p>
-            </dd>
-      <dt>.motion_sensor_active<span class="access"> (local player)</span></dt>
-            <dd>
-              <p class="description">whether player can view his motion sensor</p>
-              <p class="note">currently, this also controls compass visibility </p>
-            </dd>
-      <dt>.name<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">player’s name</p>
-            </dd>
+<dd><p class="description">kill count against slain_player</p></dd>
+      <dt>.monster<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">monster that corresponds to player</p></dd>
+      <dt>.motion_sensor_active<span class="access"> (local player)</span>
+</dt>
+<dd>
+<p class="description">whether player can view his motion sensor</p>
+<p class="note">currently, this also controls compass visibility </p>
+</dd>
+      <dt>.name<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">player’s name</p></dd>
       <dt>.oxygen</dt>
-            <dd>
-              <p class="description">amount of oxygen player has (max is 10800)</p>
-            </dd>
+<dd><p class="description">amount of oxygen player has (max is 10800)</p></dd>
       <dt>
     .overlays[n]</dt>
-            <dd>
-              <p class="description">there are 6 overlays, numbered 0 through 5</p>
-              <dl>
-                <dt>:clear()</dt>
-                <dd>
-                  <p class="description">turns off overlay</p>
-                </dd>
-                <dt>.color<span class="access"> (write-only)</span></dt>
-                <dd>
-                  <p class="description">text color</p>
-                </dd>
-                <dt>:fill_icon(color)</dt>
-                <dd>
-                  <p class="description">fills icon with solid color</p>
-                </dd>
-                <dt>.icon<span class="access"> (write-only)</span></dt>
-                <dd>
-                  <p class="description">icon</p>
-                </dd>
-                <dt>.text<span class="access"> (write-only)</span></dt>
-                <dd>
-                  <p class="description">text</p>
-                </dd>
-              </dl>
-            </dd>
+<dd>
+<p class="description">there are 6 overlays, numbered 0 through 5</p>
+<dl>
+<dt>:clear()</dt>
+<dd><p class="description">turns off overlay</p></dd>
+<dt>.color<span class="access"> (write-only)</span>
+</dt>
+<dd><p class="description">text color</p></dd>
+<dt>:fill_icon(color)</dt>
+<dd><p class="description">fills icon with solid color</p></dd>
+<dt>.icon<span class="access"> (write-only)</span>
+</dt>
+<dd><p class="description">icon</p></dd>
+<dt>.text<span class="access"> (write-only)</span>
+</dt>
+<dd><p class="description">text</p></dd>
+</dl>
+</dd>
       <dt>:play_sound(sound, pitch)</dt>
-            <dd>
-              <p class="description">plays sound that only player can hear</p>
-              <p class="note">if you want all players to hear the sound as if it is coming from this player, use .monster:play_sound() instead </p>
-            </dd>
+<dd>
+<p class="description">plays sound that only player can hear</p>
+<p class="note">if you want all players to hear the sound as if it is coming from this player, use .monster:play_sound() instead </p>
+</dd>
       <dt>.points</dt>
-            <dd>
-              <p class="description">how many points player has</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon the player is standing on</p>
-              <p class="note">if this gives you trouble, try .monster.polygon </p>
-            </dd>
+<dd><p class="description">how many points player has</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd>
+<p class="description">polygon the player is standing on</p>
+<p class="note">if this gives you trouble, try .monster.polygon </p>
+</dd>
       <dt>:position(x, y, z, polygon)</dt>
-            <dd>
-              <p class="description">set player position</p>
-            </dd>
+<dd><p class="description">set player position</p></dd>
       <dt>:print(message)</dt>
-            <dd>
-              <p class="description">prints message to player’s screen</p>
-            </dd>
-	  <dt>:revive() <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">revives player</p>
-              <p class="note">player must be totally dead </p>
-            </dd>
+<dd><p class="description">prints message to player’s screen</p></dd>
+	  <dt>:revive() <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">revives player</p>
+<p class="note">player must be totally dead </p>
+</dd>
       <dt>.team</dt>
-            <dd>
-              <p class="description">player’s team (pants color)</p>
-            </dd>
+<dd><p class="description">player’s team (pants color)</p></dd>
       <dt>:teleport(polygon)</dt>
-            <dd>
-              <p class="description">teleports player to polygon</p>
-            </dd>
+<dd><p class="description">teleports player to polygon</p></dd>
       <dt>:teleport_to_level(level)</dt>
-            <dd>
-              <p class="description">teleports player to level (of course, all the other players will also go to that level)</p>
-            </dd>
-	  <dt>.teleporting<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">whether player is teleporting</p>
-            </dd>
+<dd><p class="description">teleports player to level (of course, all the other players will also go to that level)</p></dd>
+	  <dt>.teleporting<span class="access"> (read-only)</span> <span class="version">20220115</span>
+</dt>
+<dd><p class="description">whether player is teleporting</p></dd>
       <dt>.texture_palette</dt>
-            <dd>
-              <p class="description">displays a texture palette instead of the classic HUD</p>
-              <dl>
-                <dt>.highlight<span class="access"> (local player)</span></dt>
-                <dd>
-                  <p class="description">number of slot to highlight</p>
-                  <p class="note">can be nil </p>
-                </dd>
-                <dt>.size<span class="access"> (local player)</span></dt>
-                <dd>
-                  <p class="description">how many slots the palette has</p>
-                  <p class="note">there is a maximum of 256 slots </p>
-                  <p class="note">the texture palette is visible whenever the size is greater than 0 </p>
-                  <p class="note">rows/columns may change in the future based on the user’s screen layout prefs </p>
-                </dd>
-                <dt>
+<dd>
+<p class="description">displays a texture palette instead of the classic HUD</p>
+<dl>
+<dt>.highlight<span class="access"> (local player)</span>
+</dt>
+<dd>
+<p class="description">number of slot to highlight</p>
+<p class="note">can be nil </p>
+</dd>
+<dt>.size<span class="access"> (local player)</span>
+</dt>
+<dd>
+<p class="description">how many slots the palette has</p>
+<p class="note">there is a maximum of 256 slots </p>
+<p class="note">the texture palette is visible whenever the size is greater than 0 </p>
+<p class="note">rows/columns may change in the future based on the user’s screen layout prefs </p>
+</dd>
+<dt>
     .slots[n]</dt>
-                <dd>
-                  <dl>
-                    <dt>:clear()</dt>
-                    <dd>
-                      <p class="description">makes this slot empty</p>
-                    </dd>
-                    <dt>.collection<span class="access"> (local player)</span></dt>
-                    <dd>
-                      <p class="description">collection of this slot</p>
-                    </dd>
-                    <dt>.texture_index<span class="access"> (local player)</span></dt>
-                    <dd>
-                      <p class="description">texture index of this slot</p>
-                    </dd>
-                    <dt>.type<span class="access"> (local player)</span> <span class="version">20090909</span></dt>
-                    <dd>
-                      <p class="description">texture type of this slot such as wall or sprite; see "Texture Types"</p>
-                    </dd>
-                  </dl>
-                </dd>
-              </dl>
-            </dd>
-	  <dt>.totally_dead<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">the player is dead and the death animation has finished</p>
-            </dd>
-      <dt>:view_player(player) <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">switch to another player’s view</p>
-            </dd>
-      <dt>.viewed_player<span class="access"> (read-only) (local player)</span> <span class="version">20200830</span></dt>
-            <dd>
-              <p class="description">the player currently being viewed by the local player</p>
-            </dd>
+<dd><dl>
+<dt>:clear()</dt>
+<dd><p class="description">makes this slot empty</p></dd>
+<dt>.collection<span class="access"> (local player)</span>
+</dt>
+<dd><p class="description">collection of this slot</p></dd>
+<dt>.texture_index<span class="access"> (local player)</span>
+</dt>
+<dd><p class="description">texture index of this slot</p></dd>
+<dt>.type<span class="access"> (local player)</span> <span class="version">20090909</span>
+</dt>
+<dd><p class="description">texture type of this slot such as wall or sprite; see "Texture Types"</p></dd>
+</dl></dd>
+</dl>
+</dd>
+	  <dt>.totally_dead<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">the player is dead and the death animation has finished</p></dd>
+      <dt>:view_player(player) <span class="version">20080707</span>
+</dt>
+<dd><p class="description">switch to another player’s view</p></dd>
+      <dt>.viewed_player<span class="access"> (read-only) (local player)</span> <span class="version">20200830</span>
+</dt>
+<dd><p class="description">the player currently being viewed by the local player</p></dd>
       <dt>.weapons</dt>
-            <dd>
-              <dl>
-                <dt>.active <span class="version">20080707</span></dt>
-                <dd>
-                  <p class="description">when a player’s weapons are not active, he does not see weapons in hand, and can not fire</p>
-                </dd>
-                <dt>.current<span class="access"> (read-only)</span></dt>
-                <dd>
-                  <p class="description">weapon the player is currently wielding</p>
-                  <p class="note">can be nil </p>
-                </dd>
-                <dt>.desired<span class="access"> (read-only)</span> <span class="version">20090909</span></dt>
-                <dd>
-                  <p class="description">weapon the player wants to switch to</p>
-                  <p class="note">can be nil </p>
-                </dd>
-              </dl>
-            </dd>
+<dd><dl>
+<dt>.active <span class="version">20080707</span>
+</dt>
+<dd><p class="description">when a player’s weapons are not active, he does not see weapons in hand, and can not fire</p></dd>
+<dt>.current<span class="access"> (read-only)</span>
+</dt>
+<dd>
+<p class="description">weapon the player is currently wielding</p>
+<p class="note">can be nil </p>
+</dd>
+<dt>.desired<span class="access"> (read-only)</span> <span class="version">20090909</span>
+</dt>
+<dd>
+<p class="description">weapon the player wants to switch to</p>
+<p class="note">can be nil </p>
+</dd>
+</dl></dd>
       <dt>
     .weapons[weapon_type]</dt>
-            <dd>
-              <dl>
-                <dt>.primary<br>.secondary</dt>
-                <dd>
-                  <dl>
-                    <dt>.rounds<span class="access"> (read-only)</span></dt>
-                    <dd>
-                      <p class="description">how many rounds are currently loaded into the weapon</p>
-                    </dd>
-                  </dl>
-                </dd>
-                <dt>:select()</dt>
-                <dd>
-                  <p class="description">attempts to force player to ready weapon</p>
-                </dd>
-                <dt>.type<span class="access"> (read-only)</span></dt>
-                <dd>
-                  <p class="description">type of this weapon</p>
-                </dd>
-              </dl>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.zoom_active<span class="access"> (local player)</span></dt>
-            <dd>
-              <p class="description">whether player’s sniper zoom is active</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="PlayerStarts"></a>PlayerStarts</h3>
-      <dl>
-        <dt># PlayerStarts</dt>
-        <dd>
-          <p class="description">number of map objects in the level</p>
-        </dd>
-        <dt>PlayerStarts()</dt>
-        <dd>
-          <p class="description">iterates through all player starting locations in the level</p>
-        </dd>
-        <dt>PlayerStarts[index]</dt>
-        <dd>
-          <dl>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">player starting location facing</p>
-            </dd>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether player starting location z is from ceiling</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">polygon player starting location is in</p>
-            </dd>
-      <dt>.team<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">which team starts at this player starting location</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-              <p class="note">from floor or ceiling </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Polygons"></a>Polygons</h3>
-      <dl>
-        <dt># Polygons</dt>
-        <dd>
-          <p class="description">number of polygons in the level</p>
-        </dd>
-        <dt>Polygons()</dt>
-        <dd>
-          <p class="description">iterates through all polygons in the level</p>
-        </dd>
-        <dt>Polygons[index]</dt>
-        <dd>
-          <dl>
+<dd><dl>
+<dt>.primary<br>.secondary</dt>
+<dd><dl>
+<dt>.rounds<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">how many rounds are currently loaded into the weapon</p></dd>
+</dl></dd>
+<dt>:select()</dt>
+<dd><p class="description">attempts to force player to ready weapon</p></dd>
+<dt>.type<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of this weapon</p></dd>
+</dl></dd>
+      <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.zoom_active<span class="access"> (local player)</span>
+</dt>
+<dd><p class="description">whether player’s sniper zoom is active</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Polygons"></a>Polygons</h3>
+<dl>
+<dt># Polygons</dt>
+<dd><p class="description">number of polygons in the level</p></dd>
+<dt>Polygons()</dt>
+<dd><p class="description">iterates through all polygons in the level</p></dd>
+<dt>Polygons[index]</dt>
+<dd><dl>
       <dt>
     .adjacent_polygons[n]</dt>
-            <dd>
-              <p class="description">returns adjacent polygon n (across from line n), if one exists, or nil</p>
-            </dd>
+<dd><p class="description">returns adjacent polygon n (across from line n), if one exists, or nil</p></dd>
       <dt>:adjacent_polygons()</dt>
-            <dd>
-              <p class="description">iterates through all polygons directly adjacent to this polygon</p>
-            </dd>
-      <dt>.area<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">the area of this polygon</p>
-            </dd>
+<dd><p class="description">iterates through all polygons directly adjacent to this polygon</p></dd>
+      <dt>.area<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">the area of this polygon</p></dd>
       <dt>.ceiling<br>.floor</dt>
-            <dd>
-              <dl>
-                <dt>.collection</dt>
-                <dd>
-                  <p class="description">texture collection</p>
-                </dd>
-                <dt>.height<br>.z</dt>
-                <dd>
-                  <p class="description">height</p>
-                </dd>
-                <dt>.light</dt>
-                <dd>
-                  <p class="description">texture light</p>
-                </dd>
-                <dt>.texture_index</dt>
-                <dd>
-                  <p class="description">texture bitmap index</p>
-                </dd>
-                <dt>.texture_x</dt>
-                <dd>
-                  <p class="description">texture x offset</p>
-                </dd>
-                <dt>.texture_y</dt>
-                <dd>
-                  <p class="description">texture y offset</p>
-                </dd>
-                <dt>.transfer_mode</dt>
-                <dd>
-                  <p class="description">texture transfer mode</p>
-                </dd>
-              </dl>
-            </dd>
-	  <dt>:change_height(floor, ceiling) <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">changes polygon floor and ceiling heights, if possible</p>
-              <p class="note">won’t squish monsters; returns false instead </p>
-              <p class="note">this is much less optimized than moving a platform </p>
-              <p class="note">you may need to create sides if you are raising/lowering what used to be a flat floor/ceiling </p>
-            </dd>
-	  <dt>:check_collision(x0, y0, z0, owner, x1, y1, z1 [, include_objects] [, include_media]) <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">returns t, x, y, z, polygon, where t is nil (if there was no collision), or the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the collision is with the surface of a liquid) where the line segment collided with the map (or object or media); and x, y, z, polygon is the location of the collision, or the end point if there was no collision</p>
-              <p class="note">the owner is a monster or player to ignore, or nil </p>
-              <p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
-              <p class="note">in order of descending speed: find_polygon(), check_collision() without objects, check_collision() including objects </p>
-            </dd>
+<dd><dl>
+<dt>.collection</dt>
+<dd><p class="description">texture collection</p></dd>
+<dt>.height<br>.z</dt>
+<dd><p class="description">height</p></dd>
+<dt>.light</dt>
+<dd><p class="description">texture light</p></dd>
+<dt>.texture_index</dt>
+<dd><p class="description">texture bitmap index</p></dd>
+<dt>.texture_x</dt>
+<dd><p class="description">texture x offset</p></dd>
+<dt>.texture_y</dt>
+<dd><p class="description">texture y offset</p></dd>
+<dt>.transfer_mode</dt>
+<dd><p class="description">texture transfer mode</p></dd>
+</dl></dd>
+	  <dt>:change_height(floor, ceiling) <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">changes polygon floor and ceiling heights, if possible</p>
+<p class="note">won’t squish monsters; returns false instead </p>
+<p class="note">this is much less optimized than moving a platform </p>
+<p class="note">you may need to create sides if you are raising/lowering what used to be a flat floor/ceiling </p>
+</dd>
+	  <dt>:check_collision(x0, y0, z0, owner, x1, y1, z1 [, include_objects] [, include_media]) <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">returns t, x, y, z, polygon, where t is nil (if there was no collision), or the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the collision is with the surface of a liquid) where the line segment collided with the map (or object or media); and x, y, z, polygon is the location of the collision, or the end point if there was no collision</p>
+<p class="note">the owner is a monster or player to ignore, or nil </p>
+<p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
+<p class="note">in order of descending speed: find_polygon(), check_collision() without objects, check_collision() including objects </p>
+</dd>
       <dt>:contains(x, y [, z])</dt>
-            <dd>
-              <p class="description">whether the point is in this polygon</p>
-            </dd>
+<dd><p class="description">whether the point is in this polygon</p></dd>
       <dt>
     .endpoints[n]</dt>
-            <dd>
-              <p class="description">returns endpoint n</p>
-            </dd>
+<dd><p class="description">returns endpoint n</p></dd>
       <dt>:endpoints()</dt>
-            <dd>
-              <p class="description">iterates through all of this polygon’s endpoints</p>
-            </dd>
-	  <dt>:find_polygon(x1, y1, x2, y2) <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">traverses map from (x1, y1) and returns polygon containing (x2, y2)</p>
-              <p class="note">can be nil if there is no direct route between the two points, or the destination point is not in any polygon </p>
-              <p class="note">ignores floor/ceiling height </p>
-            </dd>
-      <dt>:find_line_crossed_leaving(x1, y1, x2, y2) <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">returns the polygon line crossed by line segment (x1, y1) (x2, y2)</p>
-              <p class="note">can be nil if the line segment doesn’t intersect a polygon line </p>
-            </dd>
+<dd><p class="description">iterates through all of this polygon’s endpoints</p></dd>
+	  <dt>:find_polygon(x1, y1, x2, y2) <span class="version">20210408</span>
+</dt>
+<dd>
+<p class="description">traverses map from (x1, y1) and returns polygon containing (x2, y2)</p>
+<p class="note">can be nil if there is no direct route between the two points, or the destination point is not in any polygon </p>
+<p class="note">ignores floor/ceiling height </p>
+</dd>
+      <dt>:find_line_crossed_leaving(x1, y1, x2, y2) <span class="version">20080707</span>
+</dt>
+<dd>
+<p class="description">returns the polygon line crossed by line segment (x1, y1) (x2, y2)</p>
+<p class="note">can be nil if the line segment doesn’t intersect a polygon line </p>
+</dd>
       <dt>
     .lines[n]</dt>
-            <dd>
-              <p class="description">returns polygon line n</p>
-            </dd>
+<dd><p class="description">returns polygon line n</p></dd>
       <dt>:lines()</dt>
-            <dd>
-              <p class="description">iterates through all of this polygon’s lines</p>
-            </dd>
+<dd><p class="description">iterates through all of this polygon’s lines</p></dd>
       <dt>.media</dt>
-            <dd>
-              <p class="description">polygon media (liquid)</p>
-            </dd>
+<dd><p class="description">polygon media (liquid)</p></dd>
       <dt>:monsters()</dt>
-            <dd>
-              <p class="description">iterates through all monsters in this polygon (including player monsters)</p>
-            </dd>
+<dd><p class="description">iterates through all monsters in this polygon (including player monsters)</p></dd>
       <dt>.permutation</dt>
-            <dd>
-              <p class="description">raw permutation index of this polygon</p>
-            </dd>
+<dd><p class="description">raw permutation index of this polygon</p></dd>
       <dt>:play_sound(sound)</dt>
-            <dd>
-              <p class="description">plays sound in center of polygon on floor</p>
-            </dd>
+<dd><p class="description">plays sound in center of polygon on floor</p></dd>
       <dt>:play_sound(x, y, z, sound [, pitch])</dt>
-            <dd>
-              <p class="description">plays sound at location</p>
-              <p class="note">if you want to play a sound at an object location, use that object’s play_sound function instead </p>
-            </dd>
+<dd>
+<p class="description">plays sound at location</p>
+<p class="note">if you want to play a sound at an object location, use that object’s play_sound function instead </p>
+</dd>
       <dt>
     .sides[n]</dt>
-            <dd>
-              <p class="description">returns polygon side n if it exists</p>
-            </dd>
+<dd><p class="description">returns polygon side n if it exists</p></dd>
       <dt>:sides()</dt>
-            <dd>
-              <p class="description">iterates through all of this polygon’s sides</p>
-            </dd>
+<dd><p class="description">iterates through all of this polygon’s sides</p></dd>
       <dt>.type</dt>
-            <dd>
-              <p class="description">polygon type</p>
-            </dd>
-      <dt>.visible_on_automap <span class="version">20150619</span></dt>
-            <dd>
-              <p class="description">whether polygon is revealed on local player’s automap</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">center of polygon</p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">center of polygon</p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">shortcut for .floor.height</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Projectiles"></a>Projectiles</h3>
-      <dl>
-        <dt># Projectiles</dt>
-        <dd>
-          <p class="description">maximum number of projectiles</p>
-        </dd>
-        <dt>Projectiles()</dt>
-        <dd>
-          <p class="description">iterates through all valid projectiles</p>
-        </dd>
-        <dt>Projectiles.new(x, y, z, polygon, type)</dt>
-        <dd>
-          <p class="description">returns a new projectile</p>
-          <p class="note">remember to set the projectile’s elevation, facing and owner immediately after you’ve created it </p>
-        </dd>
-        <dt>Projectiles[index]</dt>
-        <dd>
-          <dl>
-      <dt>:delete() <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">removes projectile from the map</p>
-            </dd>
+<dd><p class="description">polygon type</p></dd>
+      <dt>.visible_on_automap <span class="version">20150619</span>
+</dt>
+<dd><p class="description">whether polygon is revealed on local player’s automap</p></dd>
+      <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">center of polygon</p></dd>
+      <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">center of polygon</p></dd>
+      <dt>.z<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">shortcut for .floor.height</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Projectiles"></a>Projectiles</h3>
+<dl>
+<dt># Projectiles</dt>
+<dd><p class="description">maximum number of projectiles</p></dd>
+<dt>Projectiles()</dt>
+<dd><p class="description">iterates through all valid projectiles</p></dd>
+<dt>Projectiles.new(x, y, z, polygon, type)</dt>
+<dd>
+<p class="description">returns a new projectile</p>
+<p class="note">remember to set the projectile’s elevation, facing and owner immediately after you’ve created it </p>
+</dd>
+<dt>Projectiles[index]</dt>
+<dd><dl>
+      <dt>:delete() <span class="version">20111201</span>
+</dt>
+<dd><p class="description">removes projectile from the map</p></dd>
       <dt>.damage_scale</dt>
-            <dd>
-              <p class="description">amount to scale projectile’s normal damage by upon detonating</p>
-            </dd>
+<dd><p class="description">amount to scale projectile’s normal damage by upon detonating</p></dd>
       <dt>.dz</dt>
-            <dd>
-              <p class="description">instantaneous downward velocity</p>
-            </dd>
+<dd><p class="description">instantaneous downward velocity</p></dd>
       <dt>.elevation<br>.pitch</dt>
-            <dd>
-              <p class="description">vertical angle</p>
-            </dd>
+<dd><p class="description">vertical angle</p></dd>
       <dt>.facing<br>.yaw</dt>
-            <dd>
-              <p class="description">direction</p>
-            </dd>
+<dd><p class="description">direction</p></dd>
       <dt>:play_sound(sound)</dt>
-            <dd>
-              <p class="description">plays sound coming from this projectile</p>
-            </dd>
+<dd><p class="description">plays sound coming from this projectile</p></dd>
       <dt>:position(x, y, z, polygon)</dt>
-            <dd>
-              <p class="description">sets projectile position</p>
-            </dd>
+<dd><p class="description">sets projectile position</p></dd>
       <dt>.owner</dt>
-            <dd>
-              <p class="description">monster that fired projectile, or nil</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon the projectile is in</p>
-            </dd>
+<dd><p class="description">monster that fired projectile, or nil</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon the projectile is in</p></dd>
       <dt>.target</dt>
-            <dd>
-              <p class="description">target of guided projectile, or nil</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">type of projectile</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Scenery"></a>Scenery</h3>
-      <dl>
-        <dt># Scenery</dt>
-        <dd>
-          <p class="description">maximum number of map objects</p>
-        </dd>
-        <dt>Scenery()</dt>
-        <dd>
-          <p class="description">iterates through all valid scenery</p>
-        </dd>
-        <dt>Scenery.new(x, y, height, polygon, type)</dt>
-        <dd>
-          <p class="description">returns a new scenery</p>
-        </dd>
-        <dt>Scenery[index]</dt>
-        <dd>
-          <dl>
+<dd><p class="description">target of guided projectile, or nil</p></dd>
+      <dt>.type<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of projectile</p></dd>
+      <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Scenery"></a>Scenery</h3>
+<dl>
+<dt># Scenery</dt>
+<dd><p class="description">maximum number of map objects</p></dd>
+<dt>Scenery()</dt>
+<dd><p class="description">iterates through all valid scenery</p></dd>
+<dt>Scenery.new(x, y, height, polygon, type)</dt>
+<dd><p class="description">returns a new scenery</p></dd>
+<dt>Scenery[index]</dt>
+<dd><dl>
       <dt>:damage()</dt>
-            <dd>
-              <p class="description">damages scenery</p>
-            </dd>
-      <dt>.damaged<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">whether this scenery has been damaged</p>
-            </dd>
+<dd><p class="description">damages scenery</p></dd>
+      <dt>.damaged<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">whether this scenery has been damaged</p></dd>
       <dt>:delete()</dt>
-            <dd>
-              <p class="description">removes scenery from the map</p>
-            </dd>
+<dd><p class="description">removes scenery from the map</p></dd>
       <dt>.facing</dt>
-            <dd>
-              <p class="description">direction scenery is facing</p>
-            </dd>
+<dd><p class="description">direction scenery is facing</p></dd>
       <dt>:play_sound(sound)</dt>
-            <dd>
-              <p class="description">play sound coming from this scenery</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon the scenery is in</p>
-            </dd>
-      <dt>:position(x, y, z, polygon) <span class="version">20090909</span></dt>
-            <dd>
-              <p class="description">sets position of scenery</p>
-            </dd>
+<dd><p class="description">play sound coming from this scenery</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon the scenery is in</p></dd>
+      <dt>:position(x, y, z, polygon) <span class="version">20090909</span>
+</dt>
+<dd><p class="description">sets position of scenery</p></dd>
       <dt>.solid</dt>
-            <dd>
-              <p class="description">whether this scenery is solid</p>
-            </dd>
-	  <dt>:teleport_in() <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">teleports scenery in</p>
-              <p class="note">can fail silently if there are not enough effects slots </p>
-            </dd>
-	  <dt>:teleport_out() <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">teleports scenery out</p>
-              <p class="note">can fail silently if there are not enough effects slots </p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">type of scenery</p>
-            </dd>
-	  <dt>.visible <span class="version">20240712</span></dt>
-            <dd>
-              <p class="description">whether this scenery is visible</p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Sides"></a>Sides</h3>
-      <dl>
-        <dt># Sides</dt>
-        <dd>
-          <p class="description">number of sides on the level</p>
-        </dd>
-        <dt>Sides()</dt>
-        <dd>
-          <p class="description">iterates through all sides on the level</p>
-        </dd>
-        <dt>Sides.new(polygon, line) <span class="version">20080707</span></dt>
-        <dd>
-          <p class="description">creates a new side</p>
-          <p class="note">side must not already exist </p>
-        </dd>
-        <dt>Sides[index]</dt>
-        <dd>
-          <dl>
-	  <dt>.ambient_delta <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">constant offset from calculated light intensity</p>
-            </dd>
+<dd><p class="description">whether this scenery is solid</p></dd>
+	  <dt>:teleport_in() <span class="version">20240712</span>
+</dt>
+<dd>
+<p class="description">teleports scenery in</p>
+<p class="note">can fail silently if there are not enough effects slots </p>
+</dd>
+	  <dt>:teleport_out() <span class="version">20240712</span>
+</dt>
+<dd>
+<p class="description">teleports scenery out</p>
+<p class="note">can fail silently if there are not enough effects slots </p>
+</dd>
+      <dt>.type<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of scenery</p></dd>
+	  <dt>.visible <span class="version">20240712</span>
+</dt>
+<dd><p class="description">whether this scenery is visible</p></dd>
+      <dt>.x<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Sides"></a>Sides</h3>
+<dl>
+<dt># Sides</dt>
+<dd><p class="description">number of sides on the level</p></dd>
+<dt>Sides()</dt>
+<dd><p class="description">iterates through all sides on the level</p></dd>
+<dt>Sides.new(polygon, line) <span class="version">20080707</span>
+</dt>
+<dd>
+<p class="description">creates a new side</p>
+<p class="note">side must not already exist </p>
+</dd>
+<dt>Sides[index]</dt>
+<dd><dl>
+	  <dt>.ambient_delta <span class="version">20210408</span>
+</dt>
+<dd><p class="description">constant offset from calculated light intensity</p></dd>
       <dt>.control_panel</dt>
-            <dd>
-              <p class="note">nil if the side is not a control panel </p>
-              <p class="note">set to true or false to create/destroy a control panel <span class="version">20080707</span></p>
-              <dl>
-                <dt>.can_be_destroyed <span class="version">20080707</span></dt>
-                <dd>
-                  <p class="description">whether projectiles destroy this switch</p>
-                </dd>
-                <dt>.light_dependent <span class="version">20080707</span></dt>
-                <dd>
-                  <p class="description">switch can only be activated if light &gt; 75%</p>
-                </dd>
-                <dt>.only_toggled_by_weapons <span class="version">20080707</span></dt>
-                <dd>
-                  <p class="description">switch can only be toggled by weapons</p>
-                </dd>
-                <dt>.permutation</dt>
-                <dd>
-                  <p class="description">permutation of control panel</p>
-                </dd>
-                <dt>.repair <span class="version">20080707</span></dt>
-                <dd>
-                  <p class="description">switch is a repair switch</p>
-                </dd>
-                <dt>.status <span class="version">20080707</span></dt>
-                <dd>
-                  <p class="description">switch is active</p>
-                </dd>
-                <dt>.type <span class="version">20080707</span></dt>
-                <dd>
-                  <p class="description">type of control panel</p>
-                </dd>
-                <dt>.uses_item<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-                <dd>
-                  <p class="description">i.e. chip insertion</p>
-                </dd>
-              </dl>
-            </dd>
+<dd>
+<p class="note">nil if the side is not a control panel </p>
+<p class="note">set to true or false to create/destroy a control panel <span class="version">20080707</span></p>
+<dl>
+<dt>.can_be_destroyed <span class="version">20080707</span>
+</dt>
+<dd><p class="description">whether projectiles destroy this switch</p></dd>
+<dt>.light_dependent <span class="version">20080707</span>
+</dt>
+<dd><p class="description">switch can only be activated if light &gt; 75%</p></dd>
+<dt>.only_toggled_by_weapons <span class="version">20080707</span>
+</dt>
+<dd><p class="description">switch can only be toggled by weapons</p></dd>
+<dt>.permutation</dt>
+<dd><p class="description">permutation of control panel</p></dd>
+<dt>.repair <span class="version">20080707</span>
+</dt>
+<dd><p class="description">switch is a repair switch</p></dd>
+<dt>.status <span class="version">20080707</span>
+</dt>
+<dd><p class="description">switch is active</p></dd>
+<dt>.type <span class="version">20080707</span>
+</dt>
+<dd><p class="description">type of control panel</p></dd>
+<dt>.uses_item<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">i.e. chip insertion</p></dd>
+</dl>
+</dd>
       <dt>.primary<br>.secondary<br>.transparent</dt>
-            <dd>
-              <dl>
-                <dt>.collection</dt>
-                <dd>
-                  <p class="description">texture collection</p>
-                </dd>
-                <dt>.empty</dt>
-                <dd>
-                  <p class="description">whether side is empty</p>
-                  <p class="note">transparent sides only in earlier versions <span class="version">Git</span></p>
-                  <p class="note">setting empty to false is a no-op; set collection and texture_index instead </p>
-                </dd>
-                <dt>.light</dt>
-                <dd>
-                  <p class="description">texture light</p>
-                </dd>
-                <dt>.texture_index</dt>
-                <dd>
-                  <p class="description">texture bitmap index</p>
-                </dd>
-                <dt>.texture_x</dt>
-                <dd>
-                  <p class="description">texture x offset</p>
-                </dd>
-                <dt>.texture_y</dt>
-                <dd>
-                  <p class="description">texture y offset</p>
-                </dd>
-                <dt>.transfer_mode</dt>
-                <dd>
-                  <p class="description">texture transfer mode</p>
-                </dd>
-              </dl>
-            </dd>
+<dd><dl>
+<dt>.collection</dt>
+<dd><p class="description">texture collection</p></dd>
+<dt>.empty</dt>
+<dd>
+<p class="description">whether side is empty</p>
+<p class="note">transparent sides only in earlier versions <span class="version">Git</span></p>
+<p class="note">setting empty to false is a no-op; set collection and texture_index instead </p>
+</dd>
+<dt>.light</dt>
+<dd><p class="description">texture light</p></dd>
+<dt>.texture_index</dt>
+<dd><p class="description">texture bitmap index</p></dd>
+<dt>.texture_x</dt>
+<dd><p class="description">texture x offset</p></dd>
+<dt>.texture_y</dt>
+<dd><p class="description">texture y offset</p></dd>
+<dt>.transfer_mode</dt>
+<dd><p class="description">texture transfer mode</p></dd>
+</dl></dd>
       <dt>:play_sound(sound [, pitch])</dt>
-            <dd>
-              <p class="description">play sound coming from this side</p>
-            </dd>
-      <dt>.line<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">line this side is attached to</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">polygon this side is attached to</p>
-            </dd>
-      <dt>:recalculate_type() <span class="version">20081213</span></dt>
-            <dd>
-              <p class="description">correct the side type (Forge can generate incorrect side types)</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">type of side</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="SoundObjects"></a>SoundObjects</h3>
-      <dl>
-        <dt># SoundObjects</dt>
-        <dd>
-          <p class="description">number of map objects in the level</p>
-        </dd>
-        <dt>SoundObjects()</dt>
-        <dd>
-          <p class="description">iterates through all sound objects in the level</p>
-        </dd>
-        <dt>SoundObjects[index]</dt>
-        <dd>
-          <dl>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether sound object location z is from ceiling</p>
-            </dd>
-      <dt>.light<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">if sound object uses a light for volume, the light it uses</p>
-              <p class="note">can be nil if sound object doesn’t use light for volume </p>
-            </dd>
-      <dt>.on_platform<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether sound object is a platform sound</p>
-            </dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">sound object polygon</p>
-            </dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">type of sound object</p>
-            </dd>
-      <dt>.volume<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">volume of sound object from 0.0 to 1.0</p>
-              <p class="note">can be nil if sound object uses light for volume </p>
-            </dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-              <p class="note">from floor or ceiling </p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Tags"></a>Tags</h3>
-      <dl>
-        <dt>Tags[index]</dt>
-        <dd>
-          <dl>
+<dd><p class="description">play sound coming from this side</p></dd>
+      <dt>.line<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">line this side is attached to</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">polygon this side is attached to</p></dd>
+      <dt>:recalculate_type() <span class="version">20081213</span>
+</dt>
+<dd><p class="description">correct the side type (Forge can generate incorrect side types)</p></dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">type of side</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="SoundObjects"></a>SoundObjects</h3>
+<dl>
+<dt># SoundObjects</dt>
+<dd><p class="description">number of map objects in the level</p></dd>
+<dt>SoundObjects()</dt>
+<dd><p class="description">iterates through all sound objects in the level</p></dd>
+<dt>SoundObjects[index]</dt>
+<dd><dl>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether sound object location z is from ceiling</p></dd>
+      <dt>.light<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description">if sound object uses a light for volume, the light it uses</p>
+<p class="note">can be nil if sound object doesn’t use light for volume </p>
+</dd>
+      <dt>.on_platform<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether sound object is a platform sound</p></dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">sound object polygon</p></dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description">type of sound object</p></dd>
+      <dt>.volume<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description">volume of sound object from 0.0 to 1.0</p>
+<p class="note">can be nil if sound object uses light for volume </p>
+</dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description"></p>
+<p class="note">from floor or ceiling </p>
+</dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Tags"></a>Tags</h3>
+<dl>
+<dt>Tags[index]</dt>
+<dd><dl>
       <dt>.active</dt>
-            <dd>
-              <p class="description">tag is active</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="Terminals"></a>Terminals</h3>
-      <dl>
-        <dt># Terminals</dt>
-        <dd>
-          <p class="description">number of terminal texts in the level</p>
-        </dd>
-        <dt>Terminals()</dt>
-        <dd>
-          <p class="description">iterates through all terminal texts on the level</p>
-        </dd>
-        <dt>Terminals[index]</dt>
-        <dd></dd>
-      </dl>
-    </div>
-    <h1><a name="types"></a>Types and Mnemonics</h1>
-    <div class="tables">
-      <p>The string mnemonics listed below can be used for assignment and as arguments to functions. Additionally, Aleph One’s Lua interpreter has been modified so that equality comparisons between userdata types and strings are possible.</p>
-      <p>For example, this script would move all players on the blue team to the red team:
+<dd><p class="description">tag is active</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="Terminals"></a>Terminals</h3>
+<dl>
+<dt># Terminals</dt>
+<dd><p class="description">number of terminal texts in the level</p></dd>
+<dt>Terminals()</dt>
+<dd><p class="description">iterates through all terminal texts on the level</p></dd>
+<dt>Terminals[index]</dt>
+<dd></dd>
+</dl>
+</div>
+<h1>
+<a name="types"></a>Types and Mnemonics</h1>
+<div class="tables">
+<p>The string mnemonics listed below can be used for assignment and as arguments to functions. Additionally, Aleph One’s Lua interpreter has been modified so that equality comparisons between userdata types and strings are possible.</p>
+<p>For example, this script would move all players on the blue team to the red team:
 <span class="pre">for p in Players() do
   if p.team == "blue" then
     p.team = "red"
@@ -2901,64 +2251,57 @@ nil
 </span>
 If you do this, you should customize them all at the beginning of the script. Changing mnemonics mid-game will confuse anyone who tries to read your script, and probably yourself as well!
 </p>
-      <h3><a name="AmbientSounds"></a>Ambient Sounds</h3>
-      <dl>
-        <dt># AmbientSounds</dt>
-        <dt>AmbientSounds()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"water"</li>
-          <li>"sewage"</li>
-          <li>"lava"</li>
-          <li>"goo"</li>
-          <li>"underwater"</li>
-          <li>"wind"</li>
-          <li>"waterfall"</li>
-          <li>"siren"</li>
-          <li>"fan"</li>
-          <li>"spht door"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"spht platform"</li>
-          <li>"heavy spht door"</li>
-          <li>"heavy spht platform"</li>
-          <li>"light machinery"</li>
-          <li>"heavy machinery"</li>
-          <li>"transformer"</li>
-          <li>"sparking transformer"</li>
-          <li>"machine binder"</li>
-          <li>"machine bookpress"</li>
-          <li>"machine puncher"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"electric hum"</li>
-          <li>"alarm"</li>
-          <li>"night wind"</li>
-          <li>"pfhor door"</li>
-          <li>"pfhor platform"</li>
-          <li>"alien noise 1"</li>
-          <li>"alien noise 2"</li>
-          <li>"alien harmonics"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="Collections"></a>Collections</h3>
-      <dl>
-        <dt># Collections</dt>
-        <dt>Collections()</dt>
-        <dt>Collections[collection]</dt>
-        <dd>
-          <dl>
+<h3>
+<a name="AmbientSounds"></a>Ambient Sounds</h3>
+<dl>
+<dt># AmbientSounds</dt>
+<dt>AmbientSounds()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"water"</li>
+<li>"sewage"</li>
+<li>"lava"</li>
+<li>"goo"</li>
+<li>"underwater"</li>
+<li>"wind"</li>
+<li>"waterfall"</li>
+<li>"siren"</li>
+<li>"fan"</li>
+<li>"spht door"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"spht platform"</li>
+<li>"heavy spht door"</li>
+<li>"heavy spht platform"</li>
+<li>"light machinery"</li>
+<li>"heavy machinery"</li>
+<li>"transformer"</li>
+<li>"sparking transformer"</li>
+<li>"machine binder"</li>
+<li>"machine bookpress"</li>
+<li>"machine puncher"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"electric hum"</li>
+<li>"alarm"</li>
+<li>"night wind"</li>
+<li>"pfhor door"</li>
+<li>"pfhor platform"</li>
+<li>"alien noise 1"</li>
+<li>"alien noise 2"</li>
+<li>"alien harmonics"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="Collections"></a>Collections</h3>
+<dl>
+<dt># Collections</dt>
+<dt>Collections()</dt>
+<dt>Collections[collection]</dt>
+<dd><dl>
       <dt>.bitmap_count</dt>
-            <dd>
-              <p class="description">number of bitmaps in collection</p>
-            </dd>
+<dd><p class="description">number of bitmaps in collection</p></dd>
       
 		
 		
@@ -2993,427 +2336,389 @@ If you do this, you should customize them all at the beginning of the script. Ch
 		
 		
       
-    </dl>
-        </dd>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"interface"</li>
-          <li>"weapons in hand"</li>
-          <li>"juggernaut"</li>
-          <li>"tick"</li>
-          <li>"explosions"</li>
-          <li>"hunter"</li>
-          <li>"player"</li>
-          <li>"items"</li>
-          <li>"trooper"</li>
-          <li>"fighter"</li>
-          <li>"defender"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"yeti"</li>
-          <li>"bob"</li>
-          <li>"vacbob"</li>
-          <li>"enforcer"</li>
-          <li>"drone"</li>
-          <li>"compiler"</li>
-          <li>"water"</li>
-          <li>"lava"</li>
-          <li>"sewage"</li>
-          <li>"jjaro"</li>
-          <li>"pfhor"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"water scenery"</li>
-          <li>"lava scenery"</li>
-          <li>"sewage scenery"</li>
-          <li>"jjaro scenery"</li>
-          <li>"pfhor scenery"</li>
-          <li>"day"</li>
-          <li>"night"</li>
-          <li>"moon"</li>
-          <li>"space"</li>
-          <li>"cyborg"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="CompletionStates"></a>Completion States</h3>
-      <dl>
-        <dt># CompletionStates</dt>
-        <dt>CompletionStates()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"unfinished"</li>
-        <li>"finished"</li>
-        <li>"failed"</li>
-      </ul>
-      <h3><a name="ControlPanelClasses"></a>Control Panel Classes</h3>
-      <dl>
-        <dt># ControlPanelClasses</dt>
-        <dt>ControlPanelClasses()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"oxygen recharger"</li>
-          <li>"single shield recharger"</li>
-          <li>"double shield recharger"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"triple shield recharger"</li>
-          <li>"light switch"</li>
-          <li>"platform switch"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"tag switch"</li>
-          <li>"pattern buffer"</li>
-          <li>"terminal"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="ControlPanelTypes"></a>Control Panel Types</h3>
-      <dl>
-        <dt># ControlPanelTypes</dt>
-        <dt>ControlPanelTypes()</dt>
-        <dt>ControlPanelTypes[control_panel_type]</dt>
-        <dd>
-          <dl>
-      <dt>.active_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">bitmap index when control panel is active</p>
-            </dd>
-      <dt>.class<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">class of this control panel type</p>
-            </dd>
-      <dt>.collection<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">collection this control panel belongs to</p>
-            </dd>
-      <dt>.inactive_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
-            <dd>
-              <p class="description">bitmap index when control panel is inactive/destroyed</p>
-            </dd>
-    </dl>
-        </dd>
-      </dl>
-      <h3><a name="DamageTypes"></a>Damage</h3>
-      <dl>
-        <dt># DamageTypes</dt>
-        <dt>DamageTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"explosion"</li>
-          <li>"staff"</li>
-          <li>"projectile"</li>
-          <li>"absorbed"</li>
-          <li>"flame"</li>
-          <li>"claws"</li>
-          <li>"alien weapon"</li>
-          <li>"hulk slap"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"compiler"</li>
-          <li>"fusion"</li>
-          <li>"hunter"</li>
-          <li>"fists"</li>
-          <li>"teleporter"</li>
-          <li>"defender"</li>
-          <li>"yeti claws"</li>
-          <li>"yeti projectile"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"crushing"</li>
-          <li>"lava"</li>
-          <li>"suffocation"</li>
-          <li>"goo"</li>
-          <li>"energy drain"</li>
-          <li>"oxygen drain"</li>
-          <li>"drone"</li>
-          <li>"shotgun"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="DifficultyTypes"></a>Difficulty</h3>
-      <dl>
-        <dt># DifficultyTypes</dt>
-        <dt>DifficultyTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"kindergarten"</li>
-        <li>"easy"</li>
-        <li>"normal"</li>
-        <li>"major damage"</li>
-        <li>"total carnage"</li>
-      </ul>
-      <h3><a name="EffectTypes"></a>Effects</h3>
-      <dl>
-        <dt># EffectTypes</dt>
-        <dt>EffectTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"rocket explosion"</li>
-          <li>"rocket contrail"</li>
-          <li>"grenade explosion"</li>
-          <li>"grenade contrail"</li>
-          <li>"bullet ricochet"</li>
-          <li>"alien weapon ricochet"</li>
-          <li>"flamethrower burst"</li>
-          <li>"fighter blood splash"</li>
-          <li>"player blood splash"</li>
-          <li>"civilian blood splash"</li>
-          <li>"assimilated civilian blood splash"</li>
-          <li>"enforcer blood splash"</li>
-          <li>"compiler bolt minor detonation"</li>
-          <li>"compiler bolt major detonation"</li>
-          <li>"compiler bolt major contrail"</li>
-          <li>"fighter projectile detonation"</li>
-          <li>"fighter melee detonation"</li>
-          <li>"hunter projectile detonation"</li>
-          <li>"hunter spark"</li>
-          <li>"minor fusion detonation"</li>
-          <li>"major fusion detonation"</li>
-          <li>"major fusion contrail"</li>
-          <li>"fist detonation"</li>
-          <li>"minor defender detonation"</li>
-          <li>"major defender detonation"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"defender spark"</li>
-          <li>"trooper blood splash"</li>
-          <li>"water lamp breaking"</li>
-          <li>"lava lamp breaking"</li>
-          <li>"sewage lamp breaking"</li>
-          <li>"alien lamp breaking"</li>
-          <li>"metallic clang"</li>
-          <li>"teleport object in"</li>
-          <li>"teleport object out"</li>
-          <li>"small water splash"</li>
-          <li>"medium water splash"</li>
-          <li>"large water splash"</li>
-          <li>"large water emergence"</li>
-          <li>"small lava splash"</li>
-          <li>"medium lava splash"</li>
-          <li>"large lava splash"</li>
-          <li>"large lava emergence"</li>
-          <li>"small sewage splash"</li>
-          <li>"medium sewage splash"</li>
-          <li>"large sewage splash"</li>
-          <li>"large sewage emergence"</li>
-          <li>"small goo splash"</li>
-          <li>"medium goo splash"</li>
-          <li>"large goo splash"</li>
-          <li>"large goo emergence"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"minor hummer projectile detonation"</li>
-          <li>"major hummer projectile detonation"</li>
-          <li>"durandal hummer projectile detonation"</li>
-          <li>"hummer spark"</li>
-          <li>"cyborg projectile detonation"</li>
-          <li>"cyborg blood splash"</li>
-          <li>"minor fusion dispersal"</li>
-          <li>"major fusion dispersal"</li>
-          <li>"overloaded fusion dispersal"</li>
-          <li>"sewage yeti blood splash"</li>
-          <li>"sewage yeti projectile detonation"</li>
-          <li>"water yeti blood splash"</li>
-          <li>"lava yeti blood splash"</li>
-          <li>"lava yeti projectile detonation"</li>
-          <li>"yeti melee detonation"</li>
-          <li>"juggernaut spark"</li>
-          <li>"juggernaut missile contrail"</li>
-          <li>"small jjaro splash"</li>
-          <li>"medium jjaro splash"</li>
-          <li>"large jjaro splash"</li>
-          <li>"large jjaro emergence"</li>
-          <li>"civilian fusion blood splash"</li>
-          <li>"assimilated civilian fusion blood splash"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="EphemeraQualities"></a>Ephemera Quality</h3>
-      <dl>
-        <dt># EphemeraQualities</dt>
-        <dt>EphemeraQualities()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"off"</li>
-        <li>"low"</li>
-        <li>"medium"</li>
-        <li>"high"</li>
-        <li>"ultra"</li>
-      </ul>
-      <h3><a name="FadeTypes"></a>Faders</h3>
-      <dl>
-        <dt># FadeTypes</dt>
-        <dt>FadeTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"start cinematic fade in"</li>
-          <li>"cinematic fade in"</li>
-          <li>"long cinematic fade in"</li>
-          <li>"cinematic fade out"</li>
-          <li>"end cinematic fade out"</li>
-          <li>"red"</li>
-          <li>"big red"</li>
-          <li>"bonus"</li>
-          <li>"bright"</li>
-          <li>"long bright"</li>
-          <li>"yellow"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"big yellow"</li>
-          <li>"purple"</li>
-          <li>"cyan"</li>
-          <li>"white"</li>
-          <li>"big white"</li>
-          <li>"orange"</li>
-          <li>"long orange"</li>
-          <li>"green"</li>
-          <li>"long green"</li>
-          <li>"static"</li>
-          <li>"negative"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"big negative"</li>
-          <li>"flicker negative"</li>
-          <li>"dodge purple"</li>
-          <li>"burn cyan"</li>
-          <li>"dodge yellow"</li>
-          <li>"burn green"</li>
-          <li>"tint green"</li>
-          <li>"tint blue"</li>
-          <li>"tint orange"</li>
-          <li>"tint gross"</li>
-          <li>"tint jjaro"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="FogModes"></a>Fog Modes</h3>
-      <dl>
-        <dt># FogModes</dt>
-        <dt>FogModes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"linear"</li>
-        <li>"exp"</li>
-        <li>"exp2"</li>
-      </ul>
-      <h3><a name="GameTypes"></a>Game Types</h3>
-      <dl>
-        <dt># GameTypes</dt>
-        <dt>GameTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"kill monsters"</li>
-          <li>"cooperative play"</li>
-          <li>"capture the flag"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"king of the hill"</li>
-          <li>"kill the man with the ball"</li>
-          <li>"defense"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"rugby"</li>
-          <li>"tag"</li>
-          <li>"netscript"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="ItemKinds"></a>Item Kinds</h3>
-      <dl>
-        <dt># ItemKinds</dt>
-        <dt>ItemKinds()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"weapon"</li>
-        <li>"ammunition"</li>
-        <li>"powerup"</li>
-        <li>"item"</li>
-        <li>"weapon powerup"</li>
-        <li>"ball"</li>
-      </ul>
-      <h3><a name="ItemTypes"></a>Item Types</h3>
-      <dl>
-        <dt># ItemTypes</dt>
-        <dt>ItemTypes()</dt>
-        <dt>ItemTypes[item_type]</dt>
-        <dd>
-          <dl>
-      <dt>.initial_count <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">how many items of this type are placed in the level during initial placement</p>
-            </dd>
-	  <dt>.kind<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">kind of item this is</p>
-            </dd>
-      <dt>.maximum_count <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">maximum number of this type of item in the level and in player inventories</p>
-            </dd>
-	  <dt>.maximum_inventory <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">maximum number of this type of item players can carry</p>
-            </dd>
-      <dt>.minimum_count <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">minimum number of this type of item in the level and in player inventories</p>
-            </dd>
-      <dt>.random_chance <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">chance from 0 to 1.0 this item will appear in a respawn period</p>
-            </dd>
-      <dt>.random_location <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether items of this type spawn in random locations</p>
-            </dd>
-      <dt>.total_available <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">total number of items of this type that can be spawned in this level</p>
-              <p class="note">-1 means infinite items are available </p>
-              <p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before item placement is done </p>
-            </dd>
+    </dl></dd>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"interface"</li>
+<li>"weapons in hand"</li>
+<li>"juggernaut"</li>
+<li>"tick"</li>
+<li>"explosions"</li>
+<li>"hunter"</li>
+<li>"player"</li>
+<li>"items"</li>
+<li>"trooper"</li>
+<li>"fighter"</li>
+<li>"defender"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"yeti"</li>
+<li>"bob"</li>
+<li>"vacbob"</li>
+<li>"enforcer"</li>
+<li>"drone"</li>
+<li>"compiler"</li>
+<li>"water"</li>
+<li>"lava"</li>
+<li>"sewage"</li>
+<li>"jjaro"</li>
+<li>"pfhor"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"water scenery"</li>
+<li>"lava scenery"</li>
+<li>"sewage scenery"</li>
+<li>"jjaro scenery"</li>
+<li>"pfhor scenery"</li>
+<li>"day"</li>
+<li>"night"</li>
+<li>"moon"</li>
+<li>"space"</li>
+<li>"cyborg"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="CompletionStates"></a>Completion States</h3>
+<dl>
+<dt># CompletionStates</dt>
+<dt>CompletionStates()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"unfinished"</li>
+<li>"finished"</li>
+<li>"failed"</li>
+</ul>
+<h3>
+<a name="ControlPanelClasses"></a>Control Panel Classes</h3>
+<dl>
+<dt># ControlPanelClasses</dt>
+<dt>ControlPanelClasses()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"oxygen recharger"</li>
+<li>"single shield recharger"</li>
+<li>"double shield recharger"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"triple shield recharger"</li>
+<li>"light switch"</li>
+<li>"platform switch"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"tag switch"</li>
+<li>"pattern buffer"</li>
+<li>"terminal"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="ControlPanelTypes"></a>Control Panel Types</h3>
+<dl>
+<dt># ControlPanelTypes</dt>
+<dt>ControlPanelTypes()</dt>
+<dt>ControlPanelTypes[control_panel_type]</dt>
+<dd><dl>
+      <dt>.active_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">bitmap index when control panel is active</p></dd>
+      <dt>.class<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">class of this control panel type</p></dd>
+      <dt>.collection<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">collection this control panel belongs to</p></dd>
+      <dt>.inactive_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span>
+</dt>
+<dd><p class="description">bitmap index when control panel is inactive/destroyed</p></dd>
+    </dl></dd>
+</dl>
+<h3>
+<a name="DamageTypes"></a>Damage</h3>
+<dl>
+<dt># DamageTypes</dt>
+<dt>DamageTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"explosion"</li>
+<li>"staff"</li>
+<li>"projectile"</li>
+<li>"absorbed"</li>
+<li>"flame"</li>
+<li>"claws"</li>
+<li>"alien weapon"</li>
+<li>"hulk slap"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"compiler"</li>
+<li>"fusion"</li>
+<li>"hunter"</li>
+<li>"fists"</li>
+<li>"teleporter"</li>
+<li>"defender"</li>
+<li>"yeti claws"</li>
+<li>"yeti projectile"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"crushing"</li>
+<li>"lava"</li>
+<li>"suffocation"</li>
+<li>"goo"</li>
+<li>"energy drain"</li>
+<li>"oxygen drain"</li>
+<li>"drone"</li>
+<li>"shotgun"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="DifficultyTypes"></a>Difficulty</h3>
+<dl>
+<dt># DifficultyTypes</dt>
+<dt>DifficultyTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"kindergarten"</li>
+<li>"easy"</li>
+<li>"normal"</li>
+<li>"major damage"</li>
+<li>"total carnage"</li>
+</ul>
+<h3>
+<a name="EffectTypes"></a>Effects</h3>
+<dl>
+<dt># EffectTypes</dt>
+<dt>EffectTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"rocket explosion"</li>
+<li>"rocket contrail"</li>
+<li>"grenade explosion"</li>
+<li>"grenade contrail"</li>
+<li>"bullet ricochet"</li>
+<li>"alien weapon ricochet"</li>
+<li>"flamethrower burst"</li>
+<li>"fighter blood splash"</li>
+<li>"player blood splash"</li>
+<li>"civilian blood splash"</li>
+<li>"assimilated civilian blood splash"</li>
+<li>"enforcer blood splash"</li>
+<li>"compiler bolt minor detonation"</li>
+<li>"compiler bolt major detonation"</li>
+<li>"compiler bolt major contrail"</li>
+<li>"fighter projectile detonation"</li>
+<li>"fighter melee detonation"</li>
+<li>"hunter projectile detonation"</li>
+<li>"hunter spark"</li>
+<li>"minor fusion detonation"</li>
+<li>"major fusion detonation"</li>
+<li>"major fusion contrail"</li>
+<li>"fist detonation"</li>
+<li>"minor defender detonation"</li>
+<li>"major defender detonation"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"defender spark"</li>
+<li>"trooper blood splash"</li>
+<li>"water lamp breaking"</li>
+<li>"lava lamp breaking"</li>
+<li>"sewage lamp breaking"</li>
+<li>"alien lamp breaking"</li>
+<li>"metallic clang"</li>
+<li>"teleport object in"</li>
+<li>"teleport object out"</li>
+<li>"small water splash"</li>
+<li>"medium water splash"</li>
+<li>"large water splash"</li>
+<li>"large water emergence"</li>
+<li>"small lava splash"</li>
+<li>"medium lava splash"</li>
+<li>"large lava splash"</li>
+<li>"large lava emergence"</li>
+<li>"small sewage splash"</li>
+<li>"medium sewage splash"</li>
+<li>"large sewage splash"</li>
+<li>"large sewage emergence"</li>
+<li>"small goo splash"</li>
+<li>"medium goo splash"</li>
+<li>"large goo splash"</li>
+<li>"large goo emergence"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"minor hummer projectile detonation"</li>
+<li>"major hummer projectile detonation"</li>
+<li>"durandal hummer projectile detonation"</li>
+<li>"hummer spark"</li>
+<li>"cyborg projectile detonation"</li>
+<li>"cyborg blood splash"</li>
+<li>"minor fusion dispersal"</li>
+<li>"major fusion dispersal"</li>
+<li>"overloaded fusion dispersal"</li>
+<li>"sewage yeti blood splash"</li>
+<li>"sewage yeti projectile detonation"</li>
+<li>"water yeti blood splash"</li>
+<li>"lava yeti blood splash"</li>
+<li>"lava yeti projectile detonation"</li>
+<li>"yeti melee detonation"</li>
+<li>"juggernaut spark"</li>
+<li>"juggernaut missile contrail"</li>
+<li>"small jjaro splash"</li>
+<li>"medium jjaro splash"</li>
+<li>"large jjaro splash"</li>
+<li>"large jjaro emergence"</li>
+<li>"civilian fusion blood splash"</li>
+<li>"assimilated civilian fusion blood splash"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="EphemeraQualities"></a>Ephemera Quality</h3>
+<dl>
+<dt># EphemeraQualities</dt>
+<dt>EphemeraQualities()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"off"</li>
+<li>"low"</li>
+<li>"medium"</li>
+<li>"high"</li>
+<li>"ultra"</li>
+</ul>
+<h3>
+<a name="FadeTypes"></a>Faders</h3>
+<dl>
+<dt># FadeTypes</dt>
+<dt>FadeTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"start cinematic fade in"</li>
+<li>"cinematic fade in"</li>
+<li>"long cinematic fade in"</li>
+<li>"cinematic fade out"</li>
+<li>"end cinematic fade out"</li>
+<li>"red"</li>
+<li>"big red"</li>
+<li>"bonus"</li>
+<li>"bright"</li>
+<li>"long bright"</li>
+<li>"yellow"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"big yellow"</li>
+<li>"purple"</li>
+<li>"cyan"</li>
+<li>"white"</li>
+<li>"big white"</li>
+<li>"orange"</li>
+<li>"long orange"</li>
+<li>"green"</li>
+<li>"long green"</li>
+<li>"static"</li>
+<li>"negative"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"big negative"</li>
+<li>"flicker negative"</li>
+<li>"dodge purple"</li>
+<li>"burn cyan"</li>
+<li>"dodge yellow"</li>
+<li>"burn green"</li>
+<li>"tint green"</li>
+<li>"tint blue"</li>
+<li>"tint orange"</li>
+<li>"tint gross"</li>
+<li>"tint jjaro"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="FogModes"></a>Fog Modes</h3>
+<dl>
+<dt># FogModes</dt>
+<dt>FogModes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"linear"</li>
+<li>"exp"</li>
+<li>"exp2"</li>
+</ul>
+<h3>
+<a name="GameTypes"></a>Game Types</h3>
+<dl>
+<dt># GameTypes</dt>
+<dt>GameTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"kill monsters"</li>
+<li>"cooperative play"</li>
+<li>"capture the flag"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"king of the hill"</li>
+<li>"kill the man with the ball"</li>
+<li>"defense"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"rugby"</li>
+<li>"tag"</li>
+<li>"netscript"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="ItemKinds"></a>Item Kinds</h3>
+<dl>
+<dt># ItemKinds</dt>
+<dt>ItemKinds()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"weapon"</li>
+<li>"ammunition"</li>
+<li>"powerup"</li>
+<li>"item"</li>
+<li>"weapon powerup"</li>
+<li>"ball"</li>
+</ul>
+<h3>
+<a name="ItemTypes"></a>Item Types</h3>
+<dl>
+<dt># ItemTypes</dt>
+<dt>ItemTypes()</dt>
+<dt>ItemTypes[item_type]</dt>
+<dd><dl>
+      <dt>.initial_count <span class="version">20111201</span>
+</dt>
+<dd><p class="description">how many items of this type are placed in the level during initial placement</p></dd>
+	  <dt>.kind<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">kind of item this is</p></dd>
+      <dt>.maximum_count <span class="version">20111201</span>
+</dt>
+<dd><p class="description">maximum number of this type of item in the level and in player inventories</p></dd>
+	  <dt>.maximum_inventory <span class="version">20210408</span>
+</dt>
+<dd><p class="description">maximum number of this type of item players can carry</p></dd>
+      <dt>.minimum_count <span class="version">20111201</span>
+</dt>
+<dd><p class="description">minimum number of this type of item in the level and in player inventories</p></dd>
+      <dt>.random_chance <span class="version">20111201</span>
+</dt>
+<dd><p class="description">chance from 0 to 1.0 this item will appear in a respawn period</p></dd>
+      <dt>.random_location <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether items of this type spawn in random locations</p></dd>
+      <dt>.total_available <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description">total number of items of this type that can be spawned in this level</p>
+<p class="note">-1 means infinite items are available </p>
+<p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before item placement is done </p>
+</dd>
       
 		
 		
@@ -3452,405 +2757,333 @@ If you do this, you should customize them all at the beginning of the script. Ch
 		
 		
       
-    </dl>
-        </dd>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"knife"</li>
-          <li>"pistol"</li>
-          <li>"pistol ammo"</li>
-          <li>"fusion pistol"</li>
-          <li>"fusion pistol ammo"</li>
-          <li>"assault rifle"</li>
-          <li>"assault rifle ammo"</li>
-          <li>"assault rifle grenades"</li>
-          <li>"missile launcher"</li>
-          <li>"missile launcher ammo"</li>
-          <li>"invisibility"</li>
-          <li>"invincibility"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"infravision"</li>
-          <li>"alien weapon"</li>
-          <li>"alien weapon ammo"</li>
-          <li>"flamethrower"</li>
-          <li>"flamethrower ammo"</li>
-          <li>"extravision"</li>
-          <li>"oxygen"</li>
-          <li>"single health"</li>
-          <li>"double health"</li>
-          <li>"triple health"</li>
-          <li>"shotgun"</li>
-          <li>"shotgun ammo"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"key"</li>
-          <li>"uplink chip"</li>
-          <li>"light blue ball"</li>
-          <li>"ball"</li>
-          <li>"violet ball"</li>
-          <li>"yellow ball"</li>
-          <li>"brown ball"</li>
-          <li>"orange ball"</li>
-          <li>"blue ball"</li>
-          <li>"green ball"</li>
-          <li>"smg"</li>
-          <li>"smg ammo"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="LightFunctions"></a>Light Functions</h3>
-      <dl>
-        <dt># LightFunctions</dt>
-        <dt>LightFunctions()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"constant"</li>
-        <li>"linear"</li>
-        <li>"smooth"</li>
-        <li>"flicker"</li>
-      </ul>
-      <h3><a name="LightPresets"></a>Light Presets</h3>
-      <dl>
-        <dt># LightPresets</dt>
-        <dt>LightPresets()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"normal"</li>
-        <li>"strobe"</li>
-        <li>"media"</li>
-      </ul>
-      <h3><a name="LightStates"></a>Light States</h3>
-      <dl>
-        <dt># LightStates</dt>
-        <dt>LightStates()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"becoming active"</li>
-        <li>"primary active"</li>
-        <li>"secondary active"</li>
-        <li>"becoming inactive"</li>
-        <li>"primary inactive"</li>
-        <li>"secondary inactive"</li>
-      </ul>
-      <h3><a name="MediaTypes"></a>Media</h3>
-      <dl>
-        <dt># MediaTypes</dt>
-        <dt>MediaTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"water"</li>
-        <li>"lava"</li>
-        <li>"goo"</li>
-        <li>"sewage"</li>
-        <li>"jjaro"</li>
-      </ul>
-      <h3><a name="MonsterActions"></a>Monster Actions</h3>
-      <dl>
-        <dt># MonsterActions</dt>
-        <dt>MonsterActions()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"stationary"</li>
-          <li>"waiting to attack again"</li>
-          <li>"moving"</li>
-          <li>"attacking close"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"attacking far"</li>
-          <li>"being hit"</li>
-          <li>"dying hard"</li>
-          <li>"dying soft"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"dying flaming"</li>
-          <li>"teleporting"</li>
-          <li>"teleporting in"</li>
-          <li>"teleporting out"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="MonsterClasses"></a>Monster Classes</h3>
-      <dl>
-        <dt># MonsterClasses</dt>
-        <dt>MonsterClasses()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"player"</li>
-          <li>"bob"</li>
-          <li>"madd"</li>
-          <li>"possessed drone"</li>
-          <li>"defender"</li>
-          <li>"fighter"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"trooper"</li>
-          <li>"hunter"</li>
-          <li>"enforcer"</li>
-          <li>"juggernaut"</li>
-          <li>"drone"</li>
-          <li>"compiler"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"cyborg"</li>
-          <li>"explodabob"</li>
-          <li>"tick"</li>
-          <li>"yeti"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="MonsterModes"></a>Monster Modes</h3>
-      <dl>
-        <dt># MonsterModes</dt>
-        <dt>MonsterModes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"locked"</li>
-        <li>"losing lock"</li>
-        <li>"lost lock"</li>
-        <li>"unlocked"</li>
-        <li>"running"</li>
-      </ul>
-      <h3><a name="MonsterTypes"></a>Monsters</h3>
-      <dl>
-        <dt># MonsterTypes</dt>
-        <dt>MonsterTypes()</dt>
-        <dt>MonsterTypes[monster_type]</dt>
-        <dd>
-          <dl>
-	  <dt>.alien <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">moves slower on slower levels, etc.</p>
-            </dd>
-      <dt>.attacks_immediately <span class="version">20120128</span></dt>
-            <dd>
-              <p class="description">monster will try an attack immediately</p>
-            </dd>
-	  <dt>.berserker <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">below 1/4 vitality, this monster goes berserk</p>
-            </dd>
-	  <dt>.can_die_in_flames <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">uses humanoid dying shape</p>
-            </dd>
-	  <dt>.can_teleport_under_media <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.cannot_attack <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">monster has no weapons and cannot attack (runs constantly to safety)</p>
-            </dd>
-      <dt>.cannot_be_dropped <span class="version">20120128</span></dt>
-            <dd>
-              <p class="description">monster cannot be skipped during placement</p>
-            </dd>
-	  <dt>.cannot_fire_backward <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">monster can’t turn more than 135 degrees</p>
-            </dd>
-	  <dt>.chooses_weapons_randomly <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
+    </dl></dd>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"knife"</li>
+<li>"pistol"</li>
+<li>"pistol ammo"</li>
+<li>"fusion pistol"</li>
+<li>"fusion pistol ammo"</li>
+<li>"assault rifle"</li>
+<li>"assault rifle ammo"</li>
+<li>"assault rifle grenades"</li>
+<li>"missile launcher"</li>
+<li>"missile launcher ammo"</li>
+<li>"invisibility"</li>
+<li>"invincibility"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"infravision"</li>
+<li>"alien weapon"</li>
+<li>"alien weapon ammo"</li>
+<li>"flamethrower"</li>
+<li>"flamethrower ammo"</li>
+<li>"extravision"</li>
+<li>"oxygen"</li>
+<li>"single health"</li>
+<li>"double health"</li>
+<li>"triple health"</li>
+<li>"shotgun"</li>
+<li>"shotgun ammo"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"key"</li>
+<li>"uplink chip"</li>
+<li>"light blue ball"</li>
+<li>"ball"</li>
+<li>"violet ball"</li>
+<li>"yellow ball"</li>
+<li>"brown ball"</li>
+<li>"orange ball"</li>
+<li>"blue ball"</li>
+<li>"green ball"</li>
+<li>"smg"</li>
+<li>"smg ammo"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="LightFunctions"></a>Light Functions</h3>
+<dl>
+<dt># LightFunctions</dt>
+<dt>LightFunctions()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"constant"</li>
+<li>"linear"</li>
+<li>"smooth"</li>
+<li>"flicker"</li>
+</ul>
+<h3>
+<a name="LightPresets"></a>Light Presets</h3>
+<dl>
+<dt># LightPresets</dt>
+<dt>LightPresets()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"normal"</li>
+<li>"strobe"</li>
+<li>"media"</li>
+</ul>
+<h3>
+<a name="LightStates"></a>Light States</h3>
+<dl>
+<dt># LightStates</dt>
+<dt>LightStates()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"becoming active"</li>
+<li>"primary active"</li>
+<li>"secondary active"</li>
+<li>"becoming inactive"</li>
+<li>"primary inactive"</li>
+<li>"secondary inactive"</li>
+</ul>
+<h3>
+<a name="MediaTypes"></a>Media</h3>
+<dl>
+<dt># MediaTypes</dt>
+<dt>MediaTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"water"</li>
+<li>"lava"</li>
+<li>"goo"</li>
+<li>"sewage"</li>
+<li>"jjaro"</li>
+</ul>
+<h3>
+<a name="MonsterActions"></a>Monster Actions</h3>
+<dl>
+<dt># MonsterActions</dt>
+<dt>MonsterActions()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"stationary"</li>
+<li>"waiting to attack again"</li>
+<li>"moving"</li>
+<li>"attacking close"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"attacking far"</li>
+<li>"being hit"</li>
+<li>"dying hard"</li>
+<li>"dying soft"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"dying flaming"</li>
+<li>"teleporting"</li>
+<li>"teleporting in"</li>
+<li>"teleporting out"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="MonsterClasses"></a>Monster Classes</h3>
+<dl>
+<dt># MonsterClasses</dt>
+<dt>MonsterClasses()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"player"</li>
+<li>"bob"</li>
+<li>"madd"</li>
+<li>"possessed drone"</li>
+<li>"defender"</li>
+<li>"fighter"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"trooper"</li>
+<li>"hunter"</li>
+<li>"enforcer"</li>
+<li>"juggernaut"</li>
+<li>"drone"</li>
+<li>"compiler"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"cyborg"</li>
+<li>"explodabob"</li>
+<li>"tick"</li>
+<li>"yeti"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="MonsterModes"></a>Monster Modes</h3>
+<dl>
+<dt># MonsterModes</dt>
+<dt>MonsterModes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"locked"</li>
+<li>"losing lock"</li>
+<li>"lost lock"</li>
+<li>"unlocked"</li>
+<li>"running"</li>
+</ul>
+<h3>
+<a name="MonsterTypes"></a>Monsters</h3>
+<dl>
+<dt># MonsterTypes</dt>
+<dt>MonsterTypes()</dt>
+<dt>MonsterTypes[monster_type]</dt>
+<dd><dl>
+	  <dt>.alien <span class="version">20220115</span>
+</dt>
+<dd><p class="description">moves slower on slower levels, etc.</p></dd>
+      <dt>.attacks_immediately <span class="version">20120128</span>
+</dt>
+<dd><p class="description">monster will try an attack immediately</p></dd>
+	  <dt>.berserker <span class="version">20220115</span>
+</dt>
+<dd><p class="description">below 1/4 vitality, this monster goes berserk</p></dd>
+	  <dt>.can_die_in_flames <span class="version">20220115</span>
+</dt>
+<dd><p class="description">uses humanoid dying shape</p></dd>
+	  <dt>.can_teleport_under_media <span class="version">20220115</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.cannot_attack <span class="version">20220115</span>
+</dt>
+<dd><p class="description">monster has no weapons and cannot attack (runs constantly to safety)</p></dd>
+      <dt>.cannot_be_dropped <span class="version">20120128</span>
+</dt>
+<dd><p class="description">monster cannot be skipped during placement</p></dd>
+	  <dt>.cannot_fire_backward <span class="version">20220115</span>
+</dt>
+<dd><p class="description">monster can’t turn more than 135 degrees</p></dd>
+	  <dt>.chooses_weapons_randomly <span class="version">20220115</span>
+</dt>
+<dd><p class="description"></p></dd>
       <dt>.class</dt>
-            <dd>
-              <p class="description">class of monster type</p>
-            </dd>
-	  <dt>.collection<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">collection of monster type</p>
-            </dd>
-	  <dt>.clut_index<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
-            <dd>
-              <p class="description">color table of monster type</p>
-            </dd>
+<dd><p class="description">class of monster type</p></dd>
+	  <dt>.collection<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">collection of monster type</p></dd>
+	  <dt>.clut_index<span class="access"> (read-only)</span> <span class="version">20210408</span>
+</dt>
+<dd><p class="description">color table of monster type</p></dd>
       <dt>
     .enemies[monster_class]
   </dt>
-            <dd>
-              <p class="description">whether monster class is an enemy</p>
-            </dd>
-	  <dt>.enlarged <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">monster is 1.25 times normal height</p>
-            </dd>
-	  <dt>.fires_symmetrically <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">fires at +/- dy, simultaneously</p>
-            </dd>
-	  <dt>.flies <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.floats <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">exclusive from flies; forces the monster to take delta-h gradually</p>
-            </dd>
+<dd><p class="description">whether monster class is an enemy</p></dd>
+	  <dt>.enlarged <span class="version">20220115</span>
+</dt>
+<dd><p class="description">monster is 1.25 times normal height</p></dd>
+	  <dt>.fires_symmetrically <span class="version">20220115</span>
+</dt>
+<dd><p class="description">fires at +/- dy, simultaneously</p></dd>
+	  <dt>.flies <span class="version">20220115</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.floats <span class="version">20220115</span>
+</dt>
+<dd><p class="description">exclusive from flies; forces the monster to take delta-h gradually</p></dd>
       <dt>
     .friends[monster_class]
   </dt>
-            <dd>
-              <p class="description">whether monster class is a friend</p>
-            </dd>
-	  <dt>.has_delayed_hard_death <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">always dies soft, then switches to hard</p>
-            </dd>
-	  <dt>.has_nuclear_hard_death <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">player’s screen whites out and slowly recovers</p>
-            </dd>
-      <dt>.impact_effect<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">type of effect generated when monster gets hit by a bleeding projectile</p>
-            </dd>
-      <dt>.height<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">height of monster</p>
-            </dd>
+<dd><p class="description">whether monster class is a friend</p></dd>
+	  <dt>.has_delayed_hard_death <span class="version">20220115</span>
+</dt>
+<dd><p class="description">always dies soft, then switches to hard</p></dd>
+	  <dt>.has_nuclear_hard_death <span class="version">20220115</span>
+</dt>
+<dd><p class="description">player’s screen whites out and slowly recovers</p></dd>
+      <dt>.impact_effect<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of effect generated when monster gets hit by a bleeding projectile</p></dd>
+      <dt>.height<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">height of monster</p></dd>
 	  <dt>
     .immunities[damage_type]
   </dt>
-            <dd>
-              <p class="description">whether monster type is immune to damage type</p>
-            </dd>
-	  <dt>.impact_effect<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-      <dt>.initial_count <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">how many monsters of this type are placed in the level during initial placement</p>
-            </dd>
-	  <dt>.invisible <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">this monster uses _xfer_invisibility</p>
-            </dd>
+<dd><p class="description">whether monster type is immune to damage type</p></dd>
+	  <dt>.impact_effect<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description"></p></dd>
+      <dt>.initial_count <span class="version">20111201</span>
+</dt>
+<dd><p class="description">how many monsters of this type are placed in the level during initial placement</p></dd>
+	  <dt>.invisible <span class="version">20220115</span>
+</dt>
+<dd><p class="description">this monster uses _xfer_invisibility</p></dd>
       <dt>.item</dt>
-            <dd>
-              <p class="description">type of item the monster drops when it dies</p>
-            </dd>
-	  <dt>.kamikaze <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">monster does shrapnel damage and will suicide if close enough to target</p>
-            </dd>
-      <dt>.major <span class="version">20120128</span></dt>
-            <dd>
-              <p class="description">monster is major</p>
-            </dd>
-      <dt>.maximum_count <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">maximum number of this type of monster in the level</p>
-            </dd>
-      <dt>.melee_impact_effect<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">type of effect generated when monster gets hit by a melee projectile</p>
-            </dd>
-      <dt>.minimum_count <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">minimum number of this type of monster in the level</p>
-            </dd>
-      <dt>.minor <span class="version">20120128</span></dt>
-            <dd>
-              <p class="description">monster is minor</p>
-            </dd>
-	  <dt>.not_afraid_of_goo <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.not_afraid_of_lava <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.not_afraid_of_sewage <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.not_afraid_of_water <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">
-              </p>
-            </dd>
-	  <dt>.omniscient <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">ignores line-of-sight during find_closest_appropriate_target()</p>
-            </dd>
-      <dt>.radius<span class="access"> (read-only)</span></dt>
-            <dd>
-              <p class="description">radius of monster</p>
-            </dd>
-      <dt>.random_chance <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">chance from 0 to 1.0 this monster will appear in a respawn period</p>
-            </dd>
-      <dt>.random_location <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">whether monsters of this type spawn in random locations</p>
-            </dd>
-	  <dt>.subtly_invisible <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">this monster uses _xfer_subtle_invisibility</p>
-            </dd>
-	  <dt>.tiny <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">0.25-size normal height</p>
-            </dd>
-      <dt>.total_available <span class="version">20111201</span></dt>
-            <dd>
-              <p class="description">total number of monsters of this type that can be spawned in this level</p>
-              <p class="note">-1 means infinite monsters are available </p>
-              <p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before monster placement is done </p>
-            </dd>
-	  <dt>.uses_sniper_ledges <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">sit on ledges and hurl shit at the player (ranged attack monsters only</p>
-            </dd>
-	  <dt>.vitality<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
-            <dd>
-              <p class="description">monster’s initial vitality</p>
-            </dd>
+<dd><p class="description">type of item the monster drops when it dies</p></dd>
+	  <dt>.kamikaze <span class="version">20220115</span>
+</dt>
+<dd><p class="description">monster does shrapnel damage and will suicide if close enough to target</p></dd>
+      <dt>.major <span class="version">20120128</span>
+</dt>
+<dd><p class="description">monster is major</p></dd>
+      <dt>.maximum_count <span class="version">20111201</span>
+</dt>
+<dd><p class="description">maximum number of this type of monster in the level</p></dd>
+      <dt>.melee_impact_effect<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">type of effect generated when monster gets hit by a melee projectile</p></dd>
+      <dt>.minimum_count <span class="version">20111201</span>
+</dt>
+<dd><p class="description">minimum number of this type of monster in the level</p></dd>
+      <dt>.minor <span class="version">20120128</span>
+</dt>
+<dd><p class="description">monster is minor</p></dd>
+	  <dt>.not_afraid_of_goo <span class="version">20220115</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.not_afraid_of_lava <span class="version">20220115</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.not_afraid_of_sewage <span class="version">20220115</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.not_afraid_of_water <span class="version">20220115</span>
+</dt>
+<dd><p class="description"></p></dd>
+	  <dt>.omniscient <span class="version">20220115</span>
+</dt>
+<dd><p class="description">ignores line-of-sight during find_closest_appropriate_target()</p></dd>
+      <dt>.radius<span class="access"> (read-only)</span>
+</dt>
+<dd><p class="description">radius of monster</p></dd>
+      <dt>.random_chance <span class="version">20111201</span>
+</dt>
+<dd><p class="description">chance from 0 to 1.0 this monster will appear in a respawn period</p></dd>
+      <dt>.random_location <span class="version">20111201</span>
+</dt>
+<dd><p class="description">whether monsters of this type spawn in random locations</p></dd>
+	  <dt>.subtly_invisible <span class="version">20220115</span>
+</dt>
+<dd><p class="description">this monster uses _xfer_subtle_invisibility</p></dd>
+	  <dt>.tiny <span class="version">20220115</span>
+</dt>
+<dd><p class="description">0.25-size normal height</p></dd>
+      <dt>.total_available <span class="version">20111201</span>
+</dt>
+<dd>
+<p class="description">total number of monsters of this type that can be spawned in this level</p>
+<p class="note">-1 means infinite monsters are available </p>
+<p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before monster placement is done </p>
+</dd>
+	  <dt>.uses_sniper_ledges <span class="version">20220115</span>
+</dt>
+<dd><p class="description">sit on ledges and hurl shit at the player (ranged attack monsters only</p></dd>
+	  <dt>.vitality<span class="access"> (read-only)</span> <span class="version">20220115</span>
+</dt>
+<dd><p class="description">monster’s initial vitality</p></dd>
       <dt>
     .weaknesses[damage type]
   </dt>
-            <dd>
-              <p class="description">whether monster type has a weakness to damage type</p>
-            </dd>
-      <dt>.waits_with_clear_shot <span class="version">20120128</span></dt>
-            <dd>
-              <p class="description">monster will sit and fire if he has a clear shot</p>
-            </dd>
+<dd><p class="description">whether monster type has a weakness to damage type</p></dd>
+      <dt>.waits_with_clear_shot <span class="version">20120128</span>
+</dt>
+<dd><p class="description">monster will sit and fire if he has a clear shot</p></dd>
       
 		
 		
@@ -3900,661 +3133,620 @@ If you do this, you should customize them all at the beginning of the script. Ch
 		
 		
       
-    </dl>
-        </dd>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"player"</li>
-          <li>"minor tick"</li>
-          <li>"major tick"</li>
-          <li>"kamikaze tick"</li>
-          <li>"minor compiler"</li>
-          <li>"major compiler"</li>
-          <li>"minor invisible compiler"</li>
-          <li>"major invisible compiler"</li>
-          <li>"minor fighter"</li>
-          <li>"major fighter"</li>
-          <li>"minor projectile fighter"</li>
-          <li>"major projectile fighter"</li>
-          <li>"green bob"</li>
-          <li>"blue bob"</li>
-          <li>"security bob"</li>
-          <li>"explodabob"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"minor drone"</li>
-          <li>"major drone"</li>
-          <li>"big minor drone"</li>
-          <li>"big major drone"</li>
-          <li>"possessed drone"</li>
-          <li>"minor cyborg"</li>
-          <li>"major cyborg"</li>
-          <li>"minor flame cyborg"</li>
-          <li>"major flame cyborg"</li>
-          <li>"minor enforcer"</li>
-          <li>"major enforcer"</li>
-          <li>"minor hunter"</li>
-          <li>"major hunter"</li>
-          <li>"minor trooper"</li>
-          <li>"major trooper"</li>
-          <li>"mother of all cyborgs"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"mother of all hunters"</li>
-          <li>"sewage yeti"</li>
-          <li>"water yeti"</li>
-          <li>"lava yeti"</li>
-          <li>"minor defender"</li>
-          <li>"major defender"</li>
-          <li>"minor juggernaut"</li>
-          <li>"major juggernaut"</li>
-          <li>"tiny pfhor"</li>
-          <li>"tiny bob"</li>
-          <li>"tiny yeti"</li>
-          <li>"green vacbob"</li>
-          <li>"blue vacbob"</li>
-          <li>"security vacbob"</li>
-          <li>"explodavacbob"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="MusicFadeTypes"></a>Music Fade Types</h3>
-      <dl>
-        <dt># MusicFadeTypes</dt>
-        <dt>MusicFadeTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"none"</li>
-        <li>"linear"</li>
-        <li>"sinusoidal"</li>
-      </ul>
-      <h3><a name="OverlayColors"></a>Overlay Colors</h3>
-      <dl>
-        <dt># OverlayColors</dt>
-        <dt>OverlayColors()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"green"</li>
-        <li>"white"</li>
-        <li>"red"</li>
-        <li>"dark green"</li>
-        <li>"cyan"</li>
-        <li>"yellow"</li>
-        <li>"dark red"</li>
-        <li>"blue"</li>
-      </ul>
-      <h3><a name="PlatformTypes"></a>Platform Types</h3>
-      <dl>
-        <dt># PlatformTypes</dt>
-        <dt>PlatformTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"spht door"</li>
-          <li>"spht split door"</li>
-          <li>"locked spht door"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"spht platform"</li>
-          <li>"noisy spht platform"</li>
-          <li>"heavy spht door"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"pfhor door"</li>
-          <li>"heavy spht platform"</li>
-          <li>"pfhor platform"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="PlayerColors"></a>Player and Team Colors</h3>
-      <dl>
-        <dt># PlayerColors</dt>
-        <dt>PlayerColors()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"slate"</li>
-        <li>"red"</li>
-        <li>"violet"</li>
-        <li>"yellow"</li>
-        <li>"white"</li>
-        <li>"orange"</li>
-        <li>"blue"</li>
-        <li>"green"</li>
-      </ul>
-      <h3><a name="PolygonTypes"></a>Polygons</h3>
-      <dl>
-        <dt># PolygonTypes</dt>
-        <dt>PolygonTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"normal"</li>
-          <li>"item impassable"</li>
-          <li>"monster impassable"</li>
-          <li>"hill"</li>
-          <li>"base"</li>
-          <li>"platform"</li>
-          <li>"light on trigger"</li>
-          <li>"platform on trigger"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"light off trigger"</li>
-          <li>"platform off trigger"</li>
-          <li>"teleporter"</li>
-          <li>"zone border"</li>
-          <li>"goal"</li>
-          <li>"visible monster trigger"</li>
-          <li>"invisible monster trigger"</li>
-          <li>"dual monster trigger"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"item trigger"</li>
-          <li>"must be explored"</li>
-          <li>"automatic exit"</li>
-          <li>"minor ouch"</li>
-          <li>"major ouch"</li>
-          <li>"glue"</li>
-          <li>"glue trigger"</li>
-          <li>"superglue"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="ProjectileTypes"></a>Projectiles</h3>
-      <dl>
-        <dt># ProjectileTypes</dt>
-        <dt>ProjectileTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"missile"</li>
-          <li>"grenade"</li>
-          <li>"pistol bullet"</li>
-          <li>"rifle bullet"</li>
-          <li>"shotgun bullet"</li>
-          <li>"staff"</li>
-          <li>"staff bolt"</li>
-          <li>"flamethrower burst"</li>
-          <li>"compiler bolt minor"</li>
-          <li>"compiler bolt major"</li>
-          <li>"alien weapon"</li>
-          <li>"fusion bolt minor"</li>
-          <li>"fusion bolt major"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"hunter"</li>
-          <li>"fist"</li>
-          <li>"armageddon sphere"</li>
-          <li>"armageddon electricity"</li>
-          <li>"juggernaut rocket"</li>
-          <li>"trooper bullet"</li>
-          <li>"trooper grenade"</li>
-          <li>"minor defender"</li>
-          <li>"major defender"</li>
-          <li>"juggernaut missile"</li>
-          <li>"minor energy drain"</li>
-          <li>"major energy drain"</li>
-          <li>"oxygen drain"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"minor hummer"</li>
-          <li>"major hummer"</li>
-          <li>"durandal hummer"</li>
-          <li>"minor cyborg ball"</li>
-          <li>"major cyborg ball"</li>
-          <li>"ball"</li>
-          <li>"minor fusion dispersal"</li>
-          <li>"major fusion dispersal"</li>
-          <li>"overloaded fusion dispersal"</li>
-          <li>"yeti"</li>
-          <li>"sewage yeti"</li>
-          <li>"lava yeti"</li>
-          <li>"smg bullet"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="SceneryTypes"></a>Scenery</h3>
-      <dl>
-        <dt># SceneryTypes</dt>
-        <dt>SceneryTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"light dirt"</li>
-          <li>"dark dirt"</li>
-          <li>"lava bones"</li>
-          <li>"lava bone"</li>
-          <li>"ribs"</li>
-          <li>"skull"</li>
-          <li>"hanging light 1"</li>
-          <li>"hanging light 2"</li>
-          <li>"small cylinder"</li>
-          <li>"large cylinder"</li>
-          <li>"block 1"</li>
-          <li>"block 2"</li>
-          <li>"block 3"</li>
-          <li>"pistol clip"</li>
-          <li>"water short light"</li>
-          <li>"water long light"</li>
-          <li>"siren"</li>
-          <li>"rocks"</li>
-          <li>"blood drops"</li>
-          <li>"water thing"</li>
-          <li>"gun"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"bob remains"</li>
-          <li>"puddles"</li>
-          <li>"big puddles"</li>
-          <li>"security monitor"</li>
-          <li>"water alien supply can"</li>
-          <li>"machine"</li>
-          <li>"staff"</li>
-          <li>"sewage short light"</li>
-          <li>"sewage long light"</li>
-          <li>"junk"</li>
-          <li>"antenna"</li>
-          <li>"big antenna"</li>
-          <li>"sewage alien supply can"</li>
-          <li>"sewage bones"</li>
-          <li>"sewage big bones"</li>
-          <li>"pfhor pieces"</li>
-          <li>"bob pieces"</li>
-          <li>"bob blood"</li>
-          <li>"alien short light"</li>
-          <li>"alien long light"</li>
-          <li>"alien ceiling rod light"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"bulbous yellow alien object"</li>
-          <li>"square gray organic object"</li>
-          <li>"pfhor skeleton"</li>
-          <li>"pfhor mask"</li>
-          <li>"green stuff"</li>
-          <li>"hunter shield"</li>
-          <li>"alien bones"</li>
-          <li>"alien sludge"</li>
-          <li>"jjaro short light"</li>
-          <li>"jjaro long light"</li>
-          <li>"weird rod"</li>
-          <li>"pfhor ship"</li>
-          <li>"sun"</li>
-          <li>"large glass container"</li>
-          <li>"nub 1"</li>
-          <li>"nub 2"</li>
-          <li>"lh'owon"</li>
-          <li>"floor whip antenna"</li>
-          <li>"ceiling whip antenna"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="ScoringModes"></a>Scoring Modes</h3>
-      <dl>
-        <dt># ScoringModes</dt>
-        <dt>ScoringModes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"most points"</li>
-        <li>"most time"</li>
-        <li>"least points"</li>
-        <li>"least time"</li>
-      </ul>
-      <h3><a name="SideTypes"></a>Side Types</h3>
-      <dl>
-        <dt># SideTypes</dt>
-        <dt>SideTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"full"</li>
-        <li>"high"</li>
-        <li>"low"</li>
-        <li>"split"</li>
-      </ul>
-      <h3><a name="Sounds"></a>Sounds</h3>
-      <dl>
-        <dt># Sounds</dt>
-        <dt>Sounds()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"startup"</li>
-          <li>"teleport in"</li>
-          <li>"teleport out"</li>
-          <li>"crushed"</li>
-          <li>"nuclear hard death"</li>
-          <li>"absorbed"</li>
-          <li>"breathing"</li>
-          <li>"oxygen warning"</li>
-          <li>"suffocation"</li>
-          <li>"energy refuel"</li>
-          <li>"oxygen refuel"</li>
-          <li>"cant toggle switch"</li>
-          <li>"switch on"</li>
-          <li>"switch off"</li>
-          <li>"puzzle switch"</li>
-          <li>"chip insertion"</li>
-          <li>"pattern buffer"</li>
-          <li>"destroy control panel"</li>
-          <li>"adjust volume"</li>
-          <li>"got powerup"</li>
-          <li>"get item"</li>
-          <li>"bullet ricochet"</li>
-          <li>"metallic ricochet"</li>
-          <li>"empty gun"</li>
-          <li>"spht door opening"</li>
-          <li>"spht door closing"</li>
-          <li>"spht door obstructed"</li>
-          <li>"spht platform starting"</li>
-          <li>"spht platform stopping"</li>
-          <li>"loon"</li>
-          <li>"smg firing"</li>
-          <li>"smg reloading"</li>
-          <li>"heavy spht platform starting"</li>
-          <li>"heavy spht platform stopping"</li>
-          <li>"fist hitting"</li>
-          <li>"pistol firing"</li>
-          <li>"pistol reloading"</li>
-          <li>"assault rifle firing"</li>
-          <li>"grenade launcher firing"</li>
-          <li>"grenade expolding"</li>
-          <li>"grenade flyby"</li>
-          <li>"fusion firing"</li>
-          <li>"fusion exploding"</li>
-          <li>"fusion flyby"</li>
-          <li>"fusion charging"</li>
-          <li>"rocket exploding"</li>
-          <li>"rocket flyby"</li>
-          <li>"rocket firing"</li>
-          <li>"flamethrower"</li>
-          <li>"body falling"</li>
-          <li>"body exploding"</li>
-          <li>"bullet hit flesh"</li>
-          <li>"fighter activate"</li>
-          <li>"fighter wail"</li>
-          <li>"fighter scream"</li>
-          <li>"fighter chatter"</li>
-          <li>"fighter attack"</li>
-          <li>"fighter projectile hit"</li>
-          <li>"fighter projectile flyby"</li>
-          <li>"spht attack"</li>
-          <li>"spht death"</li>
-          <li>"spht hit"</li>
-          <li>"spht projectile flyby"</li>
-          <li>"spht projectile hit"</li>
-          <li>"cyborg moving"</li>
-          <li>"cyborg attack"</li>
-          <li>"cyborg hit"</li>
-          <li>"cyborg death"</li>
-          <li>"cyborg projectile bounce"</li>
-          <li>"cyborg projectile hit"</li>
-          <li>"cyborg projectile flyby"</li>
-          <li>"drone activate"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"drone start attack"</li>
-          <li>"drone attack"</li>
-          <li>"drone dying"</li>
-          <li>"drone death"</li>
-          <li>"drone projectile hit"</li>
-          <li>"drone projectile flyby"</li>
-          <li>"bob wail"</li>
-          <li>"bob scream"</li>
-          <li>"bob hit"</li>
-          <li>"bob chatter"</li>
-          <li>"assimilated bob chatter"</li>
-          <li>"bob trash talk"</li>
-          <li>"bob apology"</li>
-          <li>"bob activation"</li>
-          <li>"bob clear"</li>
-          <li>"bob angry"</li>
-          <li>"bob secure"</li>
-          <li>"bob kill the player"</li>
-          <li>"water"</li>
-          <li>"sewage"</li>
-          <li>"lava"</li>
-          <li>"goo"</li>
-          <li>"underwater"</li>
-          <li>"wind"</li>
-          <li>"waterfall"</li>
-          <li>"siren"</li>
-          <li>"fan"</li>
-          <li>"spht door"</li>
-          <li>"spht platform"</li>
-          <li>"alien harmonics"</li>
-          <li>"heavy spht platform"</li>
-          <li>"light machinery"</li>
-          <li>"heavy machinery"</li>
-          <li>"transformer"</li>
-          <li>"sparking transformer"</li>
-          <li>"water drip"</li>
-          <li>"walking in water"</li>
-          <li>"exiting water"</li>
-          <li>"entering water"</li>
-          <li>"small water splash"</li>
-          <li>"medium water splash"</li>
-          <li>"large water splash"</li>
-          <li>"walking in lava"</li>
-          <li>"entering lava"</li>
-          <li>"exiting lava"</li>
-          <li>"small lava splash"</li>
-          <li>"medium lava splash"</li>
-          <li>"large lava splash"</li>
-          <li>"walking in sewage"</li>
-          <li>"exiting sewage"</li>
-          <li>"entering sewage"</li>
-          <li>"small sewage splash"</li>
-          <li>"medium sewage splash"</li>
-          <li>"large sewage splash"</li>
-          <li>"walking in goo"</li>
-          <li>"exiting goo"</li>
-          <li>"entering goo"</li>
-          <li>"small goo splash"</li>
-          <li>"medium goo splash"</li>
-          <li>"large goo splash"</li>
-          <li>"major fusion firing"</li>
-          <li>"major fusion charged"</li>
-          <li>"assault rifle reloading"</li>
-          <li>"assault rifle shell casings"</li>
-          <li>"shotgun firing"</li>
-          <li>"shotgun reloading"</li>
-          <li>"ball bounce"</li>
-          <li>"you are it"</li>
-          <li>"got ball"</li>
-          <li>"computer login"</li>
-          <li>"computer logout"</li>
-          <li>"computer page"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"heavy spht door"</li>
-          <li>"heavy spht door opening"</li>
-          <li>"heavy spht door closing"</li>
-          <li>"heavy spht door open"</li>
-          <li>"heavy spht door closed"</li>
-          <li>"heavy spht door obstructed"</li>
-          <li>"hunter activate"</li>
-          <li>"hunter attack"</li>
-          <li>"hunter dying"</li>
-          <li>"hunter landing"</li>
-          <li>"hunter exploding"</li>
-          <li>"hunter projectile hit"</li>
-          <li>"hunter projectile flyby"</li>
-          <li>"enforcer activate"</li>
-          <li>"enforcer attack"</li>
-          <li>"enforcer projectile hit"</li>
-          <li>"enforcer projectile flyby"</li>
-          <li>"flickta melee attack"</li>
-          <li>"flickta melee hit"</li>
-          <li>"flickta projectile attack"</li>
-          <li>"flickta projectile sewage hit"</li>
-          <li>"flickta projectile sewage flyby"</li>
-          <li>"flickta projectile lava hit"</li>
-          <li>"flickta projectile lava flyby"</li>
-          <li>"flickta dying"</li>
-          <li>"machine binder"</li>
-          <li>"machine bookpress"</li>
-          <li>"machine puncher"</li>
-          <li>"electric hum"</li>
-          <li>"alarm"</li>
-          <li>"night wind"</li>
-          <li>"surface explosion"</li>
-          <li>"underground explosion"</li>
-          <li>"sphtkr attack"</li>
-          <li>"sphtkr projectile hit"</li>
-          <li>"sphtkr projectile flyby"</li>
-          <li>"sphtkr hit"</li>
-          <li>"sphtkr exploding"</li>
-          <li>"tick chatter"</li>
-          <li>"tick falling"</li>
-          <li>"tick flapping"</li>
-          <li>"tick exploding"</li>
-          <li>"ceiling lamp exploding"</li>
-          <li>"pfhor platform starting"</li>
-          <li>"pfhor platform stopping"</li>
-          <li>"pfhor platform"</li>
-          <li>"pfhor door opening"</li>
-          <li>"pfhor door closing"</li>
-          <li>"pfhor door obstructed"</li>
-          <li>"pfhor door"</li>
-          <li>"pfhor switch off"</li>
-          <li>"pfhor switch on"</li>
-          <li>"juggernaut firing"</li>
-          <li>"juggernaut warning"</li>
-          <li>"juggernaut exploding"</li>
-          <li>"juggernaut start attack"</li>
-          <li>"enforcer exploding"</li>
-          <li>"alien noise 1"</li>
-          <li>"alien noise 2"</li>
-          <li>"vacbob wail"</li>
-          <li>"vacbob scream"</li>
-          <li>"vacbob hit"</li>
-          <li>"vacbob chatter"</li>
-          <li>"assimilated vacbob chatter"</li>
-          <li>"vacbob trash talk"</li>
-          <li>"vacbob apology"</li>
-          <li>"vacbob activation"</li>
-          <li>"vacbob clear"</li>
-          <li>"vacbob angry"</li>
-          <li>"vacbob secure"</li>
-          <li>"vacbob kill the player"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="TextureTypes"></a>Texture Types</h3>
-      <dl>
-        <dt># TextureTypes</dt>
-        <dt>TextureTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <ul class="mnemonics">
-        <li>"wall"</li>
-        <li>"landscape"</li>
-        <li>"sprite"</li>
-        <li>"weapon in hand"</li>
-        <li>"interface"</li>
-      </ul>
-      <h3><a name="TransferModes"></a>Transfer Modes</h3>
-      <dl>
-        <dt># TransferModes</dt>
-        <dt>TransferModes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"normal"</li>
-          <li>"pulsate"</li>
-          <li>"wobble"</li>
-          <li>"fast wobble"</li>
-          <li>"static"</li>
-          <li>"landscape"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"horizontal slide"</li>
-          <li>"fast horizontal slide"</li>
-          <li>"vertical slide"</li>
-          <li>"fast vertical slide"</li>
-          <li>"wander"</li>
-          <li>"fast wander"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"reverse horizontal slide" <span class="version">20231125</span></li>
-          <li>"reverse fast horizontal slide" <span class="version">20231125</span></li>
-          <li>"reverse vertical slide" <span class="version">20231125</span></li>
-          <li>"reverse fast vertical slide" <span class="version">20231125</span></li>
-          <li>"2x" <span class="version">20231125</span></li>
-          <li>"4x" <span class="version">20231125</span></li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-      <h3><a name="WeaponTypes"></a>Weapons</h3>
-      <dl>
-        <dt># WeaponTypes</dt>
-        <dt>WeaponTypes()</dt>
-      </dl>
-      <h4>Mnemonics</h4>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"fist"</li>
-          <li>"pistol"</li>
-          <li>"fusion pistol"</li>
-          <li>"assault rifle"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"missile launcher"</li>
-          <li>"flamethrower"</li>
-          <li>"alien weapon"</li>
-          <li>"shotgun"</li>
-        </ul>
-      </div>
-      <div class="mnemonics-column">
-        <ul class="mnemonics">
-          <li>"ball"</li>
-          <li>"smg"</li>
-        </ul>
-      </div>
-      <div class="end-mnemonics"></div>
-    </div>
-    <h1><a name="example_icon"></a>Example Icon</h1>
+    </dl></dd>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"player"</li>
+<li>"minor tick"</li>
+<li>"major tick"</li>
+<li>"kamikaze tick"</li>
+<li>"minor compiler"</li>
+<li>"major compiler"</li>
+<li>"minor invisible compiler"</li>
+<li>"major invisible compiler"</li>
+<li>"minor fighter"</li>
+<li>"major fighter"</li>
+<li>"minor projectile fighter"</li>
+<li>"major projectile fighter"</li>
+<li>"green bob"</li>
+<li>"blue bob"</li>
+<li>"security bob"</li>
+<li>"explodabob"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"minor drone"</li>
+<li>"major drone"</li>
+<li>"big minor drone"</li>
+<li>"big major drone"</li>
+<li>"possessed drone"</li>
+<li>"minor cyborg"</li>
+<li>"major cyborg"</li>
+<li>"minor flame cyborg"</li>
+<li>"major flame cyborg"</li>
+<li>"minor enforcer"</li>
+<li>"major enforcer"</li>
+<li>"minor hunter"</li>
+<li>"major hunter"</li>
+<li>"minor trooper"</li>
+<li>"major trooper"</li>
+<li>"mother of all cyborgs"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"mother of all hunters"</li>
+<li>"sewage yeti"</li>
+<li>"water yeti"</li>
+<li>"lava yeti"</li>
+<li>"minor defender"</li>
+<li>"major defender"</li>
+<li>"minor juggernaut"</li>
+<li>"major juggernaut"</li>
+<li>"tiny pfhor"</li>
+<li>"tiny bob"</li>
+<li>"tiny yeti"</li>
+<li>"green vacbob"</li>
+<li>"blue vacbob"</li>
+<li>"security vacbob"</li>
+<li>"explodavacbob"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="OverlayColors"></a>Overlay Colors</h3>
+<dl>
+<dt># OverlayColors</dt>
+<dt>OverlayColors()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"green"</li>
+<li>"white"</li>
+<li>"red"</li>
+<li>"dark green"</li>
+<li>"cyan"</li>
+<li>"yellow"</li>
+<li>"dark red"</li>
+<li>"blue"</li>
+</ul>
+<h3>
+<a name="PlatformTypes"></a>Platform Types</h3>
+<dl>
+<dt># PlatformTypes</dt>
+<dt>PlatformTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"spht door"</li>
+<li>"spht split door"</li>
+<li>"locked spht door"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"spht platform"</li>
+<li>"noisy spht platform"</li>
+<li>"heavy spht door"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"pfhor door"</li>
+<li>"heavy spht platform"</li>
+<li>"pfhor platform"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="PlayerColors"></a>Player and Team Colors</h3>
+<dl>
+<dt># PlayerColors</dt>
+<dt>PlayerColors()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"slate"</li>
+<li>"red"</li>
+<li>"violet"</li>
+<li>"yellow"</li>
+<li>"white"</li>
+<li>"orange"</li>
+<li>"blue"</li>
+<li>"green"</li>
+</ul>
+<h3>
+<a name="PolygonTypes"></a>Polygons</h3>
+<dl>
+<dt># PolygonTypes</dt>
+<dt>PolygonTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"normal"</li>
+<li>"item impassable"</li>
+<li>"monster impassable"</li>
+<li>"hill"</li>
+<li>"base"</li>
+<li>"platform"</li>
+<li>"light on trigger"</li>
+<li>"platform on trigger"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"light off trigger"</li>
+<li>"platform off trigger"</li>
+<li>"teleporter"</li>
+<li>"zone border"</li>
+<li>"goal"</li>
+<li>"visible monster trigger"</li>
+<li>"invisible monster trigger"</li>
+<li>"dual monster trigger"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"item trigger"</li>
+<li>"must be explored"</li>
+<li>"automatic exit"</li>
+<li>"minor ouch"</li>
+<li>"major ouch"</li>
+<li>"glue"</li>
+<li>"glue trigger"</li>
+<li>"superglue"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="ProjectileTypes"></a>Projectiles</h3>
+<dl>
+<dt># ProjectileTypes</dt>
+<dt>ProjectileTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"missile"</li>
+<li>"grenade"</li>
+<li>"pistol bullet"</li>
+<li>"rifle bullet"</li>
+<li>"shotgun bullet"</li>
+<li>"staff"</li>
+<li>"staff bolt"</li>
+<li>"flamethrower burst"</li>
+<li>"compiler bolt minor"</li>
+<li>"compiler bolt major"</li>
+<li>"alien weapon"</li>
+<li>"fusion bolt minor"</li>
+<li>"fusion bolt major"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"hunter"</li>
+<li>"fist"</li>
+<li>"armageddon sphere"</li>
+<li>"armageddon electricity"</li>
+<li>"juggernaut rocket"</li>
+<li>"trooper bullet"</li>
+<li>"trooper grenade"</li>
+<li>"minor defender"</li>
+<li>"major defender"</li>
+<li>"juggernaut missile"</li>
+<li>"minor energy drain"</li>
+<li>"major energy drain"</li>
+<li>"oxygen drain"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"minor hummer"</li>
+<li>"major hummer"</li>
+<li>"durandal hummer"</li>
+<li>"minor cyborg ball"</li>
+<li>"major cyborg ball"</li>
+<li>"ball"</li>
+<li>"minor fusion dispersal"</li>
+<li>"major fusion dispersal"</li>
+<li>"overloaded fusion dispersal"</li>
+<li>"yeti"</li>
+<li>"sewage yeti"</li>
+<li>"lava yeti"</li>
+<li>"smg bullet"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="SceneryTypes"></a>Scenery</h3>
+<dl>
+<dt># SceneryTypes</dt>
+<dt>SceneryTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"light dirt"</li>
+<li>"dark dirt"</li>
+<li>"lava bones"</li>
+<li>"lava bone"</li>
+<li>"ribs"</li>
+<li>"skull"</li>
+<li>"hanging light 1"</li>
+<li>"hanging light 2"</li>
+<li>"small cylinder"</li>
+<li>"large cylinder"</li>
+<li>"block 1"</li>
+<li>"block 2"</li>
+<li>"block 3"</li>
+<li>"pistol clip"</li>
+<li>"water short light"</li>
+<li>"water long light"</li>
+<li>"siren"</li>
+<li>"rocks"</li>
+<li>"blood drops"</li>
+<li>"water thing"</li>
+<li>"gun"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"bob remains"</li>
+<li>"puddles"</li>
+<li>"big puddles"</li>
+<li>"security monitor"</li>
+<li>"water alien supply can"</li>
+<li>"machine"</li>
+<li>"staff"</li>
+<li>"sewage short light"</li>
+<li>"sewage long light"</li>
+<li>"junk"</li>
+<li>"antenna"</li>
+<li>"big antenna"</li>
+<li>"sewage alien supply can"</li>
+<li>"sewage bones"</li>
+<li>"sewage big bones"</li>
+<li>"pfhor pieces"</li>
+<li>"bob pieces"</li>
+<li>"bob blood"</li>
+<li>"alien short light"</li>
+<li>"alien long light"</li>
+<li>"alien ceiling rod light"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"bulbous yellow alien object"</li>
+<li>"square gray organic object"</li>
+<li>"pfhor skeleton"</li>
+<li>"pfhor mask"</li>
+<li>"green stuff"</li>
+<li>"hunter shield"</li>
+<li>"alien bones"</li>
+<li>"alien sludge"</li>
+<li>"jjaro short light"</li>
+<li>"jjaro long light"</li>
+<li>"weird rod"</li>
+<li>"pfhor ship"</li>
+<li>"sun"</li>
+<li>"large glass container"</li>
+<li>"nub 1"</li>
+<li>"nub 2"</li>
+<li>"lh'owon"</li>
+<li>"floor whip antenna"</li>
+<li>"ceiling whip antenna"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="ScoringModes"></a>Scoring Modes</h3>
+<dl>
+<dt># ScoringModes</dt>
+<dt>ScoringModes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"most points"</li>
+<li>"most time"</li>
+<li>"least points"</li>
+<li>"least time"</li>
+</ul>
+<h3>
+<a name="SideTypes"></a>Side Types</h3>
+<dl>
+<dt># SideTypes</dt>
+<dt>SideTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"full"</li>
+<li>"high"</li>
+<li>"low"</li>
+<li>"split"</li>
+</ul>
+<h3>
+<a name="Sounds"></a>Sounds</h3>
+<dl>
+<dt># Sounds</dt>
+<dt>Sounds()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"startup"</li>
+<li>"teleport in"</li>
+<li>"teleport out"</li>
+<li>"crushed"</li>
+<li>"nuclear hard death"</li>
+<li>"absorbed"</li>
+<li>"breathing"</li>
+<li>"oxygen warning"</li>
+<li>"suffocation"</li>
+<li>"energy refuel"</li>
+<li>"oxygen refuel"</li>
+<li>"cant toggle switch"</li>
+<li>"switch on"</li>
+<li>"switch off"</li>
+<li>"puzzle switch"</li>
+<li>"chip insertion"</li>
+<li>"pattern buffer"</li>
+<li>"destroy control panel"</li>
+<li>"adjust volume"</li>
+<li>"got powerup"</li>
+<li>"get item"</li>
+<li>"bullet ricochet"</li>
+<li>"metallic ricochet"</li>
+<li>"empty gun"</li>
+<li>"spht door opening"</li>
+<li>"spht door closing"</li>
+<li>"spht door obstructed"</li>
+<li>"spht platform starting"</li>
+<li>"spht platform stopping"</li>
+<li>"loon"</li>
+<li>"smg firing"</li>
+<li>"smg reloading"</li>
+<li>"heavy spht platform starting"</li>
+<li>"heavy spht platform stopping"</li>
+<li>"fist hitting"</li>
+<li>"pistol firing"</li>
+<li>"pistol reloading"</li>
+<li>"assault rifle firing"</li>
+<li>"grenade launcher firing"</li>
+<li>"grenade expolding"</li>
+<li>"grenade flyby"</li>
+<li>"fusion firing"</li>
+<li>"fusion exploding"</li>
+<li>"fusion flyby"</li>
+<li>"fusion charging"</li>
+<li>"rocket exploding"</li>
+<li>"rocket flyby"</li>
+<li>"rocket firing"</li>
+<li>"flamethrower"</li>
+<li>"body falling"</li>
+<li>"body exploding"</li>
+<li>"bullet hit flesh"</li>
+<li>"fighter activate"</li>
+<li>"fighter wail"</li>
+<li>"fighter scream"</li>
+<li>"fighter chatter"</li>
+<li>"fighter attack"</li>
+<li>"fighter projectile hit"</li>
+<li>"fighter projectile flyby"</li>
+<li>"spht attack"</li>
+<li>"spht death"</li>
+<li>"spht hit"</li>
+<li>"spht projectile flyby"</li>
+<li>"spht projectile hit"</li>
+<li>"cyborg moving"</li>
+<li>"cyborg attack"</li>
+<li>"cyborg hit"</li>
+<li>"cyborg death"</li>
+<li>"cyborg projectile bounce"</li>
+<li>"cyborg projectile hit"</li>
+<li>"cyborg projectile flyby"</li>
+<li>"drone activate"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"drone start attack"</li>
+<li>"drone attack"</li>
+<li>"drone dying"</li>
+<li>"drone death"</li>
+<li>"drone projectile hit"</li>
+<li>"drone projectile flyby"</li>
+<li>"bob wail"</li>
+<li>"bob scream"</li>
+<li>"bob hit"</li>
+<li>"bob chatter"</li>
+<li>"assimilated bob chatter"</li>
+<li>"bob trash talk"</li>
+<li>"bob apology"</li>
+<li>"bob activation"</li>
+<li>"bob clear"</li>
+<li>"bob angry"</li>
+<li>"bob secure"</li>
+<li>"bob kill the player"</li>
+<li>"water"</li>
+<li>"sewage"</li>
+<li>"lava"</li>
+<li>"goo"</li>
+<li>"underwater"</li>
+<li>"wind"</li>
+<li>"waterfall"</li>
+<li>"siren"</li>
+<li>"fan"</li>
+<li>"spht door"</li>
+<li>"spht platform"</li>
+<li>"alien harmonics"</li>
+<li>"heavy spht platform"</li>
+<li>"light machinery"</li>
+<li>"heavy machinery"</li>
+<li>"transformer"</li>
+<li>"sparking transformer"</li>
+<li>"water drip"</li>
+<li>"walking in water"</li>
+<li>"exiting water"</li>
+<li>"entering water"</li>
+<li>"small water splash"</li>
+<li>"medium water splash"</li>
+<li>"large water splash"</li>
+<li>"walking in lava"</li>
+<li>"entering lava"</li>
+<li>"exiting lava"</li>
+<li>"small lava splash"</li>
+<li>"medium lava splash"</li>
+<li>"large lava splash"</li>
+<li>"walking in sewage"</li>
+<li>"exiting sewage"</li>
+<li>"entering sewage"</li>
+<li>"small sewage splash"</li>
+<li>"medium sewage splash"</li>
+<li>"large sewage splash"</li>
+<li>"walking in goo"</li>
+<li>"exiting goo"</li>
+<li>"entering goo"</li>
+<li>"small goo splash"</li>
+<li>"medium goo splash"</li>
+<li>"large goo splash"</li>
+<li>"major fusion firing"</li>
+<li>"major fusion charged"</li>
+<li>"assault rifle reloading"</li>
+<li>"assault rifle shell casings"</li>
+<li>"shotgun firing"</li>
+<li>"shotgun reloading"</li>
+<li>"ball bounce"</li>
+<li>"you are it"</li>
+<li>"got ball"</li>
+<li>"computer login"</li>
+<li>"computer logout"</li>
+<li>"computer page"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"heavy spht door"</li>
+<li>"heavy spht door opening"</li>
+<li>"heavy spht door closing"</li>
+<li>"heavy spht door open"</li>
+<li>"heavy spht door closed"</li>
+<li>"heavy spht door obstructed"</li>
+<li>"hunter activate"</li>
+<li>"hunter attack"</li>
+<li>"hunter dying"</li>
+<li>"hunter landing"</li>
+<li>"hunter exploding"</li>
+<li>"hunter projectile hit"</li>
+<li>"hunter projectile flyby"</li>
+<li>"enforcer activate"</li>
+<li>"enforcer attack"</li>
+<li>"enforcer projectile hit"</li>
+<li>"enforcer projectile flyby"</li>
+<li>"flickta melee attack"</li>
+<li>"flickta melee hit"</li>
+<li>"flickta projectile attack"</li>
+<li>"flickta projectile sewage hit"</li>
+<li>"flickta projectile sewage flyby"</li>
+<li>"flickta projectile lava hit"</li>
+<li>"flickta projectile lava flyby"</li>
+<li>"flickta dying"</li>
+<li>"machine binder"</li>
+<li>"machine bookpress"</li>
+<li>"machine puncher"</li>
+<li>"electric hum"</li>
+<li>"alarm"</li>
+<li>"night wind"</li>
+<li>"surface explosion"</li>
+<li>"underground explosion"</li>
+<li>"sphtkr attack"</li>
+<li>"sphtkr projectile hit"</li>
+<li>"sphtkr projectile flyby"</li>
+<li>"sphtkr hit"</li>
+<li>"sphtkr exploding"</li>
+<li>"tick chatter"</li>
+<li>"tick falling"</li>
+<li>"tick flapping"</li>
+<li>"tick exploding"</li>
+<li>"ceiling lamp exploding"</li>
+<li>"pfhor platform starting"</li>
+<li>"pfhor platform stopping"</li>
+<li>"pfhor platform"</li>
+<li>"pfhor door opening"</li>
+<li>"pfhor door closing"</li>
+<li>"pfhor door obstructed"</li>
+<li>"pfhor door"</li>
+<li>"pfhor switch off"</li>
+<li>"pfhor switch on"</li>
+<li>"juggernaut firing"</li>
+<li>"juggernaut warning"</li>
+<li>"juggernaut exploding"</li>
+<li>"juggernaut start attack"</li>
+<li>"enforcer exploding"</li>
+<li>"alien noise 1"</li>
+<li>"alien noise 2"</li>
+<li>"vacbob wail"</li>
+<li>"vacbob scream"</li>
+<li>"vacbob hit"</li>
+<li>"vacbob chatter"</li>
+<li>"assimilated vacbob chatter"</li>
+<li>"vacbob trash talk"</li>
+<li>"vacbob apology"</li>
+<li>"vacbob activation"</li>
+<li>"vacbob clear"</li>
+<li>"vacbob angry"</li>
+<li>"vacbob secure"</li>
+<li>"vacbob kill the player"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="TextureTypes"></a>Texture Types</h3>
+<dl>
+<dt># TextureTypes</dt>
+<dt>TextureTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<ul class="mnemonics">
+<li>"wall"</li>
+<li>"landscape"</li>
+<li>"sprite"</li>
+<li>"weapon in hand"</li>
+<li>"interface"</li>
+</ul>
+<h3>
+<a name="TransferModes"></a>Transfer Modes</h3>
+<dl>
+<dt># TransferModes</dt>
+<dt>TransferModes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"normal"</li>
+<li>"pulsate"</li>
+<li>"wobble"</li>
+<li>"fast wobble"</li>
+<li>"static"</li>
+<li>"landscape"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"horizontal slide"</li>
+<li>"fast horizontal slide"</li>
+<li>"vertical slide"</li>
+<li>"fast vertical slide"</li>
+<li>"wander"</li>
+<li>"fast wander"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"reverse horizontal slide" <span class="version">20231125</span>
+</li>
+<li>"reverse fast horizontal slide" <span class="version">20231125</span>
+</li>
+<li>"reverse vertical slide" <span class="version">20231125</span>
+</li>
+<li>"reverse fast vertical slide" <span class="version">20231125</span>
+</li>
+<li>"2x" <span class="version">20231125</span>
+</li>
+<li>"4x" <span class="version">20231125</span>
+</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+<h3>
+<a name="WeaponTypes"></a>Weapons</h3>
+<dl>
+<dt># WeaponTypes</dt>
+<dt>WeaponTypes()</dt>
+</dl>
+<h4>Mnemonics</h4>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"fist"</li>
+<li>"pistol"</li>
+<li>"fusion pistol"</li>
+<li>"assault rifle"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"missile launcher"</li>
+<li>"flamethrower"</li>
+<li>"alien weapon"</li>
+<li>"shotgun"</li>
+</ul></div>
+<div class="mnemonics-column"><ul class="mnemonics">
+<li>"ball"</li>
+<li>"smg"</li>
+</ul></div>
+<div class="end-mnemonics"></div>
+</div>
+<h1>
+<a name="example_icon"></a>Example Icon</h1>
       <pre>
 --[[
 This is  an example  of an  icon  in  the format  used by  Aleph One’s  overlay

--- a/docs/Lua.html
+++ b/docs/Lua.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<title>Aleph One Lua Scripters’ Guide</title>
-<style type="text/css">
+  <head>
+    <META http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Aleph One Lua Scripters’ Guide</title>
+    <style type="text/css">
       <!-- 
       body {
 	  font-family: Verdana, Helvetica, sans-serif;
@@ -122,150 +122,140 @@
 
 -->
       </style>
-</head>
-<body>
-<h1>Table of Contents</h1>
-<ol>
-<li>
-<a href="#general">General</a><ol>
-<li><a href="#what_is_this">What is This?</a></li>
-<li><a href="#running_a_script">Running a Script</a></li>
-<li><a href="#units">Units</a></li>
-<li><a href="#sync">Net Games and Films</a></li>
-<li><a href="#loading_collections">Loading Collections</a></li>
-<li><a href="#persistence">Persistence</a></li>
-<li><a href="#write_access">Solo Plugin Write Access</a></li>
-</ol>
-</li>
-<li><details><summary><a href="#triggers">Triggers</a></summary><ol>
-<li><a href="#calculate_level_completion_state">calculate_level_completion_state</a></li>
-<li><a href="#cleanup">cleanup</a></li>
-<li><a href="#end_refuel">end_refuel</a></li>
-<li><a href="#got_item">got_item</a></li>
-<li><a href="#idle">idle</a></li>
-<li><a href="#init">init</a></li>
-<li><a href="#item_created">item_created</a></li>
-<li><a href="#light_activated">light_activated</a></li>
-<li><a href="#light_switch">light_switch</a></li>
-<li><a href="#monster_damaged">monster_damaged</a></li>
-<li><a href="#monster_kamikazed">monster_kamikazed</a></li>
-<li><a href="#monster_killed">monster_killed</a></li>
-<li><a href="#pattern_buffer">pattern_buffer</a></li>
-<li><a href="#platform_activated">platform_activated</a></li>
-<li><a href="#platform_switch">platform_switch</a></li>
-<li><a href="#player_damaged">player_damaged</a></li>
-<li><a href="#player_killed">player_killed</a></li>
-<li><a href="#player_revived">player_revived</a></li>
-<li><a href="#postidle">postidle</a></li>
-<li><a href="#projectile_created">projectile_created</a></li>
-<li><a href="#projectile_detonated">projectile_detonated</a></li>
-<li><a href="#projectile_switch">projectile_switch</a></li>
-<li><a href="#start_refuel">start_refuel</a></li>
-<li><a href="#tag_switch">tag_switch</a></li>
-<li><a href="#terminal_enter">terminal_enter</a></li>
-<li><a href="#terminal_exit">terminal_exit</a></li>
-</ol></details></li>
-<li>
-<a href="#using_tables">Using Tables</a><ol>
-<li><a href="#custom">Custom Fields</a></li>
-<li><a href="#table_indices">Index</a></li>
-<li><a href="#table_is">is_ Functions</a></li>
-</ol>
-</li>
-<li><details><summary><a href="#tables">Tables</a></summary><ol>
-<li><a href="#Annotations">Annotations</a></li>
-<li><a href="#Cameras">Cameras</a></li>
-<li><a href="#Effects">Effects</a></li>
-<li><a href="#Endpoints">Endpoints</a></li>
-<li><a href="#Ephemera">Ephemera</a></li>
-<li><a href="#Game">Game</a></li>
-<li><a href="#Goals">Goals</a></li>
-<li><a href="#ItemStarts">ItemStarts</a></li>
-<li><a href="#Items">Items</a></li>
-<li><a href="#Level">Level</a></li>
-<li><a href="#Lights">Lights</a></li>
-<li><a href="#Lines">Lines</a></li>
-<li><a href="#Media">Media</a></li>
-<li><a href="#MonsterStarts">MonsterStarts</a></li>
-<li><a href="#Monsters">Monsters</a></li>
-<li><a href="#Music">Music</a></li>
-<li><a href="#Platforms">Platforms</a></li>
-<li><a href="#PlayerStarts">PlayerStarts</a></li>
-<li><a href="#Players">Players</a></li>
-<li><a href="#Polygons">Polygons</a></li>
-<li><a href="#Projectiles">Projectiles</a></li>
-<li><a href="#Scenery">Scenery</a></li>
-<li><a href="#Sides">Sides</a></li>
-<li><a href="#SoundObjects">SoundObjects</a></li>
-<li><a href="#Tags">Tags</a></li>
-<li><a href="#Terminals">Terminals</a></li>
-</ol></details></li>
-<li><details><summary><a href="#types">Types and Mnemonics</a></summary><ol>
-<li><a href="#AmbientSounds">Ambient Sounds</a></li>
-<li><a href="#Collections">Collections</a></li>
-<li><a href="#CompletionStates">Completion States</a></li>
-<li><a href="#ControlPanelClasses">Control Panel Classes</a></li>
-<li><a href="#ControlPanelTypes">Control Panel Types</a></li>
-<li><a href="#DamageTypes">Damage</a></li>
-<li><a href="#DifficultyTypes">Difficulty</a></li>
-<li><a href="#EffectTypes">Effects</a></li>
-<li><a href="#EphemeraQualities">Ephemera Quality</a></li>
-<li><a href="#FadeTypes">Faders</a></li>
-<li><a href="#FogModes">Fog Modes</a></li>
-<li><a href="#GameTypes">Game Types</a></li>
-<li><a href="#ItemKinds">Item Kinds</a></li>
-<li><a href="#ItemTypes">Item Types</a></li>
-<li><a href="#LightFunctions">Light Functions</a></li>
-<li><a href="#LightPresets">Light Presets</a></li>
-<li><a href="#LightStates">Light States</a></li>
-<li><a href="#MediaTypes">Media</a></li>
-<li><a href="#MonsterActions">Monster Actions</a></li>
-<li><a href="#MonsterClasses">Monster Classes</a></li>
-<li><a href="#MonsterModes">Monster Modes</a></li>
-<li><a href="#MonsterTypes">Monsters</a></li>
-<li><a href="#OverlayColors">Overlay Colors</a></li>
-<li><a href="#PlatformTypes">Platform Types</a></li>
-<li><a href="#PlayerColors">Player and Team Colors</a></li>
-<li><a href="#PolygonTypes">Polygons</a></li>
-<li><a href="#ProjectileTypes">Projectiles</a></li>
-<li><a href="#SceneryTypes">Scenery</a></li>
-<li><a href="#ScoringModes">Scoring Modes</a></li>
-<li><a href="#SideTypes">Side Types</a></li>
-<li><a href="#Sounds">Sounds</a></li>
-<li><a href="#TextureTypes">Texture Types</a></li>
-<li><a href="#TransferModes">Transfer Modes</a></li>
-<li><a href="#WeaponTypes">Weapons</a></li>
-</ol></details></li>
-<li><a href="#example_icon">Example Icon</a></li>
-</ol>
-<h1>
-<a name="general"></a>General</h1>
-<h2>
-<a name="what_is_this"></a>What is This?</h2>
+  </head>
+  <body>
+    <h1>Table of Contents</h1>
+    <ol>
+      <li><a href="#general">General</a><ol>
+          <li><a href="#what_is_this">What is This?</a></li>
+          <li><a href="#running_a_script">Running a Script</a></li>
+          <li><a href="#units">Units</a></li>
+          <li><a href="#sync">Net Games and Films</a></li>
+          <li><a href="#loading_collections">Loading Collections</a></li>
+          <li><a href="#persistence">Persistence</a></li>
+          <li><a href="#write_access">Solo Plugin Write Access</a></li>
+        </ol>
+      </li>
+      <li><details><summary><a href="#triggers">Triggers</a></summary><ol>
+            <li><a href="#calculate_level_completion_state">calculate_level_completion_state</a></li>
+            <li><a href="#cleanup">cleanup</a></li>
+            <li><a href="#end_refuel">end_refuel</a></li>
+            <li><a href="#got_item">got_item</a></li>
+            <li><a href="#idle">idle</a></li>
+            <li><a href="#init">init</a></li>
+            <li><a href="#item_created">item_created</a></li>
+            <li><a href="#light_activated">light_activated</a></li>
+            <li><a href="#light_switch">light_switch</a></li>
+            <li><a href="#monster_damaged">monster_damaged</a></li>
+            <li><a href="#monster_kamikazed">monster_kamikazed</a></li>
+            <li><a href="#monster_killed">monster_killed</a></li>
+            <li><a href="#pattern_buffer">pattern_buffer</a></li>
+            <li><a href="#platform_activated">platform_activated</a></li>
+            <li><a href="#platform_switch">platform_switch</a></li>
+            <li><a href="#player_damaged">player_damaged</a></li>
+            <li><a href="#player_killed">player_killed</a></li>
+            <li><a href="#player_revived">player_revived</a></li>
+            <li><a href="#postidle">postidle</a></li>
+            <li><a href="#projectile_created">projectile_created</a></li>
+            <li><a href="#projectile_detonated">projectile_detonated</a></li>
+            <li><a href="#projectile_switch">projectile_switch</a></li>
+            <li><a href="#start_refuel">start_refuel</a></li>
+            <li><a href="#tag_switch">tag_switch</a></li>
+            <li><a href="#terminal_enter">terminal_enter</a></li>
+            <li><a href="#terminal_exit">terminal_exit</a></li>
+          </ol></details></li>
+      <li><a href="#using_tables">Using Tables</a><ol>
+          <li><a href="#custom">Custom Fields</a></li>
+          <li><a href="#table_indices">Index</a></li>
+          <li><a href="#table_is">is_ Functions</a></li>
+        </ol>
+      </li>
+      <li><details><summary><a href="#tables">Tables</a></summary><ol>
+            <li><a href="#Annotations">Annotations</a></li>
+            <li><a href="#Cameras">Cameras</a></li>
+            <li><a href="#Effects">Effects</a></li>
+            <li><a href="#Endpoints">Endpoints</a></li>
+            <li><a href="#Ephemera">Ephemera</a></li>
+            <li><a href="#Game">Game</a></li>
+            <li><a href="#Goals">Goals</a></li>
+            <li><a href="#Items">Items</a></li>
+            <li><a href="#ItemStarts">ItemStarts</a></li>
+            <li><a href="#Level">Level</a></li>
+            <li><a href="#Lights">Lights</a></li>
+            <li><a href="#Lines">Lines</a></li>
+            <li><a href="#Media">Media</a></li>
+            <li><a href="#Monsters">Monsters</a></li>
+            <li><a href="#MonsterStarts">MonsterStarts</a></li>
+            <li><a href="#Music">Music</a></li>
+            <li><a href="#Platforms">Platforms</a></li>
+            <li><a href="#Players">Players</a></li>
+            <li><a href="#PlayerStarts">PlayerStarts</a></li>
+            <li><a href="#Polygons">Polygons</a></li>
+            <li><a href="#Projectiles">Projectiles</a></li>
+            <li><a href="#Scenery">Scenery</a></li>
+            <li><a href="#Sides">Sides</a></li>
+            <li><a href="#SoundObjects">SoundObjects</a></li>
+            <li><a href="#Tags">Tags</a></li>
+            <li><a href="#Terminals">Terminals</a></li>
+          </ol></details></li>
+      <li><details><summary><a href="#types">Types and Mnemonics</a></summary><ol>
+            <li><a href="#AmbientSounds">Ambient Sounds</a></li>
+            <li><a href="#Collections">Collections</a></li>
+            <li><a href="#CompletionStates">Completion States</a></li>
+            <li><a href="#ControlPanelClasses">Control Panel Classes</a></li>
+            <li><a href="#ControlPanelTypes">Control Panel Types</a></li>
+            <li><a href="#DamageTypes">Damage</a></li>
+            <li><a href="#DifficultyTypes">Difficulty</a></li>
+            <li><a href="#EffectTypes">Effects</a></li>
+            <li><a href="#EphemeraQualities">Ephemera Quality</a></li>
+            <li><a href="#FadeTypes">Faders</a></li>
+            <li><a href="#FogModes">Fog Modes</a></li>
+            <li><a href="#GameTypes">Game Types</a></li>
+            <li><a href="#ItemKinds">Item Kinds</a></li>
+            <li><a href="#ItemTypes">Item Types</a></li>
+            <li><a href="#LightFunctions">Light Functions</a></li>
+            <li><a href="#LightPresets">Light Presets</a></li>
+            <li><a href="#LightStates">Light States</a></li>
+            <li><a href="#MediaTypes">Media</a></li>
+            <li><a href="#MonsterActions">Monster Actions</a></li>
+            <li><a href="#MonsterClasses">Monster Classes</a></li>
+            <li><a href="#MonsterModes">Monster Modes</a></li>
+            <li><a href="#MonsterTypes">Monsters</a></li>
+            <li><a href="#MusicFadeTypes">Music Fade Types</a></li>
+            <li><a href="#OverlayColors">Overlay Colors</a></li>
+            <li><a href="#PlatformTypes">Platform Types</a></li>
+            <li><a href="#PlayerColors">Player and Team Colors</a></li>
+            <li><a href="#PolygonTypes">Polygons</a></li>
+            <li><a href="#ProjectileTypes">Projectiles</a></li>
+            <li><a href="#SceneryTypes">Scenery</a></li>
+            <li><a href="#ScoringModes">Scoring Modes</a></li>
+            <li><a href="#SideTypes">Side Types</a></li>
+            <li><a href="#Sounds">Sounds</a></li>
+            <li><a href="#TextureTypes">Texture Types</a></li>
+            <li><a href="#TransferModes">Transfer Modes</a></li>
+            <li><a href="#WeaponTypes">Weapons</a></li>
+          </ol></details></li>
+      <li><a href="#example_icon">Example Icon</a></li>
+    </ol>
+    <h1><a name="general"></a>General</h1>
+    <h2><a name="what_is_this"></a>What is This?</h2>
 		<p>This is a reference for writing Lua scripts to work in Aleph One. It lists every trigger and table available to Lua scripts. It is expected that Lua functionality will grow in Aleph One, and as it does, so will this document. Not everything here is completely documented, and any help fixing that would be appreciated.</p>
 		<p>This is not a reference for Lua itself - see lua.org for that.</p>
-      <h2>
-<a name="running_a_script"></a>Running a Script</h2>
+      <h2><a name="running_a_script"></a>Running a Script</h2>
 		<p>There are three ways to get a script to run - by embedding it in a level, by selecting a solo script in the Environment Preferences, or by selecting a script at the gather network game dialog.</p>
 		<p>To embed a script in a level, use a tool such as Atque. Use embedded Lua scripts only for map specific features, not for modifying game types. For instance, it may be tempting to embed the latest version of the Lua CTF script in a map designed only for playing CTF; however, this would prevent the user from using a later version of CTF if it were to come out, or from using another net script that works on CTF maps. Some older scenarios use Lua scripts in TEXT resources, but this is no longer recommended since they are not transmitted in net games.</p>
 		<p>To use a solo script, check the "Use Solo Script" box in Environment Preferences, and choose the script file to use.</p>
 		<p>To use a script via the network game dialog, put then script in a text file with the extension .lua. Then, at the gather network game dialog, select "use script", then select your script file.</p>
-      <h2>
-<a name="units"></a>Units</h2>
+      <h2><a name="units"></a>Units</h2>
 		<p>The unit for distance we use is World Units (WU) These are the same values you’d see in Forge or with F10 location display, and 1/1024 of what A1 uses internally and what you’d see in Pfhorte.</p>
 		<p>Units for speed are . . . well let’s say they’re messy. :) Lua speeds are expressed in World Units per tick (a tick is 1/30 of a second). Forge claims to use WU per sec, but it actually uses 0.87890625 WU per sec (which equals 30 internal units per tick). The following example illustrates the various conversions:</p>
 		<ul>
-		  <li>
-<b style="display: inline-block; width: 10em; text-align: right">Actual:</b> 7.5 World Units per second</li>
-		  <li>
-<b style="display: inline-block; width: 10em; text-align: right">A1 internal:</b> 256 units per tick (7.5 * 1024 / 30)</li>
-		  <li>
-<b style="display: inline-block; width: 10em; text-align: right">Lua:</b> 0.25 WU per tick (7.5 / 30)</li>
-		  <li>
-<b style="display: inline-block; width: 10em; text-align: right">Forge:</b> 8.53 "WU per second" ((7.5 * 1024 / 30) / 30)</li>
+		  <li><b style="display: inline-block; width: 10em; text-align: right">Actual:</b> 7.5 World Units per second</li>
+		  <li><b style="display: inline-block; width: 10em; text-align: right">A1 internal:</b> 256 units per tick (7.5 * 1024 / 30)</li>
+		  <li><b style="display: inline-block; width: 10em; text-align: right">Lua:</b> 0.25 WU per tick (7.5 / 30)</li>
+		  <li><b style="display: inline-block; width: 10em; text-align: right">Forge:</b> 8.53 "WU per second" ((7.5 * 1024 / 30) / 30)</li>
 		</ul>
-      <h2>
-<a name="sync"></a>Net Games and Films</h2>
+      <h2><a name="sync"></a>Net Games and Films</h2>
 		<p>Aleph One net games distribute a set of player inputs, which are applied to each distributed game world or to the game world in the film being played back. There is a separate copy of the Lua script running on each player’s machine. This means that in order to prevent net games from going out of sync, or films from playing back incorrectly, each of the separately running Lua scripts needs to manipulate the world the exact same way.</p>
 		<p>For example, if one player’s Lua script creates a monster, that monsters actions in the game are controlled by the random seed established at the beginning of the game. So, the other players’ scripts must create the same monster the same way, or the net game will go out of sync.</p>
 		<p>Usually this is not a problem, as long as scripters avoid functions marked with the "local player" tag, and the two local random functions, which will return different results on different machines. The <code>global_random</code> and <code>random</code> functions will return the same number on different machines, as long as they are called the same number of times, so they are safe to use for net games.</p>
@@ -273,28 +263,24 @@
 		<p>A few accessors, such as Ephemera and Fog were designed to be used on a "local player" basis without breaking films or net. For instance, it would be safe to programmatically disable fog when a player zooms in by checking <code>Players.local_player.zoom_active</code>--because the mere presence of fog will not cause a net game or film to go out of sync. Likewise, Ephemera can be created based on the Ephemera.quality setting, which will vary from machine to machine. A script that only uses Ephemera can be turned on and off and film playback will be unaffected.</p>
 		<p>When using local-safe accessors like Ephemera and Fog, it is important to use the matching <code>random_local</code> function, because it will not affect the progression of the ordinary random functions.</p>
 		<p>If this is confusing to you, it would be safest simply to avoid using anything marked with the "local player" tag, as well as the two local random functions and Ephemera.</p>
-	  <h2>
-<a name="loading_collections"></a>Loading Collections</h2>
+	  <h2><a name="loading_collections"></a>Loading Collections</h2>
 		<p>A Lua script can ask for the engine to load collections it might otherwise not load; for instance, in order to be able to spawn defenders and compilers on a map that might not have them otherwise, add the indices for those collections to the global table CollectionsUsed:
 		</p>
-<pre>CollectionsUsed = { 10, 16 }</pre>
-      <h2>
-<a name="persistence"></a>Persistence</h2>
+    <pre>CollectionsUsed = { 10, 16 }</pre>
+      <h2><a name="persistence"></a>Persistence</h2>
 		<p>Lua scripts are only active during a single level. If the user jumps to a new level, or restores from a saved game, the script is restarted in a clean state.</p>
 		<p>It is now possible to pass data across level jumps, by using the Game.restore_passed() function. This function will restore any custom fields (see the "Custom Fields" section of "Using Tables" below) in the Players or Game tables that were set immediately prior to the last level jump. Note that in order for data to survive multiple level jumps, Game.restore_passed() must be called after each level jump. Game.restore_passed() will not restore data from saved games.</p>
 		<p>It is also possible to restore data from saved games. The Game.restore_saved() function will restore all custom fields in use at the time the game was saved.</p>
 		<p>Only numbers, strings, booleans, and tables (including Aleph One’s built-in userdata tables) can be restored.</p>
-      <h2>
-<a name="write_access"></a>Solo Plugin Write Access</h2>
+      <h2><a name="write_access"></a>Solo Plugin Write Access</h2>
 		<p>Plugins that specify solo Lua scripts can also specify write access to features (see the Plugins Guide). Legacy solo Lua plugins are automatically assigned the <code>world</code> write access feature. This means they can modify anything in the game using Lua, but only one <code>world</code> feature script can run at a time, and achievements will be disabled.</p>
 		<p>The write access features <code>music</code>, <code>fog</code>, and <code>overlays</code> can run with other non-<code>world</code> Lua plugins that do not access the same features. For example, only one <code>music</code> plugin can run at a time, but a <code>music</code> plugin and <code>fog</code> plugin could run at the same time.</p>
 		<p>The write access features <code>ephemera</code> and <code>sound</code> can run with any other non-<code>world</code> write access plugins. Remember when writing a <code>ephemera</code> plugin that other plugins (and embedded Lua) can also access ephemera, so manage accordingly.</p>
 		<p>Plugins can specify multiple non-<code>world</code> write access features, and compatibility with other plugins will be determined automatically.</p>
 		<p>All solo Lua scripts can use Players:print and print to the console.</p>
-	  <h1>
-<a name="triggers"></a>Triggers</h1>
-<div class="triggers">
-<p>These are functions scripts can define which Aleph One will call at specific times or events. For example, to regenerate health:
+	  <h1><a name="triggers"></a>Triggers</h1>
+    <div class="triggers">
+      <p>These are functions scripts can define which Aleph One will call at specific times or events. For example, to regenerate health:
 	<span class="pre">Triggers = {}
 function Triggers.idle()
   for p in Players() do 
@@ -306,1923 +292,2587 @@ end
 	</span>
 	Calling Triggers = {} at the beginning of the script removes the compatibility triggers installed for old Lua scripts, speeding up execution of new scripts.
 	</p>
-<dl>
-<dt>Triggers</dt>
-<dd><dl>
-<dt>
-<a name="calculate_level_completion_state"></a>.calculate_level_completion_state() <span class="version">20240712</span>
-</dt>
-<dd><p class="description">replaces the classic completion state calculation</p></dd>
-<dt>
-<a name="cleanup"></a>.cleanup()</dt>
-<dd>
-<p class="description">at end of the level</p>
-<p class="note">primarily this is intended as a last chance for changing netgame scores before the postgame carnage report. </p>
-</dd>
-<dt>
-<a name="end_refuel"></a>.end_refuel(class, player, side)</dt>
-<dd><p class="description">whenever a player stops using a refuel panel</p></dd>
-<dt>
-<a name="got_item"></a>.got_item(type, player)</dt>
-<dd>
-<p class="description">whenever a player picks up an item</p>
-<p class="note">also whenever a player gets an item when a script calls .items.add() </p>
-</dd>
-<dt>
-<a name="idle"></a>.idle()</dt>
-<dd><p class="description">at each tick, before physics and such</p></dd>
-<dt>
-<a name="init"></a>.init(restoring_game)</dt>
-<dd>
-<p class="description">at beginning of level</p>
-<ul class="args"><li>restoring_game: true if restoring from a saved game</li></ul>
-</dd>
-<dt>
-<a name="item_created"></a>.item_created(item)</dt>
-<dd>
-<p class="description">whenever an item is created and placed on the ground (or floating) somewhere</p>
-<p class="note">does not trigger on initial item placement because the initial item placement is done before Lua becomes initialised. </p>
-</dd>
-<dt>
-<a name="light_activated"></a>.light_activated(light)</dt>
-<dd><p class="description">whenever a light is activated or deactivated</p></dd>
-<dt>
-<a name="light_switch"></a>.light_switch(light, player, side)</dt>
-<dd>
-<p class="description">whenever a player uses a light switch</p>
-<p class="note">not called when a projectile (e.g., fists) toggles a light switch </p>
-<p class="note">side is only valid in version 20111201 and newer </p>
-</dd>
-<dt>
-<a name="monster_damaged"></a>.monster_damaged(monster, aggressor_monster, damage_type, damage_amount, projectile) <span class="version">20100118</span>
-</dt>
-<dd>
-<p class="description">whenever a monster is damaged, but before it dies if applicable. The monster’s vitality may be negative when this trigger is called. Ther monster’s vitality will be tested again after this trigger returns, so a script may prevent a monster’s death</p>
-<ul class="args">
-<li>aggressor_monster: the monster that caused the damage (can be nil)</li>
-<li>damage_type: e.g. "fists"</li>
-<li>damage_amount: the amount recently subtracted from the monster’s vitality</li>
-<li>projectile: the projectile that delivered the damage (can be nil)</li>
-</ul>
-</dd>
-<dt>
-<a name="monster_kamikazed"></a>.monster_kamikazed(monster) <span class="version">20240712</span>
-</dt>
-<dd><p class="description">whenever a monster kamikazes</p></dd>
-<dt>
-<a name="monster_killed"></a>.monster_killed(monster, aggressor_player, projectile)</dt>
-<dd>
-<p class="description">whenever a monster dies</p>
-<ul class="args">
-<li>aggressor_player: player who killed it (can be nil)</li>
-<li>projectile: projectile that delivered the final blow (can be nil)</li>
-</ul>
-<p class="note">called after a monster has taken lethal damage, but before it’s removed from the monster list </p>
-<p class="note">you can use this to find out when a monster created with new_monster dies, but a monster discovered by Polygons.monsters() may have already taken lethal damage, so you may need to check for that case when using Polygons.monsters() </p>
-</dd>
-<dt>
-<a name="pattern_buffer"></a>.pattern_buffer(side, player)</dt>
-<dd><p class="description">whenever a player uses a pattern buffer</p></dd>
-<dt>
-<a name="platform_activated"></a>.platform_activated(polygon)</dt>
-<dd><p class="description">whenever a platform is activated or deactivated</p></dd>
-<dt>
-<a name="platform_switch"></a>.platform_switch(polygon, player, side)</dt>
-<dd>
-<p class="description">whenever a player uses a platform switch</p>
-<ul class="args"><li>polygon: polygon of the platform being toggled</li></ul>
-<p class="note">not called when a projectile (e.g., fists) toggles a platform switch </p>
-<p class="note">side is only valid in version 20111201 and newer </p>
-</dd>
-<dt>
-<a name="player_damaged"></a>.player_damaged(victim, aggressor_player, aggressor_monster, damage_type, damage_amount, projectile)</dt>
-<dd>
-<p class="description">whenever a player has taken damage, but before he dies if applicable. The player’s suit energy or oxygen may be negative when this trigger is called; if it still is when the trigger returns, it will be set to 0. The player’s suit energy is tested again after this trigger returns, so a script may prevent a player’s death
+      <dl>
+        <dt>Triggers</dt>
+        <dd>
+          <dl>
+            <dt><a name="calculate_level_completion_state"></a>.calculate_level_completion_state() <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">replaces the classic completion state calculation</p>
+            </dd>
+            <dt><a name="cleanup"></a>.cleanup()</dt>
+            <dd>
+              <p class="description">at end of the level</p>
+              <p class="note">primarily this is intended as a last chance for changing netgame scores before the postgame carnage report. </p>
+            </dd>
+            <dt><a name="end_refuel"></a>.end_refuel(class, player, side)</dt>
+            <dd>
+              <p class="description">whenever a player stops using a refuel panel</p>
+            </dd>
+            <dt><a name="got_item"></a>.got_item(type, player)</dt>
+            <dd>
+              <p class="description">whenever a player picks up an item</p>
+              <p class="note">also whenever a player gets an item when a script calls .items.add() </p>
+            </dd>
+            <dt><a name="idle"></a>.idle()</dt>
+            <dd>
+              <p class="description">at each tick, before physics and such</p>
+            </dd>
+            <dt><a name="init"></a>.init(restoring_game)</dt>
+            <dd>
+              <p class="description">at beginning of level</p>
+              <ul class="args">
+                <li>restoring_game: true if restoring from a saved game</li>
+              </ul>
+            </dd>
+            <dt><a name="item_created"></a>.item_created(item)</dt>
+            <dd>
+              <p class="description">whenever an item is created and placed on the ground (or floating) somewhere</p>
+              <p class="note">does not trigger on initial item placement because the initial item placement is done before Lua becomes initialised. </p>
+            </dd>
+            <dt><a name="light_activated"></a>.light_activated(light)</dt>
+            <dd>
+              <p class="description">whenever a light is activated or deactivated</p>
+            </dd>
+            <dt><a name="light_switch"></a>.light_switch(light, player, side)</dt>
+            <dd>
+              <p class="description">whenever a player uses a light switch</p>
+              <p class="note">not called when a projectile (e.g., fists) toggles a light switch </p>
+              <p class="note">side is only valid in version 20111201 and newer </p>
+            </dd>
+            <dt><a name="monster_damaged"></a>.monster_damaged(monster, aggressor_monster, damage_type, damage_amount, projectile) <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">whenever a monster is damaged, but before it dies if applicable. The monster’s vitality may be negative when this trigger is called. Ther monster’s vitality will be tested again after this trigger returns, so a script may prevent a monster’s death</p>
+              <ul class="args">
+                <li>aggressor_monster: the monster that caused the damage (can be nil)</li>
+                <li>damage_type: e.g. "fists"</li>
+                <li>damage_amount: the amount recently subtracted from the monster’s vitality</li>
+                <li>projectile: the projectile that delivered the damage (can be nil)</li>
+              </ul>
+            </dd>
+            <dt><a name="monster_kamikazed"></a>.monster_kamikazed(monster) <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">whenever a monster kamikazes</p>
+            </dd>
+            <dt><a name="monster_killed"></a>.monster_killed(monster, aggressor_player, projectile)</dt>
+            <dd>
+              <p class="description">whenever a monster dies</p>
+              <ul class="args">
+                <li>aggressor_player: player who killed it (can be nil)</li>
+                <li>projectile: projectile that delivered the final blow (can be nil)</li>
+              </ul>
+              <p class="note">called after a monster has taken lethal damage, but before it’s removed from the monster list </p>
+              <p class="note">you can use this to find out when a monster created with new_monster dies, but a monster discovered by Polygons.monsters() may have already taken lethal damage, so you may need to check for that case when using Polygons.monsters() </p>
+            </dd>
+            <dt><a name="pattern_buffer"></a>.pattern_buffer(side, player)</dt>
+            <dd>
+              <p class="description">whenever a player uses a pattern buffer</p>
+            </dd>
+            <dt><a name="platform_activated"></a>.platform_activated(polygon)</dt>
+            <dd>
+              <p class="description">whenever a platform is activated or deactivated</p>
+            </dd>
+            <dt><a name="platform_switch"></a>.platform_switch(polygon, player, side)</dt>
+            <dd>
+              <p class="description">whenever a player uses a platform switch</p>
+              <ul class="args">
+                <li>polygon: polygon of the platform being toggled</li>
+              </ul>
+              <p class="note">not called when a projectile (e.g., fists) toggles a platform switch </p>
+              <p class="note">side is only valid in version 20111201 and newer </p>
+            </dd>
+            <dt><a name="player_damaged"></a>.player_damaged(victim, aggressor_player, aggressor_monster, damage_type, damage_amount, projectile)</dt>
+            <dd>
+              <p class="description">whenever a player has taken damage, but before he dies if applicable. The player’s suit energy or oxygen may be negative when this trigger is called; if it still is when the trigger returns, it will be set to 0. The player’s suit energy is tested again after this trigger returns, so a script may prevent a player’s death
       </p>
-<ul class="args">
-<li>aggressor_player: player who got the kill (can be nil)</li>
-<li>aggressor_monster: monster that got the kill (can be nil)</li>
-<li>damage_type: e.g. "fists"</li>
-<li>damage_amount: the amount recently subtracted from the player. If "oxygen drain", damage_amount was assessed against player’s oxygen; otherwise against player’s suit energy</li>
-<li>projectile: the projectile that delivered the damage (can be nil)</li>
-</ul>
-</dd>
-<dt>
-<a name="player_killed"></a>.player_killed(player, aggressor_player, action, projectile)</dt>
-<dd>
-<p class="description">whenever a player dies</p>
-<ul class="args">
-<li>aggressor_player: the player who killed player, possibly himself (suicide) (can be nil)</li>
-<li>action: dying soft, dying hard, or dying flaming</li>
-<li>projectile: the projectile that delivered the final blow (can be nil)</li>
-</ul>
-</dd>
-<dt>
-<a name="player_revived"></a>.player_revived(player)</dt>
-<dd><p class="description">whenever a player revives (presumably only happens in a netgame)</p></dd>
-<dt>
-<a name="postidle"></a>.postidle()</dt>
-<dd><p class="description">at each tick, after physics and such, but before rendering</p></dd>
-<dt>
-<a name="projectile_created"></a>.projectile_created(projectile) <span class="version">20150619</span>
-</dt>
-<dd><p class="description">whenever a projectile is created</p></dd>
-<dt>
-<a name="projectile_detonated"></a>.projectile_detonated(type, owner, polygon, x, y, z, t <span class="version">20210408</span>)</dt>
-<dd>
-<p class="description">whenever a projectile detonates, after it has done any area of effect damage</p>
-<p class="note">t can be a side, polygon_floor, polygon_ceiling, monster, scenery, polygon; see Polygon:check_collision for info on how to decode. It can also be nil, in the rare case a projectile detonates without hitting something </p>
-</dd>
-<dt>
-<a name="projectile_switch"></a>.projectile_switch(projectile, side) <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description">whenever a projectile toggles a switch</p>
-<ul class="args">
-<li>projectile: projectile that toggled the switch</li>
-<li>side: side containing switch being toggled</li>
-</ul>
-</dd>
-<dt>
-<a name="start_refuel"></a>.start_refuel(class, player, side)</dt>
-<dd><p class="description">whenever a player starts to use a refuel panel</p></dd>
-<dt>
-<a name="tag_switch"></a>.tag_switch(tag, player, side)</dt>
-<dd>
-<p class="description">whenever a player uses a tag switch</p>
-<p class="note">not called when a projectile (e.g., fists) toggles a tag switch </p>
-<p class="note">side is only valid in version 20111201 and newer </p>
-</dd>
-<dt>
-<a name="terminal_enter"></a>.terminal_enter(terminal, player)</dt>
-<dd><p class="description">whenever a player starts using a terminal</p></dd>
-<dt>
-<a name="terminal_exit"></a>.terminal_exit(terminal, player)</dt>
-<dd><p class="description">whenever a player stops using a terminal</p></dd>
-</dl></dd>
-</dl>
-</div>
-<h1>
-<a name="using_tables"></a>Using Tables</h1>
-<p>There are numerous tables (technically, userdata) defined in Aleph One which scripts can use to access objects in the game. A complete list is below.</p>
+              <ul class="args">
+                <li>aggressor_player: player who got the kill (can be nil)</li>
+                <li>aggressor_monster: monster that got the kill (can be nil)</li>
+                <li>damage_type: e.g. "fists"</li>
+                <li>damage_amount: the amount recently subtracted from the player. If "oxygen drain", damage_amount was assessed against player’s oxygen; otherwise against player’s suit energy</li>
+                <li>projectile: the projectile that delivered the damage (can be nil)</li>
+              </ul>
+            </dd>
+            <dt><a name="player_killed"></a>.player_killed(player, aggressor_player, action, projectile)</dt>
+            <dd>
+              <p class="description">whenever a player dies</p>
+              <ul class="args">
+                <li>aggressor_player: the player who killed player, possibly himself (suicide) (can be nil)</li>
+                <li>action: dying soft, dying hard, or dying flaming</li>
+                <li>projectile: the projectile that delivered the final blow (can be nil)</li>
+              </ul>
+            </dd>
+            <dt><a name="player_revived"></a>.player_revived(player)</dt>
+            <dd>
+              <p class="description">whenever a player revives (presumably only happens in a netgame)</p>
+            </dd>
+            <dt><a name="postidle"></a>.postidle()</dt>
+            <dd>
+              <p class="description">at each tick, after physics and such, but before rendering</p>
+            </dd>
+            <dt><a name="projectile_created"></a>.projectile_created(projectile) <span class="version">20150619</span></dt>
+            <dd>
+              <p class="description">whenever a projectile is created</p>
+            </dd>
+            <dt><a name="projectile_detonated"></a>.projectile_detonated(type, owner, polygon, x, y, z, t <span class="version">20210408</span>)</dt>
+            <dd>
+              <p class="description">whenever a projectile detonates, after it has done any area of effect damage</p>
+              <p class="note">t can be a side, polygon_floor, polygon_ceiling, monster, scenery, polygon; see Polygon:check_collision for info on how to decode. It can also be nil, in the rare case a projectile detonates without hitting something </p>
+            </dd>
+            <dt><a name="projectile_switch"></a>.projectile_switch(projectile, side) <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whenever a projectile toggles a switch</p>
+              <ul class="args">
+                <li>projectile: projectile that toggled the switch</li>
+                <li>side: side containing switch being toggled</li>
+              </ul>
+            </dd>
+            <dt><a name="start_refuel"></a>.start_refuel(class, player, side)</dt>
+            <dd>
+              <p class="description">whenever a player starts to use a refuel panel</p>
+            </dd>
+            <dt><a name="tag_switch"></a>.tag_switch(tag, player, side)</dt>
+            <dd>
+              <p class="description">whenever a player uses a tag switch</p>
+              <p class="note">not called when a projectile (e.g., fists) toggles a tag switch </p>
+              <p class="note">side is only valid in version 20111201 and newer </p>
+            </dd>
+            <dt><a name="terminal_enter"></a>.terminal_enter(terminal, player)</dt>
+            <dd>
+              <p class="description">whenever a player starts using a terminal</p>
+            </dd>
+            <dt><a name="terminal_exit"></a>.terminal_exit(terminal, player)</dt>
+            <dd>
+              <p class="description">whenever a player stops using a terminal</p>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </div>
+    <h1><a name="using_tables"></a>Using Tables</h1>
+    <p>There are numerous tables (technically, userdata) defined in Aleph One which scripts can use to access objects in the game. A complete list is below.</p>
     <p>Unless otherwise specified, these tables are only valid inside the trigger calls listed above. Attempting to use them in the main body of a script may cause an error in this version or a future version of Aleph One.</p>
-<h2>
-<a name="custom"></a>Custom Fields</h2>
-<p>In a real Lua table, you can set any field you want. In order to help troubleshooting, Aleph One’s userdata tables will only accept the fields listed in the documentation below. However, by prepending an underscore, custom fields can be indexed. These custom fields will be associated with the object until it is destroyed.</p>
-<pre>Players[0]._favorite_flavor = "chocolate"</pre>
-<h2>
-<a name="table_indices"></a>Index</h2>
-<p>Each table has a read-only .index variable, that corresponds to the engine’s internal index.</p>
-<pre>=Players[0].index<br>0</pre>
-<h2>
-<a name="table_is"></a>is_ Functions</h2>
-<p>Aleph One installs a set of boolean functions that can be used to recognize each of the userdata table types. For example, <code>is_monster(Monsters[1])</code> returns true. Each of these functions begins with the "is_" prefix.</p>
-<h1><a name="tables">Tables</a></h1>
-<div class="tables">
-<h3>
-<a name="Annotations"></a>Annotations</h3>
-<dl>
-<dt># Annotations</dt>
-<dd><p class="description">number of map annotations</p></dd>
-<dt>Annotations()</dt>
-<dd><p class="description">iterates through all annotations</p></dd>
-<dt>Annotations.new(polygon, text [, x] [, y])</dt>
-<dd><p class="description">returns a new annotation</p></dd>
-<dt>Annotations[index]</dt>
-<dd><dl>
+    <h2><a name="custom"></a>Custom Fields</h2>
+    <p>In a real Lua table, you can set any field you want. In order to help troubleshooting, Aleph One’s userdata tables will only accept the fields listed in the documentation below. However, by prepending an underscore, custom fields can be indexed. These custom fields will be associated with the object until it is destroyed.</p>
+    <pre>Players[0]._favorite_flavor = "chocolate"</pre>
+    <h2><a name="table_indices"></a>Index</h2>
+    <p>Each table has a read-only .index variable, that corresponds to the engine’s internal index.</p>
+    <pre>=Players[0].index<br>0</pre>
+    <h2><a name="table_is"></a>is_ Functions</h2>
+    <p>Aleph One installs a set of boolean functions that can be used to recognize each of the userdata table types. For example, <code>is_monster(Monsters[1])</code> returns true. Each of these functions begins with the "is_" prefix.</p>
+    <h1><a name="tables">Tables</a></h1>
+    <div class="tables">
+      <h3><a name="Annotations"></a>Annotations</h3>
+      <dl>
+        <dt># Annotations</dt>
+        <dd>
+          <p class="description">number of map annotations</p>
+        </dd>
+        <dt>Annotations()</dt>
+        <dd>
+          <p class="description">iterates through all annotations</p>
+        </dd>
+        <dt>Annotations.new(polygon, text [, x] [, y])</dt>
+        <dd>
+          <p class="description">returns a new annotation</p>
+        </dd>
+        <dt>Annotations[index]</dt>
+        <dd>
+          <dl>
       <dt>.polygon</dt>
-<dd>
-<p class="description">polygon this annotation is associated with</p>
-<p class="note">can be nil </p>
-<p class="note">an annotation is only shown when its polygon is visible on the overhead map </p>
-</dd>
+            <dd>
+              <p class="description">polygon this annotation is associated with</p>
+              <p class="note">can be nil </p>
+              <p class="note">an annotation is only shown when its polygon is visible on the overhead map </p>
+            </dd>
       <dt>.text</dt>
-<dd><p class="description">annotation text (64 characters max)</p></dd>
+            <dd>
+              <p class="description">annotation text (64 characters max)</p>
+            </dd>
       <dt>.x</dt>
-<dd><p class="description"></p></dd>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
       <dt>.y</dt>
-<dd><p class="description"></p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Cameras"></a>Cameras</h3>
-<dl>
-<dt># Cameras</dt>
-<dd><p class="description">number of cameras</p></dd>
-<dt>Cameras()</dt>
-<dd><p class="description">iterates through all cameras</p></dd>
-<dt>Cameras.new()</dt>
-<dd>
-<p class="description">returns a new uninitialized camera</p>
-<p class="note">make sure to add path points and angles before activating the camera </p>
-</dd>
-<dt>Cameras[index]</dt>
-<dd><dl>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Cameras"></a>Cameras</h3>
+      <dl>
+        <dt># Cameras</dt>
+        <dd>
+          <p class="description">number of cameras</p>
+        </dd>
+        <dt>Cameras()</dt>
+        <dd>
+          <p class="description">iterates through all cameras</p>
+        </dd>
+        <dt>Cameras.new()</dt>
+        <dd>
+          <p class="description">returns a new uninitialized camera</p>
+          <p class="note">make sure to add path points and angles before activating the camera </p>
+        </dd>
+        <dt>Cameras[index]</dt>
+        <dd>
+          <dl>
       <dt>:activate(player)</dt>
-<dd><p class="description">activate camera for player</p></dd>
+            <dd>
+              <p class="description">activate camera for player</p>
+            </dd>
       <dt>:clear()</dt>
-<dd><p class="description">deletes all path points and angles</p></dd>
+            <dd>
+              <p class="description">deletes all path points and angles</p>
+            </dd>
       <dt>:deactivate()</dt>
-<dd><p class="description">deactivates camera</p></dd>
+            <dd>
+              <p class="description">deactivates camera</p>
+            </dd>
       <dt>.path_angles</dt>
-<dd><dl>
-<dt>:new(yaw, pitch, time)</dt>
-<dd><p class="description">adds a path angle</p></dd>
-</dl></dd>
+            <dd>
+              <dl>
+                <dt>:new(yaw, pitch, time)</dt>
+                <dd>
+                  <p class="description">adds a path angle</p>
+                </dd>
+              </dl>
+            </dd>
       <dt>.path_points</dt>
-<dd><dl>
-<dt>:new(x, y, z, polygon, time)</dt>
-<dd><p class="description">adds a path point</p></dd>
-</dl></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Effects"></a>Effects</h3>
-<dl>
-<dt># Effects</dt>
-<dd><p class="description">maximum number of effects</p></dd>
-<dt>Effects()</dt>
-<dd><p class="description">iterates through all valid effects</p></dd>
-<dt>Effects.new(x, y, height, polygon, type) <span class="version">20111201</span>
-</dt>
-<dd><p class="description">returns a new effect</p></dd>
-<dt>Effects[index]</dt>
-<dd><dl>
-      <dt>:delete() <span class="version">20111201</span>
-</dt>
-<dd><p class="description">removes effect from map</p></dd>
-      <dt>.facing <span class="version">20111201</span>
-</dt>
-<dd><p class="description">direction effect is facing</p></dd>
-      <dt>:play_sound(sound) <span class="version">20111201</span>
-</dt>
-<dd><p class="description">play sound coming from this effect</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">polygon the effect is in</p></dd>
-      <dt>:position(x, y, z, polygon) <span class="version">20111201</span>
-</dt>
-<dd><p class="description">sets position of effect</p></dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">type of effect</p></dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Endpoints"></a>Endpoints</h3>
-<dl>
-<dt># Endpoints</dt>
-<dd><p class="description">number of endpoints in level</p></dd>
-<dt>Endpoints()</dt>
-<dd><p class="description">iterates through all endpoints in the level</p></dd>
-<dt>Endpoints[index]</dt>
-<dd><dl>
-      <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Ephemera"></a>Ephemera <span class="version">20210408</span>
-</h3>
+            <dd>
+              <dl>
+                <dt>:new(x, y, z, polygon, time)</dt>
+                <dd>
+                  <p class="description">adds a path point</p>
+                </dd>
+              </dl>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Effects"></a>Effects</h3>
+      <dl>
+        <dt># Effects</dt>
+        <dd>
+          <p class="description">maximum number of effects</p>
+        </dd>
+        <dt>Effects()</dt>
+        <dd>
+          <p class="description">iterates through all valid effects</p>
+        </dd>
+        <dt>Effects.new(x, y, height, polygon, type) <span class="version">20111201</span></dt>
+        <dd>
+          <p class="description">returns a new effect</p>
+        </dd>
+        <dt>Effects[index]</dt>
+        <dd>
+          <dl>
+      <dt>:delete() <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">removes effect from map</p>
+            </dd>
+      <dt>.facing <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">direction effect is facing</p>
+            </dd>
+      <dt>:play_sound(sound) <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">play sound coming from this effect</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">polygon the effect is in</p>
+            </dd>
+      <dt>:position(x, y, z, polygon) <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">sets position of effect</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">type of effect</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Endpoints"></a>Endpoints</h3>
+      <dl>
+        <dt># Endpoints</dt>
+        <dd>
+          <p class="description">number of endpoints in level</p>
+        </dd>
+        <dt>Endpoints()</dt>
+        <dd>
+          <p class="description">iterates through all endpoints in the level</p>
+        </dd>
+        <dt>Endpoints[index]</dt>
+        <dd>
+          <dl>
+      <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Ephemera"></a>Ephemera <span class="version">20210408</span></h3>
 		<p>Ephemera are a render-only version of Effects. They were designed to be a lightweight way to add effects such as precipitation or decals. They do not use any global random functionality, and they don’t interact at all with other objects in the world, so they are safe to turn on and off without affecting net game sync and film playback (see <a href="#sync">"Net Games and Films"</a>).</p>
 		<p>Ephemera are not saved or restored in saved games, so it is up to the Lua script to serialize them and persist them if desired; and to recreate them upon resume. Likewise, ephemera custom fields are not saved/restored using <code>Level.restored_saved()</code></p>
 		<p><em>All</em> ephemera functions are "local player"</p>
 	  <dl>
-<dt># Ephemera</dt>
-<dd><p class="description">maximum number of ephemera</p></dd>
-<dt>Ephemera()</dt>
-<dd><p class="description">iterates through all valid ephemera</p></dd>
-<dt>Ephemera.new(x, y, z, polygon, collection, sequence, facing)</dt>
-<dd><p class="description">returns a new ephemera</p></dd>
-<dt>Ephemera.quality<span class="access"> (read-only)</span>
-</dt>
-<dd>
-<p class="description">user’s ephemera quality setting</p>
-<p class="note">it is up to the script’s discretion how many ephemera to create / maintain, based on this quality setting; if set to off, ephemera are not rendered regardless of how many the script creates </p>
-</dd>
-<dt>Ephemera[index]</dt>
-<dd><dl>
+        <dt># Ephemera</dt>
+        <dd>
+          <p class="description">maximum number of ephemera</p>
+        </dd>
+        <dt>Ephemera()</dt>
+        <dd>
+          <p class="description">iterates through all valid ephemera</p>
+        </dd>
+        <dt>Ephemera.new(x, y, z, polygon, collection, sequence, facing)</dt>
+        <dd>
+          <p class="description">returns a new ephemera</p>
+        </dd>
+        <dt>Ephemera.quality<span class="access"> (read-only)</span></dt>
+        <dd>
+          <p class="description">user’s ephemera quality setting</p>
+          <p class="note">it is up to the script’s discretion how many ephemera to create / maintain, based on this quality setting; if set to off, ephemera are not rendered regardless of how many the script creates </p>
+        </dd>
+        <dt>Ephemera[index]</dt>
+        <dd>
+          <dl>
 	  <dt>.clut_index</dt>
-<dd><p class="description">color table of this ephemera</p></dd>
+            <dd>
+              <p class="description">color table of this ephemera</p>
+            </dd>
 	  <dt>.collection</dt>
-<dd><p class="description">shape collection of this ephemera</p></dd>
+            <dd>
+              <p class="description">shape collection of this ephemera</p>
+            </dd>
 	  <dt>.end_when_animation_loops</dt>
-<dd><p class="description">if set, ephemera is removed once animation finishes</p></dd>
+            <dd>
+              <p class="description">if set, ephemera is removed once animation finishes</p>
+            </dd>
 	  <dt>:delete()</dt>
-<dd><p class="description">removes ephemera from the level</p></dd>
+            <dd>
+              <p class="description">removes ephemera from the level</p>
+            </dd>
 	  <dt>.enlarged</dt>
-<dd><p class="description">ephemera is rendered 25% bigger</p></dd>
+            <dd>
+              <p class="description">ephemera is rendered 25% bigger</p>
+            </dd>
 	  <dt>.facing</dt>
-<dd><p class="description">direction the ephemera is facing</p></dd>
+            <dd>
+              <p class="description">direction the ephemera is facing</p>
+            </dd>
 	  <dt>:position(x, y, z, polygon)</dt>
-<dd><p class="description">sets position of ephemera</p></dd>
-	  <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon this ephemera is in</p></dd>
-	  <dt>.rendered<span class="access"> (read-only)</span>
-</dt>
-<dd>
-<p class="description">whether this ephemera was recently rendered</p>
-<p class="note">you can use this to skip updating ephemera that aren’t currently visible </p>
-</dd>
+            <dd>
+              <p class="description">sets position of ephemera</p>
+            </dd>
+	  <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon this ephemera is in</p>
+            </dd>
+	  <dt>.rendered<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether this ephemera was recently rendered</p>
+              <p class="note">you can use this to skip updating ephemera that aren’t currently visible </p>
+            </dd>
 	  <dt>.shape_index</dt>
-<dd>
-<p class="description">shape index of ephemera</p>
-<p class="note">Anvil calls this sequence </p>
-</dd>
+            <dd>
+              <p class="description">shape index of ephemera</p>
+              <p class="note">Anvil calls this sequence </p>
+            </dd>
 	  <dt>.tiny</dt>
-<dd><p class="description">ephemera is rendered 50% size</p></dd>
-	  <dt>.valid<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether ephemera is still valid</p></dd>
-	  <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.z<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-	</dl></dd>
-</dl>
-<h3>
-<a name="Game"></a>Game</h3>
-<dl>
-<dt>Game</dt>
-<dd><dl>
-<dt>.autosave() <span class="version">20250302</span>
-</dt>
-<dd>
-<p class="description">saves the game without prompting the user, if possible</p>
-<p class="note">solo only </p>
-</dd>
-<dt>.dead_players_drop_items <span class="version">20150619</span>
-</dt>
-<dd><p class="description">whether dead players drop items</p></dd>
-<dt>.deserialize(s) <span class="version">20200830</span>
-</dt>
-<dd>
-<p class="description">deserializes s and returns the original Lua value</p>
-<p class="note">see Game.serialize </p>
-</dd>
-<dt>.difficulty<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">the difficulty level</p></dd>
-<dt>.global_random(n)</dt>
-<dd><p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p></dd>
-<dt>.kill_limit<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">the game kill limit, or 0 if there is none</p></dd>
-<dt>.local_random(n)</dt>
-<dd>
-<p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p>
-<p class="note">use only for local player effects (see Net Games and Films) </p>
-</dd>
-<dt>.monsters_replenish <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description">whether monsters spawn or not; in a net game, this corresponds to the "Aliens" checkbox</p>
-<p class="note">this can suppress initial monster placement, if set to false directly when the script is loaded </p>
-</dd>
-<dt>.nonlocal_overlays <span class="version">20200830</span>
-</dt>
-<dd><p class="description">When false, only the local player’s overlays are used, and only prints to the local player will be displayed. When true, the overlays and prints of whatever player is currently being viewed will apply. This defaults to false for compatibility with scripts that depend on the old behavior.</p></dd>
-<dt>.over<span class="access"> (write-only)</span>
-</dt>
-<dd><p class="description">Use this variable to override the game’s default scoring behavior. If set to false, the game will not end due to a score limit. If set to true, the game ends immediately. If left unset or if set to nil, the game will end if a score limit is reached. (Note that you cannot prevent the game from ending due to a time limit.)</p></dd>
-<dt>.player <span class="version">20250829</span>
-</dt>
-<dd>
-<p class="description">In Tag games, the player who is It. In Kill the Man With the Ball or Rugby games, the player who is carrying the ball</p>
-<p class="note">writing to this will only work in Tag games </p>
-</dd>
-<dt>.proper_item_accounting <span class="version">20100118</span>
-</dt>
-<dd><p class="description">When true, the current item counts on the map are updated properly when Lua deletes map items and changes player inventories. This defaults to false to preserve film playback with older scripts. New scripts that manipulate items should always set this to true.</p></dd>
-<dt>.random(n)</dt>
-<dd><p class="description">returns a random number between 0 and n-1 using a good random number generator</p></dd>
-<dt>.random_local(n) <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">returns a random number between 0 and n-1 using a good random number generator</p>
-<p class="note">use only for local player effects (see Net Games and Films) </p>
-</dd>
-<dt>.replay<span class="access"> (read-only)</span> <span class="version">20221126</span>
-</dt>
-<dd>
-<p class="description">is the script being run during a film replay</p>
-<p class="note">use sparingly; altering the world differently during a replay than during live playback will cause the replay go out of sync </p>
-</dd>
-<dt>.restore_passed() <span class="version">20090909</span>
-</dt>
-<dd>
-<p class="description">tries to restore any Player or Game custom fields from before the last level jump; returns true if custom fields were successfully restored</p>
-<p class="note">if successful, overwrites all existing Player or Game custom fields </p>
-</dd>
-<dt>.restore_saved() <span class="version">20090909</span>
-</dt>
-<dd>
-<p class="description">tries to restore any custom fields from the saved game; returns true if custom fields were successfully restored</p>
-<p class="note">if successful, overwrites all existing custom fields </p>
-</dd>
-<dt>.save()</dt>
-<dd>
-<p class="description">saves the game (as if the user had activated a pattern buffer)</p>
-<p class="note">solo only </p>
-</dd>
-<dt>.scoring_mode</dt>
-<dd><p class="description">the current scoring mode (if the gametype is "custom")</p></dd>
-<dt>.serialize(v) <span class="version">20200830</span>
-</dt>
-<dd>
-<p class="description">serializes v into a binary string</p>
-<p class="note">only numbers, strings, booleans, and tables (including Aleph One’s built-in userdata tables) can be serialized </p>
-</dd>
-<dt>.ticks<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">ticks since game started</p></dd>
-<dt>.time_remaining<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">the number of ticks until the game ends, or nil if there is no time limit</p></dd>
-<dt>.type<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether the game is EMFH, KOTH, etc.</p></dd>
-<dt>.version<span class="access"> (read-only)</span>
-</dt>
-<dd>
-<p class="description">the date version of the local player’s engine</p>
-<p class="note">for example, "20071103" </p>
-</dd>
-</dl></dd>
-</dl>
-<h3>
-<a name="Goals"></a>Goals</h3>
-<dl>
-<dt># Goals</dt>
-<dd><p class="description">number of saved map objects (of all types)</p></dd>
-<dt>Goals()</dt>
-<dd><p class="description">iterates through all goals</p></dd>
-<dt>Goals[index]</dt>
-<dd><dl>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">direction goal is facing</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">polygon the goal is in</p></dd>
-      <dt>.id<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">ID number of goal</p></dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description"></p>
-<p class="note">from floor or ceiling </p>
-</dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="ItemStarts"></a>ItemStarts</h3>
-<dl>
-<dt># ItemStarts</dt>
-<dd><p class="description">number of map objects in the level</p></dd>
-<dt>ItemStarts()</dt>
-<dd><p class="description">iterates through all item starting locations in the level</p></dd>
-<dt>ItemStarts[index]</dt>
-<dd><dl>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">direction item is initially facing</p></dd>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether item location z is from ceiling</p></dd>
-      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether item will teleport in</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">item starting location polygon</p></dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">type of item</p></dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description"></p>
-<p class="note">from floor or ceiling </p>
-</dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Items"></a>Items</h3>
-<dl>
-<dt># Items</dt>
-<dd><p class="description">maximum number of map objects</p></dd>
-<dt>Items()</dt>
-<dd><p class="description">iterates through all valid items</p></dd>
-<dt>Items.new(x, y, height, polygon, type)</dt>
-<dd><p class="description">returns a new item</p></dd>
-<dt>Items[index]</dt>
-<dd><dl>
+            <dd>
+              <p class="description">ephemera is rendered 50% size</p>
+            </dd>
+	  <dt>.valid<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether ephemera is still valid</p>
+            </dd>
+	  <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.z<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	</dl>
+        </dd>
+      </dl>
+      <h3><a name="Game"></a>Game</h3>
+      <dl>
+        <dt>Game</dt>
+        <dd>
+          <dl>
+            <dt>.autosave() <span class="version">20250302</span></dt>
+            <dd>
+              <p class="description">saves the game without prompting the user, if possible</p>
+              <p class="note">solo only </p>
+            </dd>
+            <dt>.dead_players_drop_items <span class="version">20150619</span></dt>
+            <dd>
+              <p class="description">whether dead players drop items</p>
+            </dd>
+            <dt>.deserialize(s) <span class="version">20200830</span></dt>
+            <dd>
+              <p class="description">deserializes s and returns the original Lua value</p>
+              <p class="note">see Game.serialize </p>
+            </dd>
+            <dt>.difficulty<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">the difficulty level</p>
+            </dd>
+            <dt>.global_random(n)</dt>
+            <dd>
+              <p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p>
+            </dd>
+            <dt>.kill_limit<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">the game kill limit, or 0 if there is none</p>
+            </dd>
+            <dt>.local_random(n)</dt>
+            <dd>
+              <p class="description">returns a random number between 0 and n-1 from Aleph One’s original random number generator</p>
+              <p class="note">use only for local player effects (see Net Games and Films) </p>
+            </dd>
+            <dt>.monsters_replenish <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether monsters spawn or not; in a net game, this corresponds to the "Aliens" checkbox</p>
+              <p class="note">this can suppress initial monster placement, if set to false directly when the script is loaded </p>
+            </dd>
+            <dt>.nonlocal_overlays <span class="version">20200830</span></dt>
+            <dd>
+              <p class="description">When false, only the local player’s overlays are used, and only prints to the local player will be displayed. When true, the overlays and prints of whatever player is currently being viewed will apply. This defaults to false for compatibility with scripts that depend on the old behavior.</p>
+            </dd>
+            <dt>.over<span class="access"> (write-only)</span></dt>
+            <dd>
+              <p class="description">Use this variable to override the game’s default scoring behavior. If set to false, the game will not end due to a score limit. If set to true, the game ends immediately. If left unset or if set to nil, the game will end if a score limit is reached. (Note that you cannot prevent the game from ending due to a time limit.)</p>
+            </dd>
+            <dt>.player <span class="version">20250829</span></dt>
+            <dd>
+              <p class="description">In Tag games, the player who is It. In Kill the Man With the Ball or Rugby games, the player who is carrying the ball</p>
+              <p class="note">writing to this will only work in Tag games </p>
+            </dd>
+            <dt>.proper_item_accounting <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">When true, the current item counts on the map are updated properly when Lua deletes map items and changes player inventories. This defaults to false to preserve film playback with older scripts. New scripts that manipulate items should always set this to true.</p>
+            </dd>
+            <dt>.random(n)</dt>
+            <dd>
+              <p class="description">returns a random number between 0 and n-1 using a good random number generator</p>
+            </dd>
+            <dt>.random_local(n) <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">returns a random number between 0 and n-1 using a good random number generator</p>
+              <p class="note">use only for local player effects (see Net Games and Films) </p>
+            </dd>
+            <dt>.replay<span class="access"> (read-only)</span> <span class="version">20221126</span></dt>
+            <dd>
+              <p class="description">is the script being run during a film replay</p>
+              <p class="note">use sparingly; altering the world differently during a replay than during live playback will cause the replay go out of sync </p>
+            </dd>
+            <dt>.restore_passed() <span class="version">20090909</span></dt>
+            <dd>
+              <p class="description">tries to restore any Player or Game custom fields from before the last level jump; returns true if custom fields were successfully restored</p>
+              <p class="note">if successful, overwrites all existing Player or Game custom fields </p>
+            </dd>
+            <dt>.restore_saved() <span class="version">20090909</span></dt>
+            <dd>
+              <p class="description">tries to restore any custom fields from the saved game; returns true if custom fields were successfully restored</p>
+              <p class="note">if successful, overwrites all existing custom fields </p>
+            </dd>
+            <dt>.save()</dt>
+            <dd>
+              <p class="description">saves the game (as if the user had activated a pattern buffer)</p>
+              <p class="note">solo only </p>
+            </dd>
+            <dt>.scoring_mode</dt>
+            <dd>
+              <p class="description">the current scoring mode (if the gametype is "custom")</p>
+            </dd>
+            <dt>.serialize(v) <span class="version">20200830</span></dt>
+            <dd>
+              <p class="description">serializes v into a binary string</p>
+              <p class="note">only numbers, strings, booleans, and tables (including Aleph One’s built-in userdata tables) can be serialized </p>
+            </dd>
+            <dt>.ticks<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">ticks since game started</p>
+            </dd>
+            <dt>.time_remaining<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">the number of ticks until the game ends, or nil if there is no time limit</p>
+            </dd>
+            <dt>.type<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether the game is EMFH, KOTH, etc.</p>
+            </dd>
+            <dt>.version<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">the date version of the local player’s engine</p>
+              <p class="note">for example, "20071103" </p>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+      <h3><a name="Goals"></a>Goals</h3>
+      <dl>
+        <dt># Goals</dt>
+        <dd>
+          <p class="description">number of saved map objects (of all types)</p>
+        </dd>
+        <dt>Goals()</dt>
+        <dd>
+          <p class="description">iterates through all goals</p>
+        </dd>
+        <dt>Goals[index]</dt>
+        <dd>
+          <dl>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">direction goal is facing</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">polygon the goal is in</p>
+            </dd>
+      <dt>.id<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">ID number of goal</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+              <p class="note">from floor or ceiling </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Items"></a>Items</h3>
+      <dl>
+        <dt># Items</dt>
+        <dd>
+          <p class="description">maximum number of map objects</p>
+        </dd>
+        <dt>Items()</dt>
+        <dd>
+          <p class="description">iterates through all valid items</p>
+        </dd>
+        <dt>Items.new(x, y, height, polygon, type)</dt>
+        <dd>
+          <p class="description">returns a new item</p>
+        </dd>
+        <dt>Items[index]</dt>
+        <dd>
+          <dl>
       <dt>:delete()</dt>
-<dd><p class="description">removes item from map</p></dd>
+            <dd>
+              <p class="description">removes item from map</p>
+            </dd>
       <dt>.facing</dt>
-<dd><p class="description">direction item is facing</p></dd>
+            <dd>
+              <p class="description">direction item is facing</p>
+            </dd>
       <dt>:play_sound(sound)</dt>
-<dd><p class="description">play sound coming from this item</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon the item is in</p></dd>
-      <dt>:position(x, y, z, polygon) <span class="version">20090909</span>
-</dt>
-<dd><p class="description">sets position of item</p></dd>
-	  <dt>:teleport_in() <span class="version">20240712</span>
-</dt>
-<dd>
-<p class="description">teleports item in</p>
-<p class="note">can fail silently if there are not enough effects slots </p>
-</dd>
-	  <dt>:teleport_out() <span class="version">20240712</span>
-</dt>
-<dd>
-<p class="description">teleports item out</p>
-<p class="note">can fail silently if there are not enough effects slots </p>
-</dd>
-      <dt>.type<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of item</p></dd>
-      <dt>.visible <span class="version">20240712</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Level"></a>Level</h3>
-<dl>
-<dt>Level</dt>
-<dd><dl>
-<dt>.calculate_completion_state() <span class="version">20081213</span>
-</dt>
-<dd>
-<p class="description">returns whether level is finished, unfinished, or failed</p>
-<p class="note">does not call the trigger, so it can be used in the trigger </p>
-</dd>
-<dt>.completed<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">check this in Triggers.cleanup() to determine whether the player(s) teleported out</p></dd>
-<dt>.extermination<span class="access"> (read-only)</span> <span class="version">20081213</span>
-</dt>
-<dd><p class="description">whether level has extermination flag set</p></dd>
-<dt>.exploration<span class="access"> (read-only)</span> <span class="version">20081213</span>
-</dt>
-<dd><p class="description">whether level has exploration flag set</p></dd>
-<dt>.fog<br>.underwater_fog</dt>
-<dd><dl>
-<dt>.active<br>.present</dt>
-<dd><p class="description">whether fog is present</p></dd>
-<dt>.affects_landscapes</dt>
-<dd><p class="description">whether fog affects landscapes</p></dd>
-<dt>.color</dt>
-<dd>
-<p class="note">values range from 0.0 to 1.0 </p>
-<dl>
-<dt>.b</dt>
-<dd><p class="description">blue</p></dd>
-<dt>.g</dt>
-<dd><p class="description">green</p></dd>
-<dt>.r</dt>
-<dd><p class="description">red</p></dd>
-</dl>
-</dd>
-<dt>.depth</dt>
-<dd><p class="description">fog depth in WU</p></dd>
-<dt>.landscape_mix <span class="version">20231125</span>
-</dt>
-<dd>
-<p class="description">amount of fog to mix into landscape</p>
-<p class="note">values range from 0.0 to 1.0 </p>
-</dd>
-<dt>.mode <span class="version">20231125</span>
-</dt>
-<dd><p class="description">linear, exp, or exp2</p></dd>
-<dt>.start <span class="version">20231125</span>
-</dt>
-<dd>
-<p class="description">fog start in WU</p>
-<p class="note">only applies to linear fog </p>
-</dd>
-</dl></dd>
-<dt>.low_gravity<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether level is low gravity</p></dd>
-<dt>.magnetic<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether level is magnetic</p></dd>
-<dt>.name<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">level name</p></dd>
-<dt>.index<span class="access"> (read-only)</span> <span class="version">20150619</span>
-</dt>
-<dd><p class="description">level index in the map file (starting from 0)</p></dd>
-<dt>.map_checksum<span class="access"> (read-only)</span> <span class="version">20150619</span>
-</dt>
-<dd><p class="description">checksum of map file</p></dd>
-<dt>.rebellion<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether level is rebellion</p></dd>
-<dt>.repair<span class="access"> (read-only)</span> <span class="version">20081213</span>
-</dt>
-<dd><p class="description">whether level has repair flag set</p></dd>
-<dt>.rescue<span class="access"> (read-only)</span> <span class="version">20081213</span>
-</dt>
-<dd><p class="description">whether level has rescue flag set</p></dd>
-<dt>.retrieval<span class="access"> (read-only)</span> <span class="version">20081213</span>
-</dt>
-<dd><p class="description">whether level has retrieval flag set</p></dd>
-<dt>.stash[key] <span class="version">20200830</span>
-</dt>
-<dd>
-<p class="description">reads/writes values to a stash shared between all running Lua scripts</p>
-<p class="note">keys/values must be strings </p>
-</dd>
-<dt>.vacuum<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether level is vacuum</p></dd>
-</dl></dd>
-</dl>
-<h3>
-<a name="Lights"></a>Lights</h3>
-<dl>
-<dt># Lights</dt>
-<dd><p class="description">number of lights in level</p></dd>
-<dt>Lights()</dt>
-<dd><p class="description">iterates through all lights in the level</p></dd>
-<dt>Lights.new( [light_preset])</dt>
-<dd><p class="description">returns a new light</p></dd>
-<dt>Lights[index]</dt>
-<dd><dl>
+            <dd>
+              <p class="description">play sound coming from this item</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon the item is in</p>
+            </dd>
+      <dt>:position(x, y, z, polygon) <span class="version">20090909</span></dt>
+            <dd>
+              <p class="description">sets position of item</p>
+            </dd>
+	  <dt>:teleport_in() <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">teleports item in</p>
+              <p class="note">can fail silently if there are not enough effects slots </p>
+            </dd>
+	  <dt>:teleport_out() <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">teleports item out</p>
+              <p class="note">can fail silently if there are not enough effects slots </p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">type of item</p>
+            </dd>
+      <dt>.visible <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="ItemStarts"></a>ItemStarts</h3>
+      <dl>
+        <dt># ItemStarts</dt>
+        <dd>
+          <p class="description">number of map objects in the level</p>
+        </dd>
+        <dt>ItemStarts()</dt>
+        <dd>
+          <p class="description">iterates through all item starting locations in the level</p>
+        </dd>
+        <dt>ItemStarts[index]</dt>
+        <dd>
+          <dl>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">direction item is initially facing</p>
+            </dd>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether item location z is from ceiling</p>
+            </dd>
+      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether item will teleport in</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">item starting location polygon</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">type of item</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+              <p class="note">from floor or ceiling </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Level"></a>Level</h3>
+      <dl>
+        <dt>Level</dt>
+        <dd>
+          <dl>
+            <dt>.calculate_completion_state() <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">returns whether level is finished, unfinished, or failed</p>
+              <p class="note">does not call the trigger, so it can be used in the trigger </p>
+            </dd>
+            <dt>.completed<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">check this in Triggers.cleanup() to determine whether the player(s) teleported out</p>
+            </dd>
+            <dt>.extermination<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">whether level has extermination flag set</p>
+            </dd>
+            <dt>.exploration<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">whether level has exploration flag set</p>
+            </dd>
+            <dt>.fog<br>.underwater_fog</dt>
+            <dd>
+              <dl>
+                <dt>.active<br>.present</dt>
+                <dd>
+                  <p class="description">whether fog is present</p>
+                </dd>
+                <dt>.affects_landscapes</dt>
+                <dd>
+                  <p class="description">whether fog affects landscapes</p>
+                </dd>
+                <dt>.color</dt>
+                <dd>
+                  <p class="note">values range from 0.0 to 1.0 </p>
+                  <dl>
+                    <dt>.b</dt>
+                    <dd>
+                      <p class="description">blue</p>
+                    </dd>
+                    <dt>.g</dt>
+                    <dd>
+                      <p class="description">green</p>
+                    </dd>
+                    <dt>.r</dt>
+                    <dd>
+                      <p class="description">red</p>
+                    </dd>
+                  </dl>
+                </dd>
+                <dt>.depth</dt>
+                <dd>
+                  <p class="description">fog depth in WU</p>
+                </dd>
+                <dt>.landscape_mix <span class="version">20231125</span></dt>
+                <dd>
+                  <p class="description">amount of fog to mix into landscape</p>
+                  <p class="note">values range from 0.0 to 1.0 </p>
+                </dd>
+                <dt>.mode <span class="version">20231125</span></dt>
+                <dd>
+                  <p class="description">linear, exp, or exp2</p>
+                </dd>
+                <dt>.start <span class="version">20231125</span></dt>
+                <dd>
+                  <p class="description">fog start in WU</p>
+                  <p class="note">only applies to linear fog </p>
+                </dd>
+              </dl>
+            </dd>
+            <dt>.low_gravity<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether level is low gravity</p>
+            </dd>
+            <dt>.magnetic<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether level is magnetic</p>
+            </dd>
+            <dt>.name<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">level name</p>
+            </dd>
+            <dt>.index<span class="access"> (read-only)</span> <span class="version">20150619</span></dt>
+            <dd>
+              <p class="description">level index in the map file (starting from 0)</p>
+            </dd>
+            <dt>.map_checksum<span class="access"> (read-only)</span> <span class="version">20150619</span></dt>
+            <dd>
+              <p class="description">checksum of map file</p>
+            </dd>
+            <dt>.rebellion<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether level is rebellion</p>
+            </dd>
+            <dt>.repair<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">whether level has repair flag set</p>
+            </dd>
+            <dt>.rescue<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">whether level has rescue flag set</p>
+            </dd>
+            <dt>.retrieval<span class="access"> (read-only)</span> <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">whether level has retrieval flag set</p>
+            </dd>
+            <dt>.stash[key] <span class="version">20200830</span></dt>
+            <dd>
+              <p class="description">reads/writes values to a stash shared between all running Lua scripts</p>
+              <p class="note">keys/values must be strings </p>
+            </dd>
+            <dt>.vacuum<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether level is vacuum</p>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+      <h3><a name="Lights"></a>Lights</h3>
+      <dl>
+        <dt># Lights</dt>
+        <dd>
+          <p class="description">number of lights in level</p>
+        </dd>
+        <dt>Lights()</dt>
+        <dd>
+          <p class="description">iterates through all lights in the level</p>
+        </dd>
+        <dt>Lights.new( [light_preset])</dt>
+        <dd>
+          <p class="description">returns a new light</p>
+        </dd>
+        <dt>Lights[index]</dt>
+        <dd>
+          <dl>
       <dt>.active</dt>
-<dd><p class="description">whether light is active</p></dd>
-      <dt>.tag <span class="version">20100118</span>
-</dt>
-<dd><p class="description">tag of light</p></dd>
-      <dt>.initial_phase <span class="version">20100118</span>
-</dt>
-<dd><p class="description">phase the light starts with</p></dd>
-      <dt>.initially_active <span class="version">20100118</span>
-</dt>
-<dd><p class="description">whether the light was initially active</p></dd>
-      <dt>.intensity<span class="access"> (read-only)</span> <span class="version">20100118</span>
-</dt>
-<dd><p class="description">current intensity for this light (range: 0-1)</p></dd>
+            <dd>
+              <p class="description">whether light is active</p>
+            </dd>
+      <dt>.tag <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">tag of light</p>
+            </dd>
+      <dt>.initial_phase <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">phase the light starts with</p>
+            </dd>
+      <dt>.initially_active <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">whether the light was initially active</p>
+            </dd>
+      <dt>.intensity<span class="access"> (read-only)</span> <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">current intensity for this light (range: 0-1)</p>
+            </dd>
       <dt>
     .states[light_type]</dt>
-<dd><dl>
-<dt>.delta_intensity <span class="version">20100118</span>
-</dt>
-<dd><p class="description">random intensity change for this state</p></dd>
-<dt>.delta_period <span class="version">20100118</span>
-</dt>
-<dd><p class="description">random period change for this state</p></dd>
-<dt>.intensity <span class="version">20100118</span>
-</dt>
-<dd><p class="description">intensity for this state</p></dd>
-<dt>.light_function <span class="version">20100118</span>
-</dt>
-<dd><p class="description">light function for this state</p></dd>
-<dt>.period <span class="version">20100118</span>
-</dt>
-<dd><p class="description">period for this state</p></dd>
-</dl></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Lines"></a>Lines</h3>
-<dl>
-<dt># Lines</dt>
-<dd><p class="description">number of lines in level</p></dd>
-<dt>Lines()</dt>
-<dd><p class="description">iterates through all lines in the level</p></dd>
-<dt>Lines[index]</dt>
-<dd><dl>
-      <dt>.clockwise_polygon<span class="access"> (read-only)</span><br>.cw_polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon on clockwise side of line</p></dd>
-      <dt>.clockwise_side<span class="access"> (read-only)</span><br>.cw_side<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">clockwise side of line</p></dd>
-      <dt>.counterclockwise_polygon<span class="access"> (read-only)</span><br>.ccw_polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon on counterclockwise side of line</p></dd>
-      <dt>.counterclockwise_side<span class="access"> (read-only)</span><br>.ccw_side<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">counterclockwise side of line</p></dd>
-	  <dt>.decorative <span class="version">20210408</span>
-</dt>
-<dd><p class="description">projectiles always pass the transparent sides of decorative lines</p></dd>
+            <dd>
+              <dl>
+                <dt>.delta_intensity <span class="version">20100118</span></dt>
+                <dd>
+                  <p class="description">random intensity change for this state</p>
+                </dd>
+                <dt>.delta_period <span class="version">20100118</span></dt>
+                <dd>
+                  <p class="description">random period change for this state</p>
+                </dd>
+                <dt>.intensity <span class="version">20100118</span></dt>
+                <dd>
+                  <p class="description">intensity for this state</p>
+                </dd>
+                <dt>.light_function <span class="version">20100118</span></dt>
+                <dd>
+                  <p class="description">light function for this state</p>
+                </dd>
+                <dt>.period <span class="version">20100118</span></dt>
+                <dd>
+                  <p class="description">period for this state</p>
+                </dd>
+              </dl>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Lines"></a>Lines</h3>
+      <dl>
+        <dt># Lines</dt>
+        <dd>
+          <p class="description">number of lines in level</p>
+        </dd>
+        <dt>Lines()</dt>
+        <dd>
+          <p class="description">iterates through all lines in the level</p>
+        </dd>
+        <dt>Lines[index]</dt>
+        <dd>
+          <dl>
+      <dt>.clockwise_polygon<span class="access"> (read-only)</span><br>.cw_polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon on clockwise side of line</p>
+            </dd>
+      <dt>.clockwise_side<span class="access"> (read-only)</span><br>.cw_side<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">clockwise side of line</p>
+            </dd>
+      <dt>.counterclockwise_polygon<span class="access"> (read-only)</span><br>.ccw_polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon on counterclockwise side of line</p>
+            </dd>
+      <dt>.counterclockwise_side<span class="access"> (read-only)</span><br>.ccw_side<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">counterclockwise side of line</p>
+            </dd>
+	  <dt>.decorative <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">projectiles always pass the transparent sides of decorative lines</p>
+            </dd>
       <dt>
     .endpoints[n]</dt>
-<dd><p class="description">returns line endpoint n</p></dd>
-      <dt>.has_transparent_side<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">whether one of the line’s sides has a transparent texture</p></dd>
-      <dt>.highest_adjacent_floor<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">height of higher adjacent polygon floor</p></dd>
-      <dt>.length<span class="access"> (read-only)</span>
-</dt>
-<dd>
-<p class="description">the length of this line</p>
-<p class="note">this might not be accurate, if someone used Chisel’s stretch plugin </p>
-</dd>
-      <dt>.lowest_adjacent_ceiling<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">height of lower adjacent polygon ceiling</p></dd>
-      <dt>.solid<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">whether line is solid</p></dd>
-      <dt>.visible_on_automap <span class="version">20150619</span>
-</dt>
-<dd><p class="description">whether line is revealed on local player’s automap</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Media"></a>Media</h3>
-<dl>
-<dt># Media</dt>
-<dd><p class="description">number of media (liquids) on the level</p></dd>
-<dt>Media()</dt>
-<dd><p class="description">iterates through all media on the level</p></dd>
-<dt>Media.new() <span class="version">20210408</span>
-</dt>
-<dd><p class="description">returns a new liquid</p></dd>
-<dt>Media[index]</dt>
-<dd><dl>
-      <dt>.direction <span class="version">20100118</span>
-</dt>
-<dd><p class="description">direction of media</p></dd>
-      <dt>.height<span class="access"> (read-only)</span> <span class="version">20100118</span>
-</dt>
-<dd><p class="description">height of media</p></dd>
-      <dt>.high <span class="version">20100118</span>
-</dt>
-<dd><p class="description">high tide of media</p></dd>
-      <dt>.light <span class="version">20100118</span>
-</dt>
-<dd><p class="description">light that controls this media’s tide</p></dd>
-      <dt>.low <span class="version">20100118</span>
-</dt>
-<dd><p class="description">low tide of media</p></dd>
-      <dt>.speed <span class="version">20100118</span>
-</dt>
-<dd><p class="description">speed of media</p></dd>
-      <dt>.type<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of media</p></dd>
-      <dt>.type <span class="version">20100118</span>
-</dt>
-<dd><p class="description">type of media</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="MonsterStarts"></a>MonsterStarts</h3>
-<dl>
-<dt># MonsterStarts</dt>
-<dd><p class="description">number of map objects in the level</p></dd>
-<dt>MonsterStarts()</dt>
-<dd><p class="description">iterates through all monster starting locations in the level</p></dd>
-<dt>MonsterStarts[index]</dt>
-<dd><dl>
-      <dt>.blind<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether monster is activated by sight</p></dd>
-      <dt>.deaf<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether monster is activated by sound</p></dd>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">direction monster is initially facing</p></dd>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether monster location z is from ceiling</p></dd>
-      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether monster will teleport in when activated</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">monster starting location polygon</p></dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">type of monster</p></dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description"></p>
-<p class="note">from floor or ceiling </p>
-</dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Monsters"></a>Monsters</h3>
-<dl>
-<dt># Monsters</dt>
-<dd><p class="description">maximum number of monsters</p></dd>
-<dt>Monsters()</dt>
-<dd><p class="description">iterates through all valid monsters (including player monsters)</p></dd>
-<dt>Monsters.new(x, y, height, polygon, type)</dt>
-<dd><p class="description">returns a new monster</p></dd>
-<dt>Monsters[index]</dt>
-<dd><dl>
-      <dt>:accelerate(direction, velocity, vertical_velocity) <span class="version">20081213</span>
-</dt>
-<dd><p class="description">accelerates monster</p></dd>
-      <dt>.action<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">current AI action of the monster</p></dd>
+            <dd>
+              <p class="description">returns line endpoint n</p>
+            </dd>
+      <dt>.has_transparent_side<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">whether one of the line’s sides has a transparent texture</p>
+            </dd>
+      <dt>.highest_adjacent_floor<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">height of higher adjacent polygon floor</p>
+            </dd>
+      <dt>.length<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">the length of this line</p>
+              <p class="note">this might not be accurate, if someone used Chisel’s stretch plugin </p>
+            </dd>
+      <dt>.lowest_adjacent_ceiling<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">height of lower adjacent polygon ceiling</p>
+            </dd>
+      <dt>.solid<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">whether line is solid</p>
+            </dd>
+      <dt>.visible_on_automap <span class="version">20150619</span></dt>
+            <dd>
+              <p class="description">whether line is revealed on local player’s automap</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Media"></a>Media</h3>
+      <dl>
+        <dt># Media</dt>
+        <dd>
+          <p class="description">number of media (liquids) on the level</p>
+        </dd>
+        <dt>Media()</dt>
+        <dd>
+          <p class="description">iterates through all media on the level</p>
+        </dd>
+        <dt>Media.new() <span class="version">20210408</span></dt>
+        <dd>
+          <p class="description">returns a new liquid</p>
+        </dd>
+        <dt>Media[index]</dt>
+        <dd>
+          <dl>
+      <dt>.direction <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">direction of media</p>
+            </dd>
+      <dt>.height<span class="access"> (read-only)</span> <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">height of media</p>
+            </dd>
+      <dt>.high <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">high tide of media</p>
+            </dd>
+      <dt>.light <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">light that controls this media’s tide</p>
+            </dd>
+      <dt>.low <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">low tide of media</p>
+            </dd>
+      <dt>.speed <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">speed of media</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">type of media</p>
+            </dd>
+      <dt>.type <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">type of media</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Monsters"></a>Monsters</h3>
+      <dl>
+        <dt># Monsters</dt>
+        <dd>
+          <p class="description">maximum number of monsters</p>
+        </dd>
+        <dt>Monsters()</dt>
+        <dd>
+          <p class="description">iterates through all valid monsters (including player monsters)</p>
+        </dd>
+        <dt>Monsters.new(x, y, height, polygon, type)</dt>
+        <dd>
+          <p class="description">returns a new monster</p>
+        </dd>
+        <dt>Monsters[index]</dt>
+        <dd>
+          <dl>
+      <dt>:accelerate(direction, velocity, vertical_velocity) <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">accelerates monster</p>
+            </dd>
+      <dt>.action<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">current AI action of the monster</p>
+            </dd>
       <dt>.active</dt>
-<dd><p class="description">whether monster has been activated</p></dd>
+            <dd>
+              <p class="description">whether monster has been activated</p>
+            </dd>
       <dt>:attack(target)</dt>
-<dd><p class="description">instructs monster to attack target</p></dd>
-	  <dt>.blind <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">monster is blind</p>
-<p class="note">only valid before monster activates </p>
-</dd>
+            <dd>
+              <p class="description">instructs monster to attack target</p>
+            </dd>
+	  <dt>.blind <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">monster is blind</p>
+              <p class="note">only valid before monster activates </p>
+            </dd>
       <dt>:damage(amount [, type])</dt>
-<dd>
-<p class="description">damages monster</p>
-<p class="note">if no type is specified, fist damage is dealt </p>
-</dd>
-	  <dt>.deaf <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">monster is deaf</p>
-<p class="note">only valid before monster activates </p>
-</dd>
-	  <dt>:delete() <span class="version">20210408</span>
-</dt>
-<dd><p class="description">deletes monster</p></dd>
-      <dt>.external_velocity <span class="version">20090909</span>
-</dt>
-<dd><p class="description">monster’s current external velocity (always in the opposite direction of facing)</p></dd>
+            <dd>
+              <p class="description">damages monster</p>
+              <p class="note">if no type is specified, fist damage is dealt </p>
+            </dd>
+	  <dt>.deaf <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">monster is deaf</p>
+              <p class="note">only valid before monster activates </p>
+            </dd>
+	  <dt>:delete() <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">deletes monster</p>
+            </dd>
+      <dt>.external_velocity <span class="version">20090909</span></dt>
+            <dd>
+              <p class="description">monster’s current external velocity (always in the opposite direction of facing)</p>
+            </dd>
       <dt>.facing<br>.yaw</dt>
-<dd><p class="description">direction the monster is facing</p></dd>
+            <dd>
+              <p class="description">direction the monster is facing</p>
+            </dd>
       <dt>.life<br>.vitality</dt>
-<dd>
-<p class="description">the monster’s vitality</p>
-<p class="note">monsters that haven’t spawned or teleported in yet don’t have vitality </p>
-</dd>
-      <dt>.mode<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">current AI mode of the monster</p></dd>
+            <dd>
+              <p class="description">the monster’s vitality</p>
+              <p class="note">monsters that haven’t spawned or teleported in yet don’t have vitality </p>
+            </dd>
+      <dt>.mode<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">current AI mode of the monster</p>
+            </dd>
       <dt>:move_by_path(polygon)</dt>
-<dd>
-<p class="description">instructs monster to move to polygon</p>
-<p class="note">monsters get distracted easily en route </p>
-<p class="note">once it gets there, it probably won’t choose to stay </p>
-</dd>
-      <dt>.player<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">if monster is a player monster, the player; otherwise, nil</p></dd>
+            <dd>
+              <p class="description">instructs monster to move to polygon</p>
+              <p class="note">monsters get distracted easily en route </p>
+              <p class="note">once it gets there, it probably won’t choose to stay </p>
+            </dd>
+      <dt>.player<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">if monster is a player monster, the player; otherwise, nil</p>
+            </dd>
       <dt>:play_sound(sound)</dt>
-<dd><p class="description">plays sound coming from this monster</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon this monster is in</p></dd>
+            <dd>
+              <p class="description">plays sound coming from this monster</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon this monster is in</p>
+            </dd>
       <dt>:position(x, y, z, polygon)</dt>
-<dd><p class="description">sets position of monster</p></dd>
-	  <dt>.teleports_out <span class="version">20210408</span>
-</dt>
-<dd><p class="description">monster teleports out when deactivated</p></dd>
-      <dt>.type<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of monster</p></dd>
-      <dt>.valid<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether monster is still valid</p></dd>
-      <dt>.vertical_velocity <span class="version">20090909</span>
-</dt>
-<dd><p class="description">monster’s current vertical external velocity</p></dd>
+            <dd>
+              <p class="description">sets position of monster</p>
+            </dd>
+	  <dt>.teleports_out <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">monster teleports out when deactivated</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">type of monster</p>
+            </dd>
+      <dt>.valid<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether monster is still valid</p>
+            </dd>
+      <dt>.vertical_velocity <span class="version">20090909</span></dt>
+            <dd>
+              <p class="description">monster’s current vertical external velocity</p>
+            </dd>
       <dt>.visible</dt>
-<dd>
-<p class="description">whether monster is visible (e.g. has teleported in)</p>
-<p class="note">this has nothing to do with whether monsters are cloaked (like invisible S’pht) or not </p>
-<p class="note">only writable before the monster is activated </p>
-</dd>
-      <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Music"></a>Music</h3>
-<dl>
-<dt># Music</dt>
-<dd><p class="description">maximum number of music channels active simultaneously</p></dd>
-<dt>Music()</dt>
-<dd><p class="description">iterates through all the music channels</p></dd>
-<dt>Music.new(track [, volume] [, loop]) <span class="version">20231125</span>
-</dt>
-<dd>
-<p class="description">returns a new music channel</p>
-<p class="note">volume is decimal [0 - 1] and is 1 if not specified </p>
-<p class="note">loop is enabled by default </p>
-</dd>
-<dt>Music.clear()</dt>
-<dd><p class="description">clears the level playlist</p></dd>
-<dt>Music.fade(duration)</dt>
-<dd><p class="description">fades out the currently playing track and clears the playlist</p></dd>
-<dt>Music.play(track1 [, track2] [, ...])</dt>
-<dd><p class="description">appends all of the specified tracks to the end of the playlist</p></dd>
-<dt>Music.stop()</dt>
-<dd><p class="description">stops level music and clears the playlist</p></dd>
-<dt>Music.valid(track1 [, track2] [, ...])</dt>
-<dd><p class="description">for every track passed, return true if it exists and is playable and false otherwise</p></dd>
-<dt>Music[index]</dt>
-<dd><dl>
-	  <dt>:play() <span class="version">20231125</span>
-</dt>
-<dd>
-<p class="description">plays the music</p>
-<p class="note">if the music was stopped, restarts it </p>
-</dd>
-	  <dt>:stop() <span class="version">20231125</span>
-</dt>
-<dd><p class="description">stops the music</p></dd>
-	  <dt>:fade(volume [, duration] [, stop_after_fade]) <span class="version">20231125</span>
-</dt>
-<dd>
-<p class="description">fades the music</p>
-<p class="note">it will fade in until volume is reached. volume is decimal [0 - 1] </p>
-<p class="note">duration unit is seconds and is 1 if not specified </p>
-<p class="note">stop_after_fade is disabled by default, if set to true if the volume reaches 0 while fading the music will automatically stop </p>
-</dd>
-	  <dt>.volume <span class="version">20231125</span>
-</dt>
-<dd>
-<p class="description">the volume of the music</p>
-<p class="note">volume is decimal [0 - 1] </p>
-</dd>
-	  <dt>.active<span class="access"> (read-only)</span> <span class="version">20231125</span>
-</dt>
-<dd><p class="description">returns true if the music is still playing</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Platforms"></a>Platforms</h3>
-<dl>
-<dt># Platforms</dt>
-<dd><p class="description">number of platforms on the level</p></dd>
-<dt>Platforms()</dt>
-<dd><p class="description">iterates through all platforms in the level</p></dd>
-<dt>Platforms[index]</dt>
-<dd><dl>
-	  <dt>.activates_adjacent_platforms_at_each_level <span class="version">20210408</span>
-</dt>
-<dd><p class="description">platform will activate adjacent platforms at each elevation it comes to (ie.,at floor level and ceiling level)</p></dd>
-	  <dt>.activates_adjacent_platforms_when_activating <span class="version">20210408</span>
-</dt>
-<dd><p class="description">when activating, this platform activates adjacent platforms</p></dd>
-	   <dt>.activates_adjacent_platforms_when_deactivating <span class="version">20210408</span>
-</dt>
-<dd><p class="description">when deactivating, this platform activates adjacent platforms</p></dd>
-	  <dt>.activates_light <span class="version">20210408</span>
-</dt>
-<dd><p class="description">activates floor and ceiling lightsources while activating</p></dd>
-	  <dt>.activates_only_once <span class="version">20210408</span>
-</dt>
-<dd><p class="description">cannot be activated a second time</p></dd>
+            <dd>
+              <p class="description">whether monster is visible (e.g. has teleported in)</p>
+              <p class="note">this has nothing to do with whether monsters are cloaked (like invisible S’pht) or not </p>
+              <p class="note">only writable before the monster is activated </p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="MonsterStarts"></a>MonsterStarts</h3>
+      <dl>
+        <dt># MonsterStarts</dt>
+        <dd>
+          <p class="description">number of map objects in the level</p>
+        </dd>
+        <dt>MonsterStarts()</dt>
+        <dd>
+          <p class="description">iterates through all monster starting locations in the level</p>
+        </dd>
+        <dt>MonsterStarts[index]</dt>
+        <dd>
+          <dl>
+      <dt>.blind<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether monster is activated by sight</p>
+            </dd>
+      <dt>.deaf<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether monster is activated by sound</p>
+            </dd>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">direction monster is initially facing</p>
+            </dd>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether monster location z is from ceiling</p>
+            </dd>
+      <dt>.invisible<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether monster will teleport in when activated</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">monster starting location polygon</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">type of monster</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+              <p class="note">from floor or ceiling </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Music"></a>Music</h3>
+      <dl>
+        <dt># Music</dt>
+        <dd>
+          <p class="description">maximum number of music channels active simultaneously</p>
+        </dd>
+        <dt>Music()</dt>
+        <dd>
+          <p class="description">iterates through all the music channels</p>
+        </dd>
+        <dt>Music.new( [track] [, volume] [, loop]) <span class="version">20231125</span></dt>
+        <dd>
+          <p class="description">returns a new music channel</p>
+          <p class="note">the track file parameter should be omitted for segmented music and add_track should be used instead </p>
+          <p class="note">volume is decimal [0 - 1] and is 1 if not specified </p>
+          <p class="note">loop is enabled by default </p>
+        </dd>
+        <dt>Music.clear()</dt>
+        <dd>
+          <p class="description">clears the level playlist</p>
+        </dd>
+        <dt>Music.fade(duration [, fade_type])</dt>
+        <dd>
+          <p class="description">fades out the currently playing track and clears the playlist</p>
+          <p class="note">fade_type is the fading function, see MusicFadeTypes for values, default is linear </p>
+        </dd>
+        <dt>Music.play(track1 [, track2] [, ...])</dt>
+        <dd>
+          <p class="description">appends all of the specified tracks to the end of the playlist</p>
+        </dd>
+        <dt>Music.stop()</dt>
+        <dd>
+          <p class="description">stops level music and clears the playlist</p>
+        </dd>
+        <dt>Music.valid(track1 [, track2] [, ...])</dt>
+        <dd>
+          <p class="description">for every track passed, return true if it exists and is playable and false otherwise</p>
+        </dd>
+        <dt>Music[index]</dt>
+        <dd>
+          <dl>
+	  <dt>:play( [segment]) <span class="version">20231125</span></dt>
+            <dd>
+              <p class="description">plays the music</p>
+              <p class="note">for tracks containing multiple segments, an optional starting segment can be provided </p>
+              <p class="note">if the music was stopped, restarts it </p>
+            </dd>
+	  <dt>:stop() <span class="version">20231125</span></dt>
+            <dd>
+              <p class="description">stops the music</p>
+            </dd>
+	  <dt>:fade(volume [, duration] [, stop_after_fade] [, fade_type]) <span class="version">20231125</span></dt>
+            <dd>
+              <p class="description">fades the music</p>
+              <p class="note">it will fade in until volume is reached. volume is decimal [0 - 1] </p>
+              <p class="note">duration unit is seconds and is 1 if not specified </p>
+              <p class="note">stop_after_fade is disabled by default, if set to true if the volume reaches 0 while fading the music will automatically stop </p>
+              <p class="note">fade_type is the fading function, see MusicFadeTypes for values, default is linear </p>
+            </dd>
+	  <dt>:add_track(track) <span class="version">git</span></dt>
+            <dd>
+              <p class="description">adds an audio track used to create music segments</p>
+              <p class="note">returns a unique identifier for the track, usable to create segments </p>
+            </dd>
+	  <dt>:request_sequence_transition(sequence) <span class="version">git</span></dt>
+            <dd>
+              <p class="description">requests a transition from the currently playing sequence to the specified one</p>
+              <p class="note">the transition will happen at the end of the currently playing segment and as long as a segment transition is configured between it and one from the requested sequence </p>
+            </dd>
+	  <dt>.volume <span class="version">20231125</span></dt>
+            <dd>
+              <p class="description">the volume of the music</p>
+              <p class="note">volume is decimal [0 - 1] </p>
+            </dd>
+	  <dt>.active<span class="access"> (read-only)</span> <span class="version">20231125</span></dt>
+            <dd>
+              <p class="description">returns true if the music is still playing</p>
+            </dd>
+	  <dt>.sequences <span class="version">git</span></dt>
+            <dd>
+              <dl>
+                <dt>:new()</dt>
+                <dd>
+                  <p class="description">creates a new empty sequence for the music channel and returns it</p>
+                  <p class="note">sequences can be seen as a set of segments configured to play in a specific order composing a track </p>
+                  <p class="note">sequences must be created and configured before the music channel starts playing otherwise they  will not be applied unless the music is stopped and restarted </p>
+                </dd>
+                <dt>.segments</dt>
+                <dd>
+                  <dl>
+                    <dt>:new(track_identifier)</dt>
+                    <dd>
+                      <p class="description">creates a new music segment with the specified track, adds it to the sequence and returns it</p>
+                      <p class="note">track_identifier is the unique identifier returned by the music add_track function </p>
+                      <p class="note">this function can be called multiple times with the same track identifier if multiple segments from the same track file are required </p>
+                      <p class="note">the order in which segments are created has no influence on the order in which they are played, see the add_transition function for that </p>
+                    </dd>
+                    <dt>:add_transition(segment [, fade_out_type] [, fade_out_duration] [, fade_in_type] [, fade_in_duration] [, cross_fade])</dt>
+                    <dd>
+                      <p class="description">specifies the next segment to play once the current one has finished and configures the transition</p>
+                      <p class="note">see MusicFadeTypes for the available fading functions, the default is none which means a seamless transition </p>
+                      <p class="note">the fades duration unit is seconds and is 0 if not specified </p>
+                      <p class="note">cross_fade is a boolean flag set to false if not specified </p>
+                      <p class="note">segment transitions across different sequences must also be configured to allow sequence transitions </p>
+                      <p class="note">the entire segment ordering system is handled through this function, if a full track must loop, the last segment of a sequence must transition to the first one of the same sequence </p>
+                      <p class="note">transition configuration must be completed before the music channel starts playing otherwise it will not be applied unless the music is stopped and restarted </p>
+                    </dd>
+                  </dl>
+                </dd>
+              </dl>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Platforms"></a>Platforms</h3>
+      <dl>
+        <dt># Platforms</dt>
+        <dd>
+          <p class="description">number of platforms on the level</p>
+        </dd>
+        <dt>Platforms()</dt>
+        <dd>
+          <p class="description">iterates through all platforms in the level</p>
+        </dd>
+        <dt>Platforms[index]</dt>
+        <dd>
+          <dl>
+	  <dt>.activates_adjacent_platforms_at_each_level <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">platform will activate adjacent platforms at each elevation it comes to (ie.,at floor level and ceiling level)</p>
+            </dd>
+	  <dt>.activates_adjacent_platforms_when_activating <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">when activating, this platform activates adjacent platforms</p>
+            </dd>
+	   <dt>.activates_adjacent_platforms_when_deactivating <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">when deactivating, this platform activates adjacent platforms</p>
+            </dd>
+	  <dt>.activates_light <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">activates floor and ceiling lightsources while activating</p>
+            </dd>
+	  <dt>.activates_only_once <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">cannot be activated a second time</p>
+            </dd>
       <dt>.active</dt>
-<dd><p class="description">whether platform is currently active</p></dd>
-	  <dt>.cannot_be_externally_deactivated <span class="version">20210408</span>
-</dt>
-<dd><p class="description">when active, can only be deactivated by itself</p></dd>
+            <dd>
+              <p class="description">whether platform is currently active</p>
+            </dd>
+	  <dt>.cannot_be_externally_deactivated <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">when active, can only be deactivated by itself</p>
+            </dd>
       <dt>.ceiling_height</dt>
-<dd><p class="description">current ceiling height of platform</p></dd>
-	  <dt>.comes_from_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">platform lowers from ceiling</p></dd>
-	  <dt>.comes_from_floor<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">platform rises from floor</p></dd>
+            <dd>
+              <p class="description">current ceiling height of platform</p>
+            </dd>
+	  <dt>.comes_from_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">platform lowers from ceiling</p>
+            </dd>
+	  <dt>.comes_from_floor<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">platform rises from floor</p>
+            </dd>
       <dt>.contracting</dt>
-<dd><p class="description">direction platform is moving or will move when active</p></dd>
-	  <dt>.contracts_slower <span class="version">20210408</span>
-</dt>
-<dd><p class="description">will move slower when contracting than when extending</p></dd>
-	  <dt>.deactivates_adjacent_platforms_when_activating <span class="version">20210408</span>
-</dt>
-<dd><p class="description">when activating, this platform deactivates adjacent platforms</p></dd>
-	  <dt>.deactivates_adjacent_platforms_when_deactivating <span class="version">20210408</span>
-</dt>
-<dd><p class="description">when deactivating, this platform deactivates adjacent platforms</p></dd>
-	  <dt>.deactivates_at_each_level <span class="version">20210408</span>
-</dt>
-<dd><p class="description">this platform will deactivate each time it reaches a discrete level</p></dd>
-	  <dt>.deactivates_at_initial_level <span class="version">20210408</span>
-</dt>
-<dd><p class="description">this platform will deactivate upon returning to its initial position</p></dd>
-	  <dt>.deactivates_light <span class="version">20210408</span>
-</dt>
-<dd><p class="description">deactivates floor and ceiling lightsources while deactivating</p></dd>
-	  <dt>.delays_before_activation <span class="version">20210408</span>
-</dt>
-<dd><p class="description">whether or not the platform begins with the maximum delay before moving</p></dd>
-	  <dt>.does_not_activate_parent <span class="version">20210408</span>
-</dt>
-<dd><p class="description">does not reactive its parent (the platform which activated it)</p></dd>
-      <dt>.door <span class="version">20100118</span>
-</dt>
-<dd><p class="description">platform is a door</p></dd>
+            <dd>
+              <p class="description">direction platform is moving or will move when active</p>
+            </dd>
+	  <dt>.contracts_slower <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">will move slower when contracting than when extending</p>
+            </dd>
+	  <dt>.deactivates_adjacent_platforms_when_activating <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">when activating, this platform deactivates adjacent platforms</p>
+            </dd>
+	  <dt>.deactivates_adjacent_platforms_when_deactivating <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">when deactivating, this platform deactivates adjacent platforms</p>
+            </dd>
+	  <dt>.deactivates_at_each_level <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">this platform will deactivate each time it reaches a discrete level</p>
+            </dd>
+	  <dt>.deactivates_at_initial_level <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">this platform will deactivate upon returning to its initial position</p>
+            </dd>
+	  <dt>.deactivates_light <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">deactivates floor and ceiling lightsources while deactivating</p>
+            </dd>
+	  <dt>.delays_before_activation <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">whether or not the platform begins with the maximum delay before moving</p>
+            </dd>
+	  <dt>.does_not_activate_parent <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">does not reactive its parent (the platform which activated it)</p>
+            </dd>
+      <dt>.door <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">platform is a door</p>
+            </dd>
       <dt>.extending</dt>
-<dd><p class="description">direction platform is moving or will move when active</p></dd>
-	  <dt>.extends_floor_to_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">there is no empty space when the platform is fully extended</p></dd>
+            <dd>
+              <p class="description">direction platform is moving or will move when active</p>
+            </dd>
+	  <dt>.extends_floor_to_ceiling<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">there is no empty space when the platform is fully extended</p>
+            </dd>
       <dt>.floor_height</dt>
-<dd><p class="description">current floor height of platform</p></dd>
-	  <dt>.initially_active<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">otherwise inactive</p></dd>
-	  <dt>.has_been_activated <span class="version">20210408</span>
-</dt>
-<dd><p class="description">in case platform can only be activated once</p></dd>
-	  <dt>.initially_extended<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">high for floor platforms, low for ceiling platforms, closed for two-way platforms</p></dd>
-      <dt>.locked <span class="version">20100118</span>
-</dt>
-<dd>
-<p class="description">platform is locked</p>
-<p class="note">this flag doesn’t actually do anything </p>
-</dd>
-      <dt>.maximum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
-</dt>
-<dd><p class="description">greatest height a platform's ceiling can ever rise</p></dd>
-      <dt>.maximum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
-</dt>
-<dd><p class="description">greatest height a platform's floor can ever rise</p></dd>
-      <dt>.minimum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
-</dt>
-<dd><p class="description">least height a platform's ceiling must rise</p></dd>
-      <dt>.minimum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span>
-</dt>
-<dd><p class="description">least height a platform's floor must rise</p></dd>
+            <dd>
+              <p class="description">current floor height of platform</p>
+            </dd>
+	  <dt>.initially_active<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">otherwise inactive</p>
+            </dd>
+	  <dt>.has_been_activated <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">in case platform can only be activated once</p>
+            </dd>
+	  <dt>.initially_extended<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">high for floor platforms, low for ceiling platforms, closed for two-way platforms</p>
+            </dd>
+      <dt>.locked <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">platform is locked</p>
+              <p class="note">this flag doesn’t actually do anything </p>
+            </dd>
+      <dt>.maximum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">greatest height a platform's ceiling can ever rise</p>
+            </dd>
+      <dt>.maximum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">greatest height a platform's floor can ever rise</p>
+            </dd>
+      <dt>.minimum_ceiling_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">least height a platform's ceiling must rise</p>
+            </dd>
+      <dt>.minimum_floor_height<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">least height a platform's floor must rise</p>
+            </dd>
       <dt>.monster_controllable</dt>
-<dd><p class="description">whether platform can be controlled by monsters</p></dd>
+            <dd>
+              <p class="description">whether platform can be controlled by monsters</p>
+            </dd>
       <dt>.player_controllable</dt>
-<dd><p class="description">whether platform can be controlled by players</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon of this platform</p></dd>
-	  <dt>.reverses_direction_when_obstructed <span class="version">20210408</span>
-</dt>
-<dd><p class="description">platform reverses direction when obstructed</p></dd>
-      <dt>.secret <span class="version">20100118</span>
-</dt>
-<dd>
-<p class="description">platform is secret</p>
-<p class="note">secret platforms aren’t shown on the overhead map </p>
-</dd>
+            <dd>
+              <p class="description">whether platform can be controlled by players</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon of this platform</p>
+            </dd>
+	  <dt>.reverses_direction_when_obstructed <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">platform reverses direction when obstructed</p>
+            </dd>
+      <dt>.secret <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">platform is secret</p>
+              <p class="note">secret platforms aren’t shown on the overhead map </p>
+            </dd>
       <dt>.speed</dt>
-<dd><p class="description">platform speed</p></dd>
-	  <dt>.tag <span class="version">20221126</span>
-</dt>
-<dd><p class="description">tag of platform</p></dd>
-      <dt>.type <span class="version">20100118</span>
-</dt>
-<dd>
-<p class="description">type of this platform</p>
-<p class="note">the only thing the engine uses type for is the platform’s sound </p>
-</dd>
-	  <dt>.uses_native_polygon_heights<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">uses native polygon heights during automatic min,max calculation</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="PlayerStarts"></a>PlayerStarts</h3>
-<dl>
-<dt># PlayerStarts</dt>
-<dd><p class="description">number of map objects in the level</p></dd>
-<dt>PlayerStarts()</dt>
-<dd><p class="description">iterates through all player starting locations in the level</p></dd>
-<dt>PlayerStarts[index]</dt>
-<dd><dl>
-      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">player starting location facing</p></dd>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether player starting location z is from ceiling</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">polygon player starting location is in</p></dd>
-      <dt>.team<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">which team starts at this player starting location</p></dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description"></p>
-<p class="note">from floor or ceiling </p>
-</dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Players"></a>Players</h3>
-<dl>
-<dt># Players</dt>
-<dd><p class="description">number of players in the game</p></dd>
-<dt>Players()</dt>
-<dd><p class="description">iterates through all players in the game</p></dd>
-<dt>Players.print(message)</dt>
-<dd><p class="description">prints message to all players’ screens</p></dd>
-<dt>Players.local_player<span class="access"> (read-only)</span> <span class="version">20200830</span>
-</dt>
-<dd>
-<p class="description">the local player</p>
-<p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
-</dd>
-<dt>Players[index]</dt>
-<dd><dl>
+            <dd>
+              <p class="description">platform speed</p>
+            </dd>
+	  <dt>.tag <span class="version">20221126</span></dt>
+            <dd>
+              <p class="description">tag of platform</p>
+            </dd>
+      <dt>.type <span class="version">20100118</span></dt>
+            <dd>
+              <p class="description">type of this platform</p>
+              <p class="note">the only thing the engine uses type for is the platform’s sound </p>
+            </dd>
+	  <dt>.uses_native_polygon_heights<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">uses native polygon heights during automatic min,max calculation</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Players"></a>Players</h3>
+      <dl>
+        <dt># Players</dt>
+        <dd>
+          <p class="description">number of players in the game</p>
+        </dd>
+        <dt>Players()</dt>
+        <dd>
+          <p class="description">iterates through all players in the game</p>
+        </dd>
+        <dt>Players.print(message)</dt>
+        <dd>
+          <p class="description">prints message to all players’ screens</p>
+        </dd>
+        <dt>Players.local_player<span class="access"> (read-only)</span> <span class="version">20200830</span></dt>
+        <dd>
+          <p class="description">the local player</p>
+          <p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
+        </dd>
+        <dt>Players[index]</dt>
+        <dd>
+          <dl>
       <dt>:accelerate(direction, velocity, vertical_velocity)</dt>
-<dd><p class="description">accelerates player</p></dd>
+            <dd>
+              <p class="description">accelerates player</p>
+            </dd>
       <dt>.action_flags</dt>
-<dd>
-<p class="note">only valid when read/written in idle() </p>
-<p class="note">disabled when the player is viewing a terminal </p>
-<p class="note">latched action flags are only true the first tick the key is held down </p>
-<dl>
-<dt>.action_trigger</dt>
-<dd>
-<p class="description">respawns, or activates platforms/doors/control panels</p>
-<p class="note">latched </p>
-</dd>
-<dt>.aux_trigger <span class="version">20231125</span>
-</dt>
-<dd><p class="description">formerly microphone button; now dedicated to Lua scripts</p></dd>
-<dt>.cycle_weapons_backward</dt>
-<dd>
-<p class="description">switches to previous weapon</p>
-<p class="note">latched </p>
-</dd>
-<dt>.cycle_weapons_forward</dt>
-<dd>
-<p class="description">switches to next weapon</p>
-<p class="note">latched </p>
-</dd>
-<dt>.left_trigger</dt>
-<dd><p class="description">fires primary trigger</p></dd>
-<dt>.right_trigger</dt>
-<dd><p class="description">fires secondary trigger</p></dd>
-<dt>.toggle_map</dt>
-<dd>
-<p class="description">toggles the overhead map</p>
-<p class="note">latched </p>
-</dd>
-</dl>
-</dd>
+            <dd>
+              <p class="note">only valid when read/written in idle() </p>
+              <p class="note">disabled when the player is viewing a terminal </p>
+              <p class="note">latched action flags are only true the first tick the key is held down </p>
+              <dl>
+                <dt>.action_trigger</dt>
+                <dd>
+                  <p class="description">respawns, or activates platforms/doors/control panels</p>
+                  <p class="note">latched </p>
+                </dd>
+                <dt>.aux_trigger <span class="version">20231125</span></dt>
+                <dd>
+                  <p class="description">formerly microphone button; now dedicated to Lua scripts</p>
+                </dd>
+                <dt>.cycle_weapons_backward</dt>
+                <dd>
+                  <p class="description">switches to previous weapon</p>
+                  <p class="note">latched </p>
+                </dd>
+                <dt>.cycle_weapons_forward</dt>
+                <dd>
+                  <p class="description">switches to next weapon</p>
+                  <p class="note">latched </p>
+                </dd>
+                <dt>.left_trigger</dt>
+                <dd>
+                  <p class="description">fires primary trigger</p>
+                </dd>
+                <dt>.right_trigger</dt>
+                <dd>
+                  <p class="description">fires secondary trigger</p>
+                </dd>
+                <dt>.toggle_map</dt>
+                <dd>
+                  <p class="description">toggles the overhead map</p>
+                  <p class="note">latched </p>
+                </dd>
+              </dl>
+            </dd>
       <dt>:activate_terminal(terminal)</dt>
-<dd><p class="description">activates terminal</p></dd>
+            <dd>
+              <p class="description">activates terminal</p>
+            </dd>
       <dt>.color</dt>
-<dd><p class="description">color of player (shirt color, if teams are enabled)</p></dd>
+            <dd>
+              <p class="description">color of player (shirt color, if teams are enabled)</p>
+            </dd>
       <dt>.compass</dt>
-<dd><dl>
-<dt>:all_off()</dt>
-<dd><p class="description">turns all compass quadrants off, disables beacon</p></dd>
-<dt>:all_on()</dt>
-<dd><p class="description">turns all compass quadrants on, disables beacon</p></dd>
-<dt>.beacon</dt>
-<dd><p class="description">whether to use the beacon</p></dd>
-<dt>.lua</dt>
-<dd><p class="description">whether Lua is controlling the compass</p></dd>
-<dt>.ne<br>.northeast</dt>
-<dd><p class="description">whether north east compass quadrant is active</p></dd>
-<dt>.nw<br>.northwest</dt>
-<dd><p class="description">whether north west compass quadrant is active</p></dd>
-<dt>.se<br>.southeast</dt>
-<dd><p class="description">whether south east compass quadrant is active</p></dd>
-<dt>.sw<br>.southwest</dt>
-<dd><p class="description">whether south west compass quadrant is active</p></dd>
-<dt>.x</dt>
-<dd><p class="description">beacon location</p></dd>
-<dt>.y</dt>
-<dd><p class="description">beacon location</p></dd>
-</dl></dd>
+            <dd>
+              <dl>
+                <dt>:all_off()</dt>
+                <dd>
+                  <p class="description">turns all compass quadrants off, disables beacon</p>
+                </dd>
+                <dt>:all_on()</dt>
+                <dd>
+                  <p class="description">turns all compass quadrants on, disables beacon</p>
+                </dd>
+                <dt>.beacon</dt>
+                <dd>
+                  <p class="description">whether to use the beacon</p>
+                </dd>
+                <dt>.lua</dt>
+                <dd>
+                  <p class="description">whether Lua is controlling the compass</p>
+                </dd>
+                <dt>.ne<br>.northeast</dt>
+                <dd>
+                  <p class="description">whether north east compass quadrant is active</p>
+                </dd>
+                <dt>.nw<br>.northwest</dt>
+                <dd>
+                  <p class="description">whether north west compass quadrant is active</p>
+                </dd>
+                <dt>.se<br>.southeast</dt>
+                <dd>
+                  <p class="description">whether south east compass quadrant is active</p>
+                </dd>
+                <dt>.sw<br>.southwest</dt>
+                <dd>
+                  <p class="description">whether south west compass quadrant is active</p>
+                </dd>
+                <dt>.x</dt>
+                <dd>
+                  <p class="description">beacon location</p>
+                </dd>
+                <dt>.y</dt>
+                <dd>
+                  <p class="description">beacon location</p>
+                </dd>
+              </dl>
+            </dd>
       <dt>.crosshairs</dt>
-<dd><dl>
-<dt>.active<span class="access"> (local player)</span>
-</dt>
-<dd>
-<p class="description">whether crosshairs are visible</p>
-<p class="note">if you wish to stop the user from toggling the crosshairs, you must set the state every tick </p>
-</dd>
-</dl></dd>
+            <dd>
+              <dl>
+                <dt>.active<span class="access"> (local player)</span></dt>
+                <dd>
+                  <p class="description">whether crosshairs are visible</p>
+                  <p class="note">if you wish to stop the user from toggling the crosshairs, you must set the state every tick </p>
+                </dd>
+              </dl>
+            </dd>
       <dt>:damage(amount [, type])</dt>
-<dd>
-<p class="description">inflicts damage on player</p>
-<ul class="args"><li>type: if unspecified, crush damage is delt</li></ul>
-</dd>
-      <dt>.dead<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether player is dead</p></dd>
+            <dd>
+              <p class="description">inflicts damage on player</p>
+              <ul class="args">
+                <li>type: if unspecified, crush damage is delt</li>
+              </ul>
+            </dd>
+      <dt>.dead<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether player is dead</p>
+            </dd>
       <dt>.deaths</dt>
-<dd><p class="description">deaths not caused by players</p></dd>
+            <dd>
+              <p class="description">deaths not caused by players</p>
+            </dd>
       <dt>.direction<br>.yaw</dt>
-<dd>
-<p class="description">direction player is facing</p>
-<p class="note">this is the direction in which this player will run; for their aim, use .head_direction </p>
-</dd>
+            <dd>
+              <p class="description">direction player is facing</p>
+              <p class="note">this is the direction in which this player will run; for their aim, use .head_direction </p>
+            </dd>
       <dt>.disconnected</dt>
-<dd><p class="description">whether player dropped out of the game</p></dd>
+            <dd>
+              <p class="description">whether player dropped out of the game</p>
+            </dd>
       <dt>.energy<br>.life</dt>
-<dd><p class="description">amount of suit energy player has (150 is normal red health)</p></dd>
+            <dd>
+              <p class="description">amount of suit energy player has (150 is normal red health)</p>
+            </dd>
       <dt>.elevation<br>.pitch</dt>
-<dd><p class="description">angle player is looking up or down</p></dd>
+            <dd>
+              <p class="description">angle player is looking up or down</p>
+            </dd>
       <dt>.external_velocity</dt>
-<dd><dl>
-<dt>.i<br>.x</dt>
-<dd><p class="description"></p></dd>
-<dt>.j<br>.y</dt>
-<dd><p class="description"></p></dd>
-<dt>.k<br>.z</dt>
-<dd><p class="description"></p></dd>
-</dl></dd>
+            <dd>
+              <dl>
+                <dt>.i<br>.x</dt>
+                <dd>
+                  <p class="description">
+                  </p>
+                </dd>
+                <dt>.j<br>.y</dt>
+                <dd>
+                  <p class="description">
+                  </p>
+                </dd>
+                <dt>.k<br>.z</dt>
+                <dd>
+                  <p class="description">
+                  </p>
+                </dd>
+              </dl>
+            </dd>
       <dt>.extravision_duration</dt>
-<dd><p class="description">extravision time remaining</p></dd>
-      <dt>.feet_below_media<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether player is standing in liquid</p></dd>
+            <dd>
+              <p class="description">extravision time remaining</p>
+            </dd>
+      <dt>.feet_below_media<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether player is standing in liquid</p>
+            </dd>
       <dt>:fade_screen(type)</dt>
-<dd><p class="description">fades player’s screen</p></dd>
+            <dd>
+              <p class="description">fades player’s screen</p>
+            </dd>
       <dt>:find_action_key_target()</dt>
-<dd>
-<p class="description">if player is in range of a platform or control panel, returns a platform or side; otherwise returns nil</p>
-<p class="note">you can check the type of the return with is_polygon() and is_side() </p>
-</dd>
+            <dd>
+              <p class="description">if player is in range of a platform or control panel, returns a platform or side; otherwise returns nil</p>
+              <p class="note">you can check the type of the return with is_polygon() and is_side() </p>
+            </dd>
       <dt>:find_target( [penetrate_media] <span class="version">20220115</span>)</dt>
-<dd>
-<p class="description">returns t, x, y, z, polygon, where t is the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the target is the surface of a liquid, and penetrate_media is false) the player is looking at; and x, y, z, and polygon are the point the player is looking at</p>
-<p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
-<p class="note">this function will not work under liquid unless penetrate_media is true </p>
-</dd>
-	  <dt>.has_map_open<span class="access"> (read-only)</span> <span class="version">20220115</span>
-</dt>
-<dd><p class="description">whether player has overhead map open</p></dd>
-      <dt>.head_below_media<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether player is completely below liquid</p></dd>
-      <dt>.head_direction <span class="version">20200830</span>
-</dt>
-<dd>
-<p class="description">direction in which player is looking</p>
-<p class="note">while glancing, this differs from .direction </p>
-</dd>
-	  <dt>.hotkey <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">pressed hotkey, from 1-12, or 0 for no hotkey</p>
-<p class="note">only valid when read/written in idle() </p>
-<p class="note">hotkeys aren’t latched, and can only be transmitted every 3 ticks </p>
-<p class="note">to check for a continously pressed hotkey, or to implement your own latch, count down from 2 before checking it again </p>
-<p class="note">hotkeys override cycle weapon backward/forward; these flags will be false for 3 ticks after a hotkey is pressed </p>
-</dd>
+            <dd>
+              <p class="description">returns t, x, y, z, polygon, where t is the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the target is the surface of a liquid, and penetrate_media is false) the player is looking at; and x, y, z, and polygon are the point the player is looking at</p>
+              <p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
+              <p class="note">this function will not work under liquid unless penetrate_media is true </p>
+            </dd>
+	  <dt>.has_map_open<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">whether player has overhead map open</p>
+            </dd>
+      <dt>.head_below_media<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether player is completely below liquid</p>
+            </dd>
+      <dt>.head_direction <span class="version">20200830</span></dt>
+            <dd>
+              <p class="description">direction in which player is looking</p>
+              <p class="note">while glancing, this differs from .direction </p>
+            </dd>
+	  <dt>.hotkey <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">pressed hotkey, from 1-12, or 0 for no hotkey</p>
+              <p class="note">only valid when read/written in idle() </p>
+              <p class="note">hotkeys aren’t latched, and can only be transmitted every 3 ticks </p>
+              <p class="note">to check for a continously pressed hotkey, or to implement your own latch, count down from 2 before checking it again </p>
+              <p class="note">hotkeys override cycle weapon backward/forward; these flags will be false for 3 ticks after a hotkey is pressed </p>
+            </dd>
 	  <dt>
-    .hotkey_bindings[n] <span class="version">20210408</span><span class="access"> (local player)</span>
-</dt>
-<dd>
-<p class="description">keys or buttons the player has bound to hotkeys 1-12</p>
-<dl>
-<dt>.joystick<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">joystick button binding</p></dd>
-<dt>.key<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">key binding</p></dd>
-<dt>.mouse<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">mouse button binding</p></dd>
-</dl>
-</dd>
+    .hotkey_bindings[n] <span class="version">20210408</span><span class="access"> (local player)</span></dt>
+            <dd>
+              <p class="description">keys or buttons the player has bound to hotkeys 1-12</p>
+              <dl>
+                <dt>.joystick<span class="access"> (read-only)</span></dt>
+                <dd>
+                  <p class="description">joystick button binding</p>
+                </dd>
+                <dt>.key<span class="access"> (read-only)</span></dt>
+                <dd>
+                  <p class="description">key binding</p>
+                </dd>
+                <dt>.mouse<span class="access"> (read-only)</span></dt>
+                <dd>
+                  <p class="description">mouse button binding</p>
+                </dd>
+              </dl>
+            </dd>
       <dt>.infravision_duration</dt>
-<dd><p class="description">infravision time remaining</p></dd>
+            <dd>
+              <p class="description">infravision time remaining</p>
+            </dd>
       <dt>.internal_velocity</dt>
-<dd><dl>
-<dt>.forward<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">player’s forward velocity</p></dd>
-<dt>.perpendicular<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">player’s perpendicular (sidestep) velocity</p></dd>
-</dl></dd>
+            <dd>
+              <dl>
+                <dt>.forward<span class="access"> (read-only)</span></dt>
+                <dd>
+                  <p class="description">player’s forward velocity</p>
+                </dd>
+                <dt>.perpendicular<span class="access"> (read-only)</span></dt>
+                <dd>
+                  <p class="description">player’s perpendicular (sidestep) velocity</p>
+                </dd>
+              </dl>
+            </dd>
       <dt>.invincibility_duration</dt>
-<dd><p class="description">invincibility time remaining</p></dd>
+            <dd>
+              <p class="description">invincibility time remaining</p>
+            </dd>
       <dt>.invisibility_duration</dt>
-<dd>
-<p class="description">invisibility time remaining</p>
-<p class="note">player will become subtly invisible if this is set higher than the standard invisibility duration (70 seconds) </p>
-</dd>
+            <dd>
+              <p class="description">invisibility time remaining</p>
+              <p class="note">player will become subtly invisible if this is set higher than the standard invisibility duration (70 seconds) </p>
+            </dd>
       <dt>
     .items[item_type]
   </dt>
-<dd><p class="description">how many of item the player is carrying</p></dd>
-      <dt>.local_<span class="access"> (read-only)</span>
-</dt>
-<dd>
-<p class="description">true if this player is the local player</p>
-<p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
-</dd>
+            <dd>
+              <p class="description">how many of item the player is carrying</p>
+            </dd>
+      <dt>.local_<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">true if this player is the local player</p>
+              <p class="note">normally, you shouldn’t need this--you’ll just make the game go out of sync </p>
+            </dd>
       <dt>
     .kills[slain_player]
   </dt>
-<dd><p class="description">kill count against slain_player</p></dd>
-      <dt>.monster<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">monster that corresponds to player</p></dd>
-      <dt>.motion_sensor_active<span class="access"> (local player)</span>
-</dt>
-<dd>
-<p class="description">whether player can view his motion sensor</p>
-<p class="note">currently, this also controls compass visibility </p>
-</dd>
-      <dt>.name<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">player’s name</p></dd>
+            <dd>
+              <p class="description">kill count against slain_player</p>
+            </dd>
+      <dt>.monster<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">monster that corresponds to player</p>
+            </dd>
+      <dt>.motion_sensor_active<span class="access"> (local player)</span></dt>
+            <dd>
+              <p class="description">whether player can view his motion sensor</p>
+              <p class="note">currently, this also controls compass visibility </p>
+            </dd>
+      <dt>.name<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">player’s name</p>
+            </dd>
       <dt>.oxygen</dt>
-<dd><p class="description">amount of oxygen player has (max is 10800)</p></dd>
+            <dd>
+              <p class="description">amount of oxygen player has (max is 10800)</p>
+            </dd>
       <dt>
     .overlays[n]</dt>
-<dd>
-<p class="description">there are 6 overlays, numbered 0 through 5</p>
-<dl>
-<dt>:clear()</dt>
-<dd><p class="description">turns off overlay</p></dd>
-<dt>.color<span class="access"> (write-only)</span>
-</dt>
-<dd><p class="description">text color</p></dd>
-<dt>:fill_icon(color)</dt>
-<dd><p class="description">fills icon with solid color</p></dd>
-<dt>.icon<span class="access"> (write-only)</span>
-</dt>
-<dd><p class="description">icon</p></dd>
-<dt>.text<span class="access"> (write-only)</span>
-</dt>
-<dd><p class="description">text</p></dd>
-</dl>
-</dd>
+            <dd>
+              <p class="description">there are 6 overlays, numbered 0 through 5</p>
+              <dl>
+                <dt>:clear()</dt>
+                <dd>
+                  <p class="description">turns off overlay</p>
+                </dd>
+                <dt>.color<span class="access"> (write-only)</span></dt>
+                <dd>
+                  <p class="description">text color</p>
+                </dd>
+                <dt>:fill_icon(color)</dt>
+                <dd>
+                  <p class="description">fills icon with solid color</p>
+                </dd>
+                <dt>.icon<span class="access"> (write-only)</span></dt>
+                <dd>
+                  <p class="description">icon</p>
+                </dd>
+                <dt>.text<span class="access"> (write-only)</span></dt>
+                <dd>
+                  <p class="description">text</p>
+                </dd>
+              </dl>
+            </dd>
       <dt>:play_sound(sound, pitch)</dt>
-<dd>
-<p class="description">plays sound that only player can hear</p>
-<p class="note">if you want all players to hear the sound as if it is coming from this player, use .monster:play_sound() instead </p>
-</dd>
+            <dd>
+              <p class="description">plays sound that only player can hear</p>
+              <p class="note">if you want all players to hear the sound as if it is coming from this player, use .monster:play_sound() instead </p>
+            </dd>
       <dt>.points</dt>
-<dd><p class="description">how many points player has</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd>
-<p class="description">polygon the player is standing on</p>
-<p class="note">if this gives you trouble, try .monster.polygon </p>
-</dd>
+            <dd>
+              <p class="description">how many points player has</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon the player is standing on</p>
+              <p class="note">if this gives you trouble, try .monster.polygon </p>
+            </dd>
       <dt>:position(x, y, z, polygon)</dt>
-<dd><p class="description">set player position</p></dd>
+            <dd>
+              <p class="description">set player position</p>
+            </dd>
       <dt>:print(message)</dt>
-<dd><p class="description">prints message to player’s screen</p></dd>
-	  <dt>:revive() <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">revives player</p>
-<p class="note">player must be totally dead </p>
-</dd>
+            <dd>
+              <p class="description">prints message to player’s screen</p>
+            </dd>
+	  <dt>:revive() <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">revives player</p>
+              <p class="note">player must be totally dead </p>
+            </dd>
       <dt>.team</dt>
-<dd><p class="description">player’s team (pants color)</p></dd>
+            <dd>
+              <p class="description">player’s team (pants color)</p>
+            </dd>
       <dt>:teleport(polygon)</dt>
-<dd><p class="description">teleports player to polygon</p></dd>
+            <dd>
+              <p class="description">teleports player to polygon</p>
+            </dd>
       <dt>:teleport_to_level(level)</dt>
-<dd><p class="description">teleports player to level (of course, all the other players will also go to that level)</p></dd>
-	  <dt>.teleporting<span class="access"> (read-only)</span> <span class="version">20220115</span>
-</dt>
-<dd><p class="description">whether player is teleporting</p></dd>
+            <dd>
+              <p class="description">teleports player to level (of course, all the other players will also go to that level)</p>
+            </dd>
+	  <dt>.teleporting<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">whether player is teleporting</p>
+            </dd>
       <dt>.texture_palette</dt>
-<dd>
-<p class="description">displays a texture palette instead of the classic HUD</p>
-<dl>
-<dt>.highlight<span class="access"> (local player)</span>
-</dt>
-<dd>
-<p class="description">number of slot to highlight</p>
-<p class="note">can be nil </p>
-</dd>
-<dt>.size<span class="access"> (local player)</span>
-</dt>
-<dd>
-<p class="description">how many slots the palette has</p>
-<p class="note">there is a maximum of 256 slots </p>
-<p class="note">the texture palette is visible whenever the size is greater than 0 </p>
-<p class="note">rows/columns may change in the future based on the user’s screen layout prefs </p>
-</dd>
-<dt>
+            <dd>
+              <p class="description">displays a texture palette instead of the classic HUD</p>
+              <dl>
+                <dt>.highlight<span class="access"> (local player)</span></dt>
+                <dd>
+                  <p class="description">number of slot to highlight</p>
+                  <p class="note">can be nil </p>
+                </dd>
+                <dt>.size<span class="access"> (local player)</span></dt>
+                <dd>
+                  <p class="description">how many slots the palette has</p>
+                  <p class="note">there is a maximum of 256 slots </p>
+                  <p class="note">the texture palette is visible whenever the size is greater than 0 </p>
+                  <p class="note">rows/columns may change in the future based on the user’s screen layout prefs </p>
+                </dd>
+                <dt>
     .slots[n]</dt>
-<dd><dl>
-<dt>:clear()</dt>
-<dd><p class="description">makes this slot empty</p></dd>
-<dt>.collection<span class="access"> (local player)</span>
-</dt>
-<dd><p class="description">collection of this slot</p></dd>
-<dt>.texture_index<span class="access"> (local player)</span>
-</dt>
-<dd><p class="description">texture index of this slot</p></dd>
-<dt>.type<span class="access"> (local player)</span> <span class="version">20090909</span>
-</dt>
-<dd><p class="description">texture type of this slot such as wall or sprite; see "Texture Types"</p></dd>
-</dl></dd>
-</dl>
-</dd>
-	  <dt>.totally_dead<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">the player is dead and the death animation has finished</p></dd>
-      <dt>:view_player(player) <span class="version">20080707</span>
-</dt>
-<dd><p class="description">switch to another player’s view</p></dd>
-      <dt>.viewed_player<span class="access"> (read-only) (local player)</span> <span class="version">20200830</span>
-</dt>
-<dd><p class="description">the player currently being viewed by the local player</p></dd>
+                <dd>
+                  <dl>
+                    <dt>:clear()</dt>
+                    <dd>
+                      <p class="description">makes this slot empty</p>
+                    </dd>
+                    <dt>.collection<span class="access"> (local player)</span></dt>
+                    <dd>
+                      <p class="description">collection of this slot</p>
+                    </dd>
+                    <dt>.texture_index<span class="access"> (local player)</span></dt>
+                    <dd>
+                      <p class="description">texture index of this slot</p>
+                    </dd>
+                    <dt>.type<span class="access"> (local player)</span> <span class="version">20090909</span></dt>
+                    <dd>
+                      <p class="description">texture type of this slot such as wall or sprite; see "Texture Types"</p>
+                    </dd>
+                  </dl>
+                </dd>
+              </dl>
+            </dd>
+	  <dt>.totally_dead<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">the player is dead and the death animation has finished</p>
+            </dd>
+      <dt>:view_player(player) <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">switch to another player’s view</p>
+            </dd>
+      <dt>.viewed_player<span class="access"> (read-only) (local player)</span> <span class="version">20200830</span></dt>
+            <dd>
+              <p class="description">the player currently being viewed by the local player</p>
+            </dd>
       <dt>.weapons</dt>
-<dd><dl>
-<dt>.active <span class="version">20080707</span>
-</dt>
-<dd><p class="description">when a player’s weapons are not active, he does not see weapons in hand, and can not fire</p></dd>
-<dt>.current<span class="access"> (read-only)</span>
-</dt>
-<dd>
-<p class="description">weapon the player is currently wielding</p>
-<p class="note">can be nil </p>
-</dd>
-<dt>.desired<span class="access"> (read-only)</span> <span class="version">20090909</span>
-</dt>
-<dd>
-<p class="description">weapon the player wants to switch to</p>
-<p class="note">can be nil </p>
-</dd>
-</dl></dd>
+            <dd>
+              <dl>
+                <dt>.active <span class="version">20080707</span></dt>
+                <dd>
+                  <p class="description">when a player’s weapons are not active, he does not see weapons in hand, and can not fire</p>
+                </dd>
+                <dt>.current<span class="access"> (read-only)</span></dt>
+                <dd>
+                  <p class="description">weapon the player is currently wielding</p>
+                  <p class="note">can be nil </p>
+                </dd>
+                <dt>.desired<span class="access"> (read-only)</span> <span class="version">20090909</span></dt>
+                <dd>
+                  <p class="description">weapon the player wants to switch to</p>
+                  <p class="note">can be nil </p>
+                </dd>
+              </dl>
+            </dd>
       <dt>
     .weapons[weapon_type]</dt>
-<dd><dl>
-<dt>.primary<br>.secondary</dt>
-<dd><dl>
-<dt>.rounds<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">how many rounds are currently loaded into the weapon</p></dd>
-</dl></dd>
-<dt>:select()</dt>
-<dd><p class="description">attempts to force player to ready weapon</p></dd>
-<dt>.type<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of this weapon</p></dd>
-</dl></dd>
-      <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.zoom_active<span class="access"> (local player)</span>
-</dt>
-<dd><p class="description">whether player’s sniper zoom is active</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Polygons"></a>Polygons</h3>
-<dl>
-<dt># Polygons</dt>
-<dd><p class="description">number of polygons in the level</p></dd>
-<dt>Polygons()</dt>
-<dd><p class="description">iterates through all polygons in the level</p></dd>
-<dt>Polygons[index]</dt>
-<dd><dl>
+            <dd>
+              <dl>
+                <dt>.primary<br>.secondary</dt>
+                <dd>
+                  <dl>
+                    <dt>.rounds<span class="access"> (read-only)</span></dt>
+                    <dd>
+                      <p class="description">how many rounds are currently loaded into the weapon</p>
+                    </dd>
+                  </dl>
+                </dd>
+                <dt>:select()</dt>
+                <dd>
+                  <p class="description">attempts to force player to ready weapon</p>
+                </dd>
+                <dt>.type<span class="access"> (read-only)</span></dt>
+                <dd>
+                  <p class="description">type of this weapon</p>
+                </dd>
+              </dl>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.zoom_active<span class="access"> (local player)</span></dt>
+            <dd>
+              <p class="description">whether player’s sniper zoom is active</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="PlayerStarts"></a>PlayerStarts</h3>
+      <dl>
+        <dt># PlayerStarts</dt>
+        <dd>
+          <p class="description">number of map objects in the level</p>
+        </dd>
+        <dt>PlayerStarts()</dt>
+        <dd>
+          <p class="description">iterates through all player starting locations in the level</p>
+        </dd>
+        <dt>PlayerStarts[index]</dt>
+        <dd>
+          <dl>
+      <dt>.facing<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">player starting location facing</p>
+            </dd>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether player starting location z is from ceiling</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">polygon player starting location is in</p>
+            </dd>
+      <dt>.team<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">which team starts at this player starting location</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+              <p class="note">from floor or ceiling </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Polygons"></a>Polygons</h3>
+      <dl>
+        <dt># Polygons</dt>
+        <dd>
+          <p class="description">number of polygons in the level</p>
+        </dd>
+        <dt>Polygons()</dt>
+        <dd>
+          <p class="description">iterates through all polygons in the level</p>
+        </dd>
+        <dt>Polygons[index]</dt>
+        <dd>
+          <dl>
       <dt>
     .adjacent_polygons[n]</dt>
-<dd><p class="description">returns adjacent polygon n (across from line n), if one exists, or nil</p></dd>
+            <dd>
+              <p class="description">returns adjacent polygon n (across from line n), if one exists, or nil</p>
+            </dd>
       <dt>:adjacent_polygons()</dt>
-<dd><p class="description">iterates through all polygons directly adjacent to this polygon</p></dd>
-      <dt>.area<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">the area of this polygon</p></dd>
+            <dd>
+              <p class="description">iterates through all polygons directly adjacent to this polygon</p>
+            </dd>
+      <dt>.area<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">the area of this polygon</p>
+            </dd>
       <dt>.ceiling<br>.floor</dt>
-<dd><dl>
-<dt>.collection</dt>
-<dd><p class="description">texture collection</p></dd>
-<dt>.height<br>.z</dt>
-<dd><p class="description">height</p></dd>
-<dt>.light</dt>
-<dd><p class="description">texture light</p></dd>
-<dt>.texture_index</dt>
-<dd><p class="description">texture bitmap index</p></dd>
-<dt>.texture_x</dt>
-<dd><p class="description">texture x offset</p></dd>
-<dt>.texture_y</dt>
-<dd><p class="description">texture y offset</p></dd>
-<dt>.transfer_mode</dt>
-<dd><p class="description">texture transfer mode</p></dd>
-</dl></dd>
-	  <dt>:change_height(floor, ceiling) <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">changes polygon floor and ceiling heights, if possible</p>
-<p class="note">won’t squish monsters; returns false instead </p>
-<p class="note">this is much less optimized than moving a platform </p>
-<p class="note">you may need to create sides if you are raising/lowering what used to be a flat floor/ceiling </p>
-</dd>
-	  <dt>:check_collision(x0, y0, z0, owner, x1, y1, z1 [, include_objects] [, include_media]) <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">returns t, x, y, z, polygon, where t is nil (if there was no collision), or the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the collision is with the surface of a liquid) where the line segment collided with the map (or object or media); and x, y, z, polygon is the location of the collision, or the end point if there was no collision</p>
-<p class="note">the owner is a monster or player to ignore, or nil </p>
-<p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
-<p class="note">in order of descending speed: find_polygon(), check_collision() without objects, check_collision() including objects </p>
-</dd>
+            <dd>
+              <dl>
+                <dt>.collection</dt>
+                <dd>
+                  <p class="description">texture collection</p>
+                </dd>
+                <dt>.height<br>.z</dt>
+                <dd>
+                  <p class="description">height</p>
+                </dd>
+                <dt>.light</dt>
+                <dd>
+                  <p class="description">texture light</p>
+                </dd>
+                <dt>.texture_index</dt>
+                <dd>
+                  <p class="description">texture bitmap index</p>
+                </dd>
+                <dt>.texture_x</dt>
+                <dd>
+                  <p class="description">texture x offset</p>
+                </dd>
+                <dt>.texture_y</dt>
+                <dd>
+                  <p class="description">texture y offset</p>
+                </dd>
+                <dt>.transfer_mode</dt>
+                <dd>
+                  <p class="description">texture transfer mode</p>
+                </dd>
+              </dl>
+            </dd>
+	  <dt>:change_height(floor, ceiling) <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">changes polygon floor and ceiling heights, if possible</p>
+              <p class="note">won’t squish monsters; returns false instead </p>
+              <p class="note">this is much less optimized than moving a platform </p>
+              <p class="note">you may need to create sides if you are raising/lowering what used to be a flat floor/ceiling </p>
+            </dd>
+	  <dt>:check_collision(x0, y0, z0, owner, x1, y1, z1 [, include_objects] [, include_media]) <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">returns t, x, y, z, polygon, where t is nil (if there was no collision), or the side, polygon_floor, polygon_ceiling, monster, scenery, or polygon (if the collision is with the surface of a liquid) where the line segment collided with the map (or object or media); and x, y, z, polygon is the location of the collision, or the end point if there was no collision</p>
+              <p class="note">the owner is a monster or player to ignore, or nil </p>
+              <p class="note">you can check the type of t with is_side(), is_polygon_floor(), is_polygon_ceiling(), is_monster(), is_scenery(), and is_polygon() </p>
+              <p class="note">in order of descending speed: find_polygon(), check_collision() without objects, check_collision() including objects </p>
+            </dd>
       <dt>:contains(x, y [, z])</dt>
-<dd><p class="description">whether the point is in this polygon</p></dd>
+            <dd>
+              <p class="description">whether the point is in this polygon</p>
+            </dd>
       <dt>
     .endpoints[n]</dt>
-<dd><p class="description">returns endpoint n</p></dd>
+            <dd>
+              <p class="description">returns endpoint n</p>
+            </dd>
       <dt>:endpoints()</dt>
-<dd><p class="description">iterates through all of this polygon’s endpoints</p></dd>
-	  <dt>:find_polygon(x1, y1, x2, y2) <span class="version">20210408</span>
-</dt>
-<dd>
-<p class="description">traverses map from (x1, y1) and returns polygon containing (x2, y2)</p>
-<p class="note">can be nil if there is no direct route between the two points, or the destination point is not in any polygon </p>
-<p class="note">ignores floor/ceiling height </p>
-</dd>
-      <dt>:find_line_crossed_leaving(x1, y1, x2, y2) <span class="version">20080707</span>
-</dt>
-<dd>
-<p class="description">returns the polygon line crossed by line segment (x1, y1) (x2, y2)</p>
-<p class="note">can be nil if the line segment doesn’t intersect a polygon line </p>
-</dd>
+            <dd>
+              <p class="description">iterates through all of this polygon’s endpoints</p>
+            </dd>
+	  <dt>:find_polygon(x1, y1, x2, y2) <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">traverses map from (x1, y1) and returns polygon containing (x2, y2)</p>
+              <p class="note">can be nil if there is no direct route between the two points, or the destination point is not in any polygon </p>
+              <p class="note">ignores floor/ceiling height </p>
+            </dd>
+      <dt>:find_line_crossed_leaving(x1, y1, x2, y2) <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">returns the polygon line crossed by line segment (x1, y1) (x2, y2)</p>
+              <p class="note">can be nil if the line segment doesn’t intersect a polygon line </p>
+            </dd>
       <dt>
     .lines[n]</dt>
-<dd><p class="description">returns polygon line n</p></dd>
+            <dd>
+              <p class="description">returns polygon line n</p>
+            </dd>
       <dt>:lines()</dt>
-<dd><p class="description">iterates through all of this polygon’s lines</p></dd>
+            <dd>
+              <p class="description">iterates through all of this polygon’s lines</p>
+            </dd>
       <dt>.media</dt>
-<dd><p class="description">polygon media (liquid)</p></dd>
+            <dd>
+              <p class="description">polygon media (liquid)</p>
+            </dd>
       <dt>:monsters()</dt>
-<dd><p class="description">iterates through all monsters in this polygon (including player monsters)</p></dd>
+            <dd>
+              <p class="description">iterates through all monsters in this polygon (including player monsters)</p>
+            </dd>
       <dt>.permutation</dt>
-<dd><p class="description">raw permutation index of this polygon</p></dd>
+            <dd>
+              <p class="description">raw permutation index of this polygon</p>
+            </dd>
       <dt>:play_sound(sound)</dt>
-<dd><p class="description">plays sound in center of polygon on floor</p></dd>
+            <dd>
+              <p class="description">plays sound in center of polygon on floor</p>
+            </dd>
       <dt>:play_sound(x, y, z, sound [, pitch])</dt>
-<dd>
-<p class="description">plays sound at location</p>
-<p class="note">if you want to play a sound at an object location, use that object’s play_sound function instead </p>
-</dd>
+            <dd>
+              <p class="description">plays sound at location</p>
+              <p class="note">if you want to play a sound at an object location, use that object’s play_sound function instead </p>
+            </dd>
       <dt>
     .sides[n]</dt>
-<dd><p class="description">returns polygon side n if it exists</p></dd>
+            <dd>
+              <p class="description">returns polygon side n if it exists</p>
+            </dd>
       <dt>:sides()</dt>
-<dd><p class="description">iterates through all of this polygon’s sides</p></dd>
+            <dd>
+              <p class="description">iterates through all of this polygon’s sides</p>
+            </dd>
       <dt>.type</dt>
-<dd><p class="description">polygon type</p></dd>
-      <dt>.visible_on_automap <span class="version">20150619</span>
-</dt>
-<dd><p class="description">whether polygon is revealed on local player’s automap</p></dd>
-      <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">center of polygon</p></dd>
-      <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">center of polygon</p></dd>
-      <dt>.z<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">shortcut for .floor.height</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Projectiles"></a>Projectiles</h3>
-<dl>
-<dt># Projectiles</dt>
-<dd><p class="description">maximum number of projectiles</p></dd>
-<dt>Projectiles()</dt>
-<dd><p class="description">iterates through all valid projectiles</p></dd>
-<dt>Projectiles.new(x, y, z, polygon, type)</dt>
-<dd>
-<p class="description">returns a new projectile</p>
-<p class="note">remember to set the projectile’s elevation, facing and owner immediately after you’ve created it </p>
-</dd>
-<dt>Projectiles[index]</dt>
-<dd><dl>
-      <dt>:delete() <span class="version">20111201</span>
-</dt>
-<dd><p class="description">removes projectile from the map</p></dd>
+            <dd>
+              <p class="description">polygon type</p>
+            </dd>
+      <dt>.visible_on_automap <span class="version">20150619</span></dt>
+            <dd>
+              <p class="description">whether polygon is revealed on local player’s automap</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">center of polygon</p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">center of polygon</p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">shortcut for .floor.height</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Projectiles"></a>Projectiles</h3>
+      <dl>
+        <dt># Projectiles</dt>
+        <dd>
+          <p class="description">maximum number of projectiles</p>
+        </dd>
+        <dt>Projectiles()</dt>
+        <dd>
+          <p class="description">iterates through all valid projectiles</p>
+        </dd>
+        <dt>Projectiles.new(x, y, z, polygon, type)</dt>
+        <dd>
+          <p class="description">returns a new projectile</p>
+          <p class="note">remember to set the projectile’s elevation, facing and owner immediately after you’ve created it </p>
+        </dd>
+        <dt>Projectiles[index]</dt>
+        <dd>
+          <dl>
+      <dt>:delete() <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">removes projectile from the map</p>
+            </dd>
       <dt>.damage_scale</dt>
-<dd><p class="description">amount to scale projectile’s normal damage by upon detonating</p></dd>
+            <dd>
+              <p class="description">amount to scale projectile’s normal damage by upon detonating</p>
+            </dd>
       <dt>.dz</dt>
-<dd><p class="description">instantaneous downward velocity</p></dd>
+            <dd>
+              <p class="description">instantaneous downward velocity</p>
+            </dd>
       <dt>.elevation<br>.pitch</dt>
-<dd><p class="description">vertical angle</p></dd>
+            <dd>
+              <p class="description">vertical angle</p>
+            </dd>
       <dt>.facing<br>.yaw</dt>
-<dd><p class="description">direction</p></dd>
+            <dd>
+              <p class="description">direction</p>
+            </dd>
       <dt>:play_sound(sound)</dt>
-<dd><p class="description">plays sound coming from this projectile</p></dd>
+            <dd>
+              <p class="description">plays sound coming from this projectile</p>
+            </dd>
       <dt>:position(x, y, z, polygon)</dt>
-<dd><p class="description">sets projectile position</p></dd>
+            <dd>
+              <p class="description">sets projectile position</p>
+            </dd>
       <dt>.owner</dt>
-<dd><p class="description">monster that fired projectile, or nil</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon the projectile is in</p></dd>
+            <dd>
+              <p class="description">monster that fired projectile, or nil</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon the projectile is in</p>
+            </dd>
       <dt>.target</dt>
-<dd><p class="description">target of guided projectile, or nil</p></dd>
-      <dt>.type<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of projectile</p></dd>
-      <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Scenery"></a>Scenery</h3>
-<dl>
-<dt># Scenery</dt>
-<dd><p class="description">maximum number of map objects</p></dd>
-<dt>Scenery()</dt>
-<dd><p class="description">iterates through all valid scenery</p></dd>
-<dt>Scenery.new(x, y, height, polygon, type)</dt>
-<dd><p class="description">returns a new scenery</p></dd>
-<dt>Scenery[index]</dt>
-<dd><dl>
+            <dd>
+              <p class="description">target of guided projectile, or nil</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">type of projectile</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Scenery"></a>Scenery</h3>
+      <dl>
+        <dt># Scenery</dt>
+        <dd>
+          <p class="description">maximum number of map objects</p>
+        </dd>
+        <dt>Scenery()</dt>
+        <dd>
+          <p class="description">iterates through all valid scenery</p>
+        </dd>
+        <dt>Scenery.new(x, y, height, polygon, type)</dt>
+        <dd>
+          <p class="description">returns a new scenery</p>
+        </dd>
+        <dt>Scenery[index]</dt>
+        <dd>
+          <dl>
       <dt>:damage()</dt>
-<dd><p class="description">damages scenery</p></dd>
-      <dt>.damaged<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">whether this scenery has been damaged</p></dd>
+            <dd>
+              <p class="description">damages scenery</p>
+            </dd>
+      <dt>.damaged<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">whether this scenery has been damaged</p>
+            </dd>
       <dt>:delete()</dt>
-<dd><p class="description">removes scenery from the map</p></dd>
+            <dd>
+              <p class="description">removes scenery from the map</p>
+            </dd>
       <dt>.facing</dt>
-<dd><p class="description">direction scenery is facing</p></dd>
+            <dd>
+              <p class="description">direction scenery is facing</p>
+            </dd>
       <dt>:play_sound(sound)</dt>
-<dd><p class="description">play sound coming from this scenery</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon the scenery is in</p></dd>
-      <dt>:position(x, y, z, polygon) <span class="version">20090909</span>
-</dt>
-<dd><p class="description">sets position of scenery</p></dd>
+            <dd>
+              <p class="description">play sound coming from this scenery</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon the scenery is in</p>
+            </dd>
+      <dt>:position(x, y, z, polygon) <span class="version">20090909</span></dt>
+            <dd>
+              <p class="description">sets position of scenery</p>
+            </dd>
       <dt>.solid</dt>
-<dd><p class="description">whether this scenery is solid</p></dd>
-	  <dt>:teleport_in() <span class="version">20240712</span>
-</dt>
-<dd>
-<p class="description">teleports scenery in</p>
-<p class="note">can fail silently if there are not enough effects slots </p>
-</dd>
-	  <dt>:teleport_out() <span class="version">20240712</span>
-</dt>
-<dd>
-<p class="description">teleports scenery out</p>
-<p class="note">can fail silently if there are not enough effects slots </p>
-</dd>
-      <dt>.type<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of scenery</p></dd>
-	  <dt>.visible <span class="version">20240712</span>
-</dt>
-<dd><p class="description">whether this scenery is visible</p></dd>
-      <dt>.x<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Sides"></a>Sides</h3>
-<dl>
-<dt># Sides</dt>
-<dd><p class="description">number of sides on the level</p></dd>
-<dt>Sides()</dt>
-<dd><p class="description">iterates through all sides on the level</p></dd>
-<dt>Sides.new(polygon, line) <span class="version">20080707</span>
-</dt>
-<dd>
-<p class="description">creates a new side</p>
-<p class="note">side must not already exist </p>
-</dd>
-<dt>Sides[index]</dt>
-<dd><dl>
-	  <dt>.ambient_delta <span class="version">20210408</span>
-</dt>
-<dd><p class="description">constant offset from calculated light intensity</p></dd>
+            <dd>
+              <p class="description">whether this scenery is solid</p>
+            </dd>
+	  <dt>:teleport_in() <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">teleports scenery in</p>
+              <p class="note">can fail silently if there are not enough effects slots </p>
+            </dd>
+	  <dt>:teleport_out() <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">teleports scenery out</p>
+              <p class="note">can fail silently if there are not enough effects slots </p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">type of scenery</p>
+            </dd>
+	  <dt>.visible <span class="version">20240712</span></dt>
+            <dd>
+              <p class="description">whether this scenery is visible</p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Sides"></a>Sides</h3>
+      <dl>
+        <dt># Sides</dt>
+        <dd>
+          <p class="description">number of sides on the level</p>
+        </dd>
+        <dt>Sides()</dt>
+        <dd>
+          <p class="description">iterates through all sides on the level</p>
+        </dd>
+        <dt>Sides.new(polygon, line) <span class="version">20080707</span></dt>
+        <dd>
+          <p class="description">creates a new side</p>
+          <p class="note">side must not already exist </p>
+        </dd>
+        <dt>Sides[index]</dt>
+        <dd>
+          <dl>
+	  <dt>.ambient_delta <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">constant offset from calculated light intensity</p>
+            </dd>
       <dt>.control_panel</dt>
-<dd>
-<p class="note">nil if the side is not a control panel </p>
-<p class="note">set to true or false to create/destroy a control panel <span class="version">20080707</span></p>
-<dl>
-<dt>.can_be_destroyed <span class="version">20080707</span>
-</dt>
-<dd><p class="description">whether projectiles destroy this switch</p></dd>
-<dt>.light_dependent <span class="version">20080707</span>
-</dt>
-<dd><p class="description">switch can only be activated if light &gt; 75%</p></dd>
-<dt>.only_toggled_by_weapons <span class="version">20080707</span>
-</dt>
-<dd><p class="description">switch can only be toggled by weapons</p></dd>
-<dt>.permutation</dt>
-<dd><p class="description">permutation of control panel</p></dd>
-<dt>.repair <span class="version">20080707</span>
-</dt>
-<dd><p class="description">switch is a repair switch</p></dd>
-<dt>.status <span class="version">20080707</span>
-</dt>
-<dd><p class="description">switch is active</p></dd>
-<dt>.type <span class="version">20080707</span>
-</dt>
-<dd><p class="description">type of control panel</p></dd>
-<dt>.uses_item<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">i.e. chip insertion</p></dd>
-</dl>
-</dd>
+            <dd>
+              <p class="note">nil if the side is not a control panel </p>
+              <p class="note">set to true or false to create/destroy a control panel <span class="version">20080707</span></p>
+              <dl>
+                <dt>.can_be_destroyed <span class="version">20080707</span></dt>
+                <dd>
+                  <p class="description">whether projectiles destroy this switch</p>
+                </dd>
+                <dt>.light_dependent <span class="version">20080707</span></dt>
+                <dd>
+                  <p class="description">switch can only be activated if light &gt; 75%</p>
+                </dd>
+                <dt>.only_toggled_by_weapons <span class="version">20080707</span></dt>
+                <dd>
+                  <p class="description">switch can only be toggled by weapons</p>
+                </dd>
+                <dt>.permutation</dt>
+                <dd>
+                  <p class="description">permutation of control panel</p>
+                </dd>
+                <dt>.repair <span class="version">20080707</span></dt>
+                <dd>
+                  <p class="description">switch is a repair switch</p>
+                </dd>
+                <dt>.status <span class="version">20080707</span></dt>
+                <dd>
+                  <p class="description">switch is active</p>
+                </dd>
+                <dt>.type <span class="version">20080707</span></dt>
+                <dd>
+                  <p class="description">type of control panel</p>
+                </dd>
+                <dt>.uses_item<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+                <dd>
+                  <p class="description">i.e. chip insertion</p>
+                </dd>
+              </dl>
+            </dd>
       <dt>.primary<br>.secondary<br>.transparent</dt>
-<dd><dl>
-<dt>.collection</dt>
-<dd><p class="description">texture collection</p></dd>
-<dt>.empty</dt>
-<dd>
-<p class="description">whether side is empty</p>
-<p class="note">transparent sides only in earlier versions <span class="version">Git</span></p>
-<p class="note">setting empty to false is a no-op; set collection and texture_index instead </p>
-</dd>
-<dt>.light</dt>
-<dd><p class="description">texture light</p></dd>
-<dt>.texture_index</dt>
-<dd><p class="description">texture bitmap index</p></dd>
-<dt>.texture_x</dt>
-<dd><p class="description">texture x offset</p></dd>
-<dt>.texture_y</dt>
-<dd><p class="description">texture y offset</p></dd>
-<dt>.transfer_mode</dt>
-<dd><p class="description">texture transfer mode</p></dd>
-</dl></dd>
+            <dd>
+              <dl>
+                <dt>.collection</dt>
+                <dd>
+                  <p class="description">texture collection</p>
+                </dd>
+                <dt>.empty</dt>
+                <dd>
+                  <p class="description">whether side is empty</p>
+                  <p class="note">transparent sides only in earlier versions <span class="version">Git</span></p>
+                  <p class="note">setting empty to false is a no-op; set collection and texture_index instead </p>
+                </dd>
+                <dt>.light</dt>
+                <dd>
+                  <p class="description">texture light</p>
+                </dd>
+                <dt>.texture_index</dt>
+                <dd>
+                  <p class="description">texture bitmap index</p>
+                </dd>
+                <dt>.texture_x</dt>
+                <dd>
+                  <p class="description">texture x offset</p>
+                </dd>
+                <dt>.texture_y</dt>
+                <dd>
+                  <p class="description">texture y offset</p>
+                </dd>
+                <dt>.transfer_mode</dt>
+                <dd>
+                  <p class="description">texture transfer mode</p>
+                </dd>
+              </dl>
+            </dd>
       <dt>:play_sound(sound [, pitch])</dt>
-<dd><p class="description">play sound coming from this side</p></dd>
-      <dt>.line<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">line this side is attached to</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">polygon this side is attached to</p></dd>
-      <dt>:recalculate_type() <span class="version">20081213</span>
-</dt>
-<dd><p class="description">correct the side type (Forge can generate incorrect side types)</p></dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">type of side</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="SoundObjects"></a>SoundObjects</h3>
-<dl>
-<dt># SoundObjects</dt>
-<dd><p class="description">number of map objects in the level</p></dd>
-<dt>SoundObjects()</dt>
-<dd><p class="description">iterates through all sound objects in the level</p></dd>
-<dt>SoundObjects[index]</dt>
-<dd><dl>
-      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether sound object location z is from ceiling</p></dd>
-      <dt>.light<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description">if sound object uses a light for volume, the light it uses</p>
-<p class="note">can be nil if sound object doesn’t use light for volume </p>
-</dd>
-      <dt>.on_platform<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether sound object is a platform sound</p></dd>
-      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">sound object polygon</p></dd>
-      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description">type of sound object</p></dd>
-      <dt>.volume<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description">volume of sound object from 0.0 to 1.0</p>
-<p class="note">can be nil if sound object uses light for volume </p>
-</dd>
-      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description"></p>
-<p class="note">from floor or ceiling </p>
-</dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Tags"></a>Tags</h3>
-<dl>
-<dt>Tags[index]</dt>
-<dd><dl>
+            <dd>
+              <p class="description">play sound coming from this side</p>
+            </dd>
+      <dt>.line<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">line this side is attached to</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">polygon this side is attached to</p>
+            </dd>
+      <dt>:recalculate_type() <span class="version">20081213</span></dt>
+            <dd>
+              <p class="description">correct the side type (Forge can generate incorrect side types)</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">type of side</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="SoundObjects"></a>SoundObjects</h3>
+      <dl>
+        <dt># SoundObjects</dt>
+        <dd>
+          <p class="description">number of map objects in the level</p>
+        </dd>
+        <dt>SoundObjects()</dt>
+        <dd>
+          <p class="description">iterates through all sound objects in the level</p>
+        </dd>
+        <dt>SoundObjects[index]</dt>
+        <dd>
+          <dl>
+      <dt>.from_ceiling<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether sound object location z is from ceiling</p>
+            </dd>
+      <dt>.light<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">if sound object uses a light for volume, the light it uses</p>
+              <p class="note">can be nil if sound object doesn’t use light for volume </p>
+            </dd>
+      <dt>.on_platform<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether sound object is a platform sound</p>
+            </dd>
+      <dt>.polygon<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">sound object polygon</p>
+            </dd>
+      <dt>.type<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">type of sound object</p>
+            </dd>
+      <dt>.volume<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">volume of sound object from 0.0 to 1.0</p>
+              <p class="note">can be nil if sound object uses light for volume </p>
+            </dd>
+      <dt>.x<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.y<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.z<span class="access"> (read-only)</span> <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+              <p class="note">from floor or ceiling </p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Tags"></a>Tags</h3>
+      <dl>
+        <dt>Tags[index]</dt>
+        <dd>
+          <dl>
       <dt>.active</dt>
-<dd><p class="description">tag is active</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="Terminals"></a>Terminals</h3>
-<dl>
-<dt># Terminals</dt>
-<dd><p class="description">number of terminal texts in the level</p></dd>
-<dt>Terminals()</dt>
-<dd><p class="description">iterates through all terminal texts on the level</p></dd>
-<dt>Terminals[index]</dt>
-<dd></dd>
-</dl>
-</div>
-<h1>
-<a name="types"></a>Types and Mnemonics</h1>
-<div class="tables">
-<p>The string mnemonics listed below can be used for assignment and as arguments to functions. Additionally, Aleph One’s Lua interpreter has been modified so that equality comparisons between userdata types and strings are possible.</p>
-<p>For example, this script would move all players on the blue team to the red team:
+            <dd>
+              <p class="description">tag is active</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="Terminals"></a>Terminals</h3>
+      <dl>
+        <dt># Terminals</dt>
+        <dd>
+          <p class="description">number of terminal texts in the level</p>
+        </dd>
+        <dt>Terminals()</dt>
+        <dd>
+          <p class="description">iterates through all terminal texts on the level</p>
+        </dd>
+        <dt>Terminals[index]</dt>
+        <dd></dd>
+      </dl>
+    </div>
+    <h1><a name="types"></a>Types and Mnemonics</h1>
+    <div class="tables">
+      <p>The string mnemonics listed below can be used for assignment and as arguments to functions. Additionally, Aleph One’s Lua interpreter has been modified so that equality comparisons between userdata types and strings are possible.</p>
+      <p>For example, this script would move all players on the blue team to the red team:
 <span class="pre">for p in Players() do
   if p.team == "blue" then
     p.team = "red"
@@ -2251,57 +2901,64 @@ nil
 </span>
 If you do this, you should customize them all at the beginning of the script. Changing mnemonics mid-game will confuse anyone who tries to read your script, and probably yourself as well!
 </p>
-<h3>
-<a name="AmbientSounds"></a>Ambient Sounds</h3>
-<dl>
-<dt># AmbientSounds</dt>
-<dt>AmbientSounds()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"water"</li>
-<li>"sewage"</li>
-<li>"lava"</li>
-<li>"goo"</li>
-<li>"underwater"</li>
-<li>"wind"</li>
-<li>"waterfall"</li>
-<li>"siren"</li>
-<li>"fan"</li>
-<li>"spht door"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"spht platform"</li>
-<li>"heavy spht door"</li>
-<li>"heavy spht platform"</li>
-<li>"light machinery"</li>
-<li>"heavy machinery"</li>
-<li>"transformer"</li>
-<li>"sparking transformer"</li>
-<li>"machine binder"</li>
-<li>"machine bookpress"</li>
-<li>"machine puncher"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"electric hum"</li>
-<li>"alarm"</li>
-<li>"night wind"</li>
-<li>"pfhor door"</li>
-<li>"pfhor platform"</li>
-<li>"alien noise 1"</li>
-<li>"alien noise 2"</li>
-<li>"alien harmonics"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="Collections"></a>Collections</h3>
-<dl>
-<dt># Collections</dt>
-<dt>Collections()</dt>
-<dt>Collections[collection]</dt>
-<dd><dl>
+      <h3><a name="AmbientSounds"></a>Ambient Sounds</h3>
+      <dl>
+        <dt># AmbientSounds</dt>
+        <dt>AmbientSounds()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"water"</li>
+          <li>"sewage"</li>
+          <li>"lava"</li>
+          <li>"goo"</li>
+          <li>"underwater"</li>
+          <li>"wind"</li>
+          <li>"waterfall"</li>
+          <li>"siren"</li>
+          <li>"fan"</li>
+          <li>"spht door"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"spht platform"</li>
+          <li>"heavy spht door"</li>
+          <li>"heavy spht platform"</li>
+          <li>"light machinery"</li>
+          <li>"heavy machinery"</li>
+          <li>"transformer"</li>
+          <li>"sparking transformer"</li>
+          <li>"machine binder"</li>
+          <li>"machine bookpress"</li>
+          <li>"machine puncher"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"electric hum"</li>
+          <li>"alarm"</li>
+          <li>"night wind"</li>
+          <li>"pfhor door"</li>
+          <li>"pfhor platform"</li>
+          <li>"alien noise 1"</li>
+          <li>"alien noise 2"</li>
+          <li>"alien harmonics"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="Collections"></a>Collections</h3>
+      <dl>
+        <dt># Collections</dt>
+        <dt>Collections()</dt>
+        <dt>Collections[collection]</dt>
+        <dd>
+          <dl>
       <dt>.bitmap_count</dt>
-<dd><p class="description">number of bitmaps in collection</p></dd>
+            <dd>
+              <p class="description">number of bitmaps in collection</p>
+            </dd>
       
 		
 		
@@ -2336,389 +2993,427 @@ If you do this, you should customize them all at the beginning of the script. Ch
 		
 		
       
-    </dl></dd>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"interface"</li>
-<li>"weapons in hand"</li>
-<li>"juggernaut"</li>
-<li>"tick"</li>
-<li>"explosions"</li>
-<li>"hunter"</li>
-<li>"player"</li>
-<li>"items"</li>
-<li>"trooper"</li>
-<li>"fighter"</li>
-<li>"defender"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"yeti"</li>
-<li>"bob"</li>
-<li>"vacbob"</li>
-<li>"enforcer"</li>
-<li>"drone"</li>
-<li>"compiler"</li>
-<li>"water"</li>
-<li>"lava"</li>
-<li>"sewage"</li>
-<li>"jjaro"</li>
-<li>"pfhor"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"water scenery"</li>
-<li>"lava scenery"</li>
-<li>"sewage scenery"</li>
-<li>"jjaro scenery"</li>
-<li>"pfhor scenery"</li>
-<li>"day"</li>
-<li>"night"</li>
-<li>"moon"</li>
-<li>"space"</li>
-<li>"cyborg"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="CompletionStates"></a>Completion States</h3>
-<dl>
-<dt># CompletionStates</dt>
-<dt>CompletionStates()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"unfinished"</li>
-<li>"finished"</li>
-<li>"failed"</li>
-</ul>
-<h3>
-<a name="ControlPanelClasses"></a>Control Panel Classes</h3>
-<dl>
-<dt># ControlPanelClasses</dt>
-<dt>ControlPanelClasses()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"oxygen recharger"</li>
-<li>"single shield recharger"</li>
-<li>"double shield recharger"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"triple shield recharger"</li>
-<li>"light switch"</li>
-<li>"platform switch"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"tag switch"</li>
-<li>"pattern buffer"</li>
-<li>"terminal"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="ControlPanelTypes"></a>Control Panel Types</h3>
-<dl>
-<dt># ControlPanelTypes</dt>
-<dt>ControlPanelTypes()</dt>
-<dt>ControlPanelTypes[control_panel_type]</dt>
-<dd><dl>
-      <dt>.active_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">bitmap index when control panel is active</p></dd>
-      <dt>.class<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">class of this control panel type</p></dd>
-      <dt>.collection<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">collection this control panel belongs to</p></dd>
-      <dt>.inactive_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span>
-</dt>
-<dd><p class="description">bitmap index when control panel is inactive/destroyed</p></dd>
-    </dl></dd>
-</dl>
-<h3>
-<a name="DamageTypes"></a>Damage</h3>
-<dl>
-<dt># DamageTypes</dt>
-<dt>DamageTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"explosion"</li>
-<li>"staff"</li>
-<li>"projectile"</li>
-<li>"absorbed"</li>
-<li>"flame"</li>
-<li>"claws"</li>
-<li>"alien weapon"</li>
-<li>"hulk slap"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"compiler"</li>
-<li>"fusion"</li>
-<li>"hunter"</li>
-<li>"fists"</li>
-<li>"teleporter"</li>
-<li>"defender"</li>
-<li>"yeti claws"</li>
-<li>"yeti projectile"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"crushing"</li>
-<li>"lava"</li>
-<li>"suffocation"</li>
-<li>"goo"</li>
-<li>"energy drain"</li>
-<li>"oxygen drain"</li>
-<li>"drone"</li>
-<li>"shotgun"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="DifficultyTypes"></a>Difficulty</h3>
-<dl>
-<dt># DifficultyTypes</dt>
-<dt>DifficultyTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"kindergarten"</li>
-<li>"easy"</li>
-<li>"normal"</li>
-<li>"major damage"</li>
-<li>"total carnage"</li>
-</ul>
-<h3>
-<a name="EffectTypes"></a>Effects</h3>
-<dl>
-<dt># EffectTypes</dt>
-<dt>EffectTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"rocket explosion"</li>
-<li>"rocket contrail"</li>
-<li>"grenade explosion"</li>
-<li>"grenade contrail"</li>
-<li>"bullet ricochet"</li>
-<li>"alien weapon ricochet"</li>
-<li>"flamethrower burst"</li>
-<li>"fighter blood splash"</li>
-<li>"player blood splash"</li>
-<li>"civilian blood splash"</li>
-<li>"assimilated civilian blood splash"</li>
-<li>"enforcer blood splash"</li>
-<li>"compiler bolt minor detonation"</li>
-<li>"compiler bolt major detonation"</li>
-<li>"compiler bolt major contrail"</li>
-<li>"fighter projectile detonation"</li>
-<li>"fighter melee detonation"</li>
-<li>"hunter projectile detonation"</li>
-<li>"hunter spark"</li>
-<li>"minor fusion detonation"</li>
-<li>"major fusion detonation"</li>
-<li>"major fusion contrail"</li>
-<li>"fist detonation"</li>
-<li>"minor defender detonation"</li>
-<li>"major defender detonation"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"defender spark"</li>
-<li>"trooper blood splash"</li>
-<li>"water lamp breaking"</li>
-<li>"lava lamp breaking"</li>
-<li>"sewage lamp breaking"</li>
-<li>"alien lamp breaking"</li>
-<li>"metallic clang"</li>
-<li>"teleport object in"</li>
-<li>"teleport object out"</li>
-<li>"small water splash"</li>
-<li>"medium water splash"</li>
-<li>"large water splash"</li>
-<li>"large water emergence"</li>
-<li>"small lava splash"</li>
-<li>"medium lava splash"</li>
-<li>"large lava splash"</li>
-<li>"large lava emergence"</li>
-<li>"small sewage splash"</li>
-<li>"medium sewage splash"</li>
-<li>"large sewage splash"</li>
-<li>"large sewage emergence"</li>
-<li>"small goo splash"</li>
-<li>"medium goo splash"</li>
-<li>"large goo splash"</li>
-<li>"large goo emergence"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"minor hummer projectile detonation"</li>
-<li>"major hummer projectile detonation"</li>
-<li>"durandal hummer projectile detonation"</li>
-<li>"hummer spark"</li>
-<li>"cyborg projectile detonation"</li>
-<li>"cyborg blood splash"</li>
-<li>"minor fusion dispersal"</li>
-<li>"major fusion dispersal"</li>
-<li>"overloaded fusion dispersal"</li>
-<li>"sewage yeti blood splash"</li>
-<li>"sewage yeti projectile detonation"</li>
-<li>"water yeti blood splash"</li>
-<li>"lava yeti blood splash"</li>
-<li>"lava yeti projectile detonation"</li>
-<li>"yeti melee detonation"</li>
-<li>"juggernaut spark"</li>
-<li>"juggernaut missile contrail"</li>
-<li>"small jjaro splash"</li>
-<li>"medium jjaro splash"</li>
-<li>"large jjaro splash"</li>
-<li>"large jjaro emergence"</li>
-<li>"civilian fusion blood splash"</li>
-<li>"assimilated civilian fusion blood splash"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="EphemeraQualities"></a>Ephemera Quality</h3>
-<dl>
-<dt># EphemeraQualities</dt>
-<dt>EphemeraQualities()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"off"</li>
-<li>"low"</li>
-<li>"medium"</li>
-<li>"high"</li>
-<li>"ultra"</li>
-</ul>
-<h3>
-<a name="FadeTypes"></a>Faders</h3>
-<dl>
-<dt># FadeTypes</dt>
-<dt>FadeTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"start cinematic fade in"</li>
-<li>"cinematic fade in"</li>
-<li>"long cinematic fade in"</li>
-<li>"cinematic fade out"</li>
-<li>"end cinematic fade out"</li>
-<li>"red"</li>
-<li>"big red"</li>
-<li>"bonus"</li>
-<li>"bright"</li>
-<li>"long bright"</li>
-<li>"yellow"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"big yellow"</li>
-<li>"purple"</li>
-<li>"cyan"</li>
-<li>"white"</li>
-<li>"big white"</li>
-<li>"orange"</li>
-<li>"long orange"</li>
-<li>"green"</li>
-<li>"long green"</li>
-<li>"static"</li>
-<li>"negative"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"big negative"</li>
-<li>"flicker negative"</li>
-<li>"dodge purple"</li>
-<li>"burn cyan"</li>
-<li>"dodge yellow"</li>
-<li>"burn green"</li>
-<li>"tint green"</li>
-<li>"tint blue"</li>
-<li>"tint orange"</li>
-<li>"tint gross"</li>
-<li>"tint jjaro"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="FogModes"></a>Fog Modes</h3>
-<dl>
-<dt># FogModes</dt>
-<dt>FogModes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"linear"</li>
-<li>"exp"</li>
-<li>"exp2"</li>
-</ul>
-<h3>
-<a name="GameTypes"></a>Game Types</h3>
-<dl>
-<dt># GameTypes</dt>
-<dt>GameTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"kill monsters"</li>
-<li>"cooperative play"</li>
-<li>"capture the flag"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"king of the hill"</li>
-<li>"kill the man with the ball"</li>
-<li>"defense"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"rugby"</li>
-<li>"tag"</li>
-<li>"netscript"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="ItemKinds"></a>Item Kinds</h3>
-<dl>
-<dt># ItemKinds</dt>
-<dt>ItemKinds()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"weapon"</li>
-<li>"ammunition"</li>
-<li>"powerup"</li>
-<li>"item"</li>
-<li>"weapon powerup"</li>
-<li>"ball"</li>
-</ul>
-<h3>
-<a name="ItemTypes"></a>Item Types</h3>
-<dl>
-<dt># ItemTypes</dt>
-<dt>ItemTypes()</dt>
-<dt>ItemTypes[item_type]</dt>
-<dd><dl>
-      <dt>.initial_count <span class="version">20111201</span>
-</dt>
-<dd><p class="description">how many items of this type are placed in the level during initial placement</p></dd>
-	  <dt>.kind<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">kind of item this is</p></dd>
-      <dt>.maximum_count <span class="version">20111201</span>
-</dt>
-<dd><p class="description">maximum number of this type of item in the level and in player inventories</p></dd>
-	  <dt>.maximum_inventory <span class="version">20210408</span>
-</dt>
-<dd><p class="description">maximum number of this type of item players can carry</p></dd>
-      <dt>.minimum_count <span class="version">20111201</span>
-</dt>
-<dd><p class="description">minimum number of this type of item in the level and in player inventories</p></dd>
-      <dt>.random_chance <span class="version">20111201</span>
-</dt>
-<dd><p class="description">chance from 0 to 1.0 this item will appear in a respawn period</p></dd>
-      <dt>.random_location <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether items of this type spawn in random locations</p></dd>
-      <dt>.total_available <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description">total number of items of this type that can be spawned in this level</p>
-<p class="note">-1 means infinite items are available </p>
-<p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before item placement is done </p>
-</dd>
+    </dl>
+        </dd>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"interface"</li>
+          <li>"weapons in hand"</li>
+          <li>"juggernaut"</li>
+          <li>"tick"</li>
+          <li>"explosions"</li>
+          <li>"hunter"</li>
+          <li>"player"</li>
+          <li>"items"</li>
+          <li>"trooper"</li>
+          <li>"fighter"</li>
+          <li>"defender"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"yeti"</li>
+          <li>"bob"</li>
+          <li>"vacbob"</li>
+          <li>"enforcer"</li>
+          <li>"drone"</li>
+          <li>"compiler"</li>
+          <li>"water"</li>
+          <li>"lava"</li>
+          <li>"sewage"</li>
+          <li>"jjaro"</li>
+          <li>"pfhor"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"water scenery"</li>
+          <li>"lava scenery"</li>
+          <li>"sewage scenery"</li>
+          <li>"jjaro scenery"</li>
+          <li>"pfhor scenery"</li>
+          <li>"day"</li>
+          <li>"night"</li>
+          <li>"moon"</li>
+          <li>"space"</li>
+          <li>"cyborg"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="CompletionStates"></a>Completion States</h3>
+      <dl>
+        <dt># CompletionStates</dt>
+        <dt>CompletionStates()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"unfinished"</li>
+        <li>"finished"</li>
+        <li>"failed"</li>
+      </ul>
+      <h3><a name="ControlPanelClasses"></a>Control Panel Classes</h3>
+      <dl>
+        <dt># ControlPanelClasses</dt>
+        <dt>ControlPanelClasses()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"oxygen recharger"</li>
+          <li>"single shield recharger"</li>
+          <li>"double shield recharger"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"triple shield recharger"</li>
+          <li>"light switch"</li>
+          <li>"platform switch"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"tag switch"</li>
+          <li>"pattern buffer"</li>
+          <li>"terminal"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="ControlPanelTypes"></a>Control Panel Types</h3>
+      <dl>
+        <dt># ControlPanelTypes</dt>
+        <dt>ControlPanelTypes()</dt>
+        <dt>ControlPanelTypes[control_panel_type]</dt>
+        <dd>
+          <dl>
+      <dt>.active_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">bitmap index when control panel is active</p>
+            </dd>
+      <dt>.class<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">class of this control panel type</p>
+            </dd>
+      <dt>.collection<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">collection this control panel belongs to</p>
+            </dd>
+      <dt>.inactive_texture_index<span class="access"> (read-only)</span> <span class="version">20080707</span></dt>
+            <dd>
+              <p class="description">bitmap index when control panel is inactive/destroyed</p>
+            </dd>
+    </dl>
+        </dd>
+      </dl>
+      <h3><a name="DamageTypes"></a>Damage</h3>
+      <dl>
+        <dt># DamageTypes</dt>
+        <dt>DamageTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"explosion"</li>
+          <li>"staff"</li>
+          <li>"projectile"</li>
+          <li>"absorbed"</li>
+          <li>"flame"</li>
+          <li>"claws"</li>
+          <li>"alien weapon"</li>
+          <li>"hulk slap"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"compiler"</li>
+          <li>"fusion"</li>
+          <li>"hunter"</li>
+          <li>"fists"</li>
+          <li>"teleporter"</li>
+          <li>"defender"</li>
+          <li>"yeti claws"</li>
+          <li>"yeti projectile"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"crushing"</li>
+          <li>"lava"</li>
+          <li>"suffocation"</li>
+          <li>"goo"</li>
+          <li>"energy drain"</li>
+          <li>"oxygen drain"</li>
+          <li>"drone"</li>
+          <li>"shotgun"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="DifficultyTypes"></a>Difficulty</h3>
+      <dl>
+        <dt># DifficultyTypes</dt>
+        <dt>DifficultyTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"kindergarten"</li>
+        <li>"easy"</li>
+        <li>"normal"</li>
+        <li>"major damage"</li>
+        <li>"total carnage"</li>
+      </ul>
+      <h3><a name="EffectTypes"></a>Effects</h3>
+      <dl>
+        <dt># EffectTypes</dt>
+        <dt>EffectTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"rocket explosion"</li>
+          <li>"rocket contrail"</li>
+          <li>"grenade explosion"</li>
+          <li>"grenade contrail"</li>
+          <li>"bullet ricochet"</li>
+          <li>"alien weapon ricochet"</li>
+          <li>"flamethrower burst"</li>
+          <li>"fighter blood splash"</li>
+          <li>"player blood splash"</li>
+          <li>"civilian blood splash"</li>
+          <li>"assimilated civilian blood splash"</li>
+          <li>"enforcer blood splash"</li>
+          <li>"compiler bolt minor detonation"</li>
+          <li>"compiler bolt major detonation"</li>
+          <li>"compiler bolt major contrail"</li>
+          <li>"fighter projectile detonation"</li>
+          <li>"fighter melee detonation"</li>
+          <li>"hunter projectile detonation"</li>
+          <li>"hunter spark"</li>
+          <li>"minor fusion detonation"</li>
+          <li>"major fusion detonation"</li>
+          <li>"major fusion contrail"</li>
+          <li>"fist detonation"</li>
+          <li>"minor defender detonation"</li>
+          <li>"major defender detonation"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"defender spark"</li>
+          <li>"trooper blood splash"</li>
+          <li>"water lamp breaking"</li>
+          <li>"lava lamp breaking"</li>
+          <li>"sewage lamp breaking"</li>
+          <li>"alien lamp breaking"</li>
+          <li>"metallic clang"</li>
+          <li>"teleport object in"</li>
+          <li>"teleport object out"</li>
+          <li>"small water splash"</li>
+          <li>"medium water splash"</li>
+          <li>"large water splash"</li>
+          <li>"large water emergence"</li>
+          <li>"small lava splash"</li>
+          <li>"medium lava splash"</li>
+          <li>"large lava splash"</li>
+          <li>"large lava emergence"</li>
+          <li>"small sewage splash"</li>
+          <li>"medium sewage splash"</li>
+          <li>"large sewage splash"</li>
+          <li>"large sewage emergence"</li>
+          <li>"small goo splash"</li>
+          <li>"medium goo splash"</li>
+          <li>"large goo splash"</li>
+          <li>"large goo emergence"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"minor hummer projectile detonation"</li>
+          <li>"major hummer projectile detonation"</li>
+          <li>"durandal hummer projectile detonation"</li>
+          <li>"hummer spark"</li>
+          <li>"cyborg projectile detonation"</li>
+          <li>"cyborg blood splash"</li>
+          <li>"minor fusion dispersal"</li>
+          <li>"major fusion dispersal"</li>
+          <li>"overloaded fusion dispersal"</li>
+          <li>"sewage yeti blood splash"</li>
+          <li>"sewage yeti projectile detonation"</li>
+          <li>"water yeti blood splash"</li>
+          <li>"lava yeti blood splash"</li>
+          <li>"lava yeti projectile detonation"</li>
+          <li>"yeti melee detonation"</li>
+          <li>"juggernaut spark"</li>
+          <li>"juggernaut missile contrail"</li>
+          <li>"small jjaro splash"</li>
+          <li>"medium jjaro splash"</li>
+          <li>"large jjaro splash"</li>
+          <li>"large jjaro emergence"</li>
+          <li>"civilian fusion blood splash"</li>
+          <li>"assimilated civilian fusion blood splash"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="EphemeraQualities"></a>Ephemera Quality</h3>
+      <dl>
+        <dt># EphemeraQualities</dt>
+        <dt>EphemeraQualities()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"off"</li>
+        <li>"low"</li>
+        <li>"medium"</li>
+        <li>"high"</li>
+        <li>"ultra"</li>
+      </ul>
+      <h3><a name="FadeTypes"></a>Faders</h3>
+      <dl>
+        <dt># FadeTypes</dt>
+        <dt>FadeTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"start cinematic fade in"</li>
+          <li>"cinematic fade in"</li>
+          <li>"long cinematic fade in"</li>
+          <li>"cinematic fade out"</li>
+          <li>"end cinematic fade out"</li>
+          <li>"red"</li>
+          <li>"big red"</li>
+          <li>"bonus"</li>
+          <li>"bright"</li>
+          <li>"long bright"</li>
+          <li>"yellow"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"big yellow"</li>
+          <li>"purple"</li>
+          <li>"cyan"</li>
+          <li>"white"</li>
+          <li>"big white"</li>
+          <li>"orange"</li>
+          <li>"long orange"</li>
+          <li>"green"</li>
+          <li>"long green"</li>
+          <li>"static"</li>
+          <li>"negative"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"big negative"</li>
+          <li>"flicker negative"</li>
+          <li>"dodge purple"</li>
+          <li>"burn cyan"</li>
+          <li>"dodge yellow"</li>
+          <li>"burn green"</li>
+          <li>"tint green"</li>
+          <li>"tint blue"</li>
+          <li>"tint orange"</li>
+          <li>"tint gross"</li>
+          <li>"tint jjaro"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="FogModes"></a>Fog Modes</h3>
+      <dl>
+        <dt># FogModes</dt>
+        <dt>FogModes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"linear"</li>
+        <li>"exp"</li>
+        <li>"exp2"</li>
+      </ul>
+      <h3><a name="GameTypes"></a>Game Types</h3>
+      <dl>
+        <dt># GameTypes</dt>
+        <dt>GameTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"kill monsters"</li>
+          <li>"cooperative play"</li>
+          <li>"capture the flag"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"king of the hill"</li>
+          <li>"kill the man with the ball"</li>
+          <li>"defense"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"rugby"</li>
+          <li>"tag"</li>
+          <li>"netscript"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="ItemKinds"></a>Item Kinds</h3>
+      <dl>
+        <dt># ItemKinds</dt>
+        <dt>ItemKinds()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"weapon"</li>
+        <li>"ammunition"</li>
+        <li>"powerup"</li>
+        <li>"item"</li>
+        <li>"weapon powerup"</li>
+        <li>"ball"</li>
+      </ul>
+      <h3><a name="ItemTypes"></a>Item Types</h3>
+      <dl>
+        <dt># ItemTypes</dt>
+        <dt>ItemTypes()</dt>
+        <dt>ItemTypes[item_type]</dt>
+        <dd>
+          <dl>
+      <dt>.initial_count <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">how many items of this type are placed in the level during initial placement</p>
+            </dd>
+	  <dt>.kind<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">kind of item this is</p>
+            </dd>
+      <dt>.maximum_count <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">maximum number of this type of item in the level and in player inventories</p>
+            </dd>
+	  <dt>.maximum_inventory <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">maximum number of this type of item players can carry</p>
+            </dd>
+      <dt>.minimum_count <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">minimum number of this type of item in the level and in player inventories</p>
+            </dd>
+      <dt>.random_chance <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">chance from 0 to 1.0 this item will appear in a respawn period</p>
+            </dd>
+      <dt>.random_location <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether items of this type spawn in random locations</p>
+            </dd>
+      <dt>.total_available <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">total number of items of this type that can be spawned in this level</p>
+              <p class="note">-1 means infinite items are available </p>
+              <p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before item placement is done </p>
+            </dd>
       
 		
 		
@@ -2757,333 +3452,405 @@ If you do this, you should customize them all at the beginning of the script. Ch
 		
 		
       
-    </dl></dd>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"knife"</li>
-<li>"pistol"</li>
-<li>"pistol ammo"</li>
-<li>"fusion pistol"</li>
-<li>"fusion pistol ammo"</li>
-<li>"assault rifle"</li>
-<li>"assault rifle ammo"</li>
-<li>"assault rifle grenades"</li>
-<li>"missile launcher"</li>
-<li>"missile launcher ammo"</li>
-<li>"invisibility"</li>
-<li>"invincibility"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"infravision"</li>
-<li>"alien weapon"</li>
-<li>"alien weapon ammo"</li>
-<li>"flamethrower"</li>
-<li>"flamethrower ammo"</li>
-<li>"extravision"</li>
-<li>"oxygen"</li>
-<li>"single health"</li>
-<li>"double health"</li>
-<li>"triple health"</li>
-<li>"shotgun"</li>
-<li>"shotgun ammo"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"key"</li>
-<li>"uplink chip"</li>
-<li>"light blue ball"</li>
-<li>"ball"</li>
-<li>"violet ball"</li>
-<li>"yellow ball"</li>
-<li>"brown ball"</li>
-<li>"orange ball"</li>
-<li>"blue ball"</li>
-<li>"green ball"</li>
-<li>"smg"</li>
-<li>"smg ammo"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="LightFunctions"></a>Light Functions</h3>
-<dl>
-<dt># LightFunctions</dt>
-<dt>LightFunctions()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"constant"</li>
-<li>"linear"</li>
-<li>"smooth"</li>
-<li>"flicker"</li>
-</ul>
-<h3>
-<a name="LightPresets"></a>Light Presets</h3>
-<dl>
-<dt># LightPresets</dt>
-<dt>LightPresets()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"normal"</li>
-<li>"strobe"</li>
-<li>"media"</li>
-</ul>
-<h3>
-<a name="LightStates"></a>Light States</h3>
-<dl>
-<dt># LightStates</dt>
-<dt>LightStates()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"becoming active"</li>
-<li>"primary active"</li>
-<li>"secondary active"</li>
-<li>"becoming inactive"</li>
-<li>"primary inactive"</li>
-<li>"secondary inactive"</li>
-</ul>
-<h3>
-<a name="MediaTypes"></a>Media</h3>
-<dl>
-<dt># MediaTypes</dt>
-<dt>MediaTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"water"</li>
-<li>"lava"</li>
-<li>"goo"</li>
-<li>"sewage"</li>
-<li>"jjaro"</li>
-</ul>
-<h3>
-<a name="MonsterActions"></a>Monster Actions</h3>
-<dl>
-<dt># MonsterActions</dt>
-<dt>MonsterActions()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"stationary"</li>
-<li>"waiting to attack again"</li>
-<li>"moving"</li>
-<li>"attacking close"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"attacking far"</li>
-<li>"being hit"</li>
-<li>"dying hard"</li>
-<li>"dying soft"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"dying flaming"</li>
-<li>"teleporting"</li>
-<li>"teleporting in"</li>
-<li>"teleporting out"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="MonsterClasses"></a>Monster Classes</h3>
-<dl>
-<dt># MonsterClasses</dt>
-<dt>MonsterClasses()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"player"</li>
-<li>"bob"</li>
-<li>"madd"</li>
-<li>"possessed drone"</li>
-<li>"defender"</li>
-<li>"fighter"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"trooper"</li>
-<li>"hunter"</li>
-<li>"enforcer"</li>
-<li>"juggernaut"</li>
-<li>"drone"</li>
-<li>"compiler"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"cyborg"</li>
-<li>"explodabob"</li>
-<li>"tick"</li>
-<li>"yeti"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="MonsterModes"></a>Monster Modes</h3>
-<dl>
-<dt># MonsterModes</dt>
-<dt>MonsterModes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"locked"</li>
-<li>"losing lock"</li>
-<li>"lost lock"</li>
-<li>"unlocked"</li>
-<li>"running"</li>
-</ul>
-<h3>
-<a name="MonsterTypes"></a>Monsters</h3>
-<dl>
-<dt># MonsterTypes</dt>
-<dt>MonsterTypes()</dt>
-<dt>MonsterTypes[monster_type]</dt>
-<dd><dl>
-	  <dt>.alien <span class="version">20220115</span>
-</dt>
-<dd><p class="description">moves slower on slower levels, etc.</p></dd>
-      <dt>.attacks_immediately <span class="version">20120128</span>
-</dt>
-<dd><p class="description">monster will try an attack immediately</p></dd>
-	  <dt>.berserker <span class="version">20220115</span>
-</dt>
-<dd><p class="description">below 1/4 vitality, this monster goes berserk</p></dd>
-	  <dt>.can_die_in_flames <span class="version">20220115</span>
-</dt>
-<dd><p class="description">uses humanoid dying shape</p></dd>
-	  <dt>.can_teleport_under_media <span class="version">20220115</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.cannot_attack <span class="version">20220115</span>
-</dt>
-<dd><p class="description">monster has no weapons and cannot attack (runs constantly to safety)</p></dd>
-      <dt>.cannot_be_dropped <span class="version">20120128</span>
-</dt>
-<dd><p class="description">monster cannot be skipped during placement</p></dd>
-	  <dt>.cannot_fire_backward <span class="version">20220115</span>
-</dt>
-<dd><p class="description">monster can’t turn more than 135 degrees</p></dd>
-	  <dt>.chooses_weapons_randomly <span class="version">20220115</span>
-</dt>
-<dd><p class="description"></p></dd>
+    </dl>
+        </dd>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"knife"</li>
+          <li>"pistol"</li>
+          <li>"pistol ammo"</li>
+          <li>"fusion pistol"</li>
+          <li>"fusion pistol ammo"</li>
+          <li>"assault rifle"</li>
+          <li>"assault rifle ammo"</li>
+          <li>"assault rifle grenades"</li>
+          <li>"missile launcher"</li>
+          <li>"missile launcher ammo"</li>
+          <li>"invisibility"</li>
+          <li>"invincibility"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"infravision"</li>
+          <li>"alien weapon"</li>
+          <li>"alien weapon ammo"</li>
+          <li>"flamethrower"</li>
+          <li>"flamethrower ammo"</li>
+          <li>"extravision"</li>
+          <li>"oxygen"</li>
+          <li>"single health"</li>
+          <li>"double health"</li>
+          <li>"triple health"</li>
+          <li>"shotgun"</li>
+          <li>"shotgun ammo"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"key"</li>
+          <li>"uplink chip"</li>
+          <li>"light blue ball"</li>
+          <li>"ball"</li>
+          <li>"violet ball"</li>
+          <li>"yellow ball"</li>
+          <li>"brown ball"</li>
+          <li>"orange ball"</li>
+          <li>"blue ball"</li>
+          <li>"green ball"</li>
+          <li>"smg"</li>
+          <li>"smg ammo"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="LightFunctions"></a>Light Functions</h3>
+      <dl>
+        <dt># LightFunctions</dt>
+        <dt>LightFunctions()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"constant"</li>
+        <li>"linear"</li>
+        <li>"smooth"</li>
+        <li>"flicker"</li>
+      </ul>
+      <h3><a name="LightPresets"></a>Light Presets</h3>
+      <dl>
+        <dt># LightPresets</dt>
+        <dt>LightPresets()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"normal"</li>
+        <li>"strobe"</li>
+        <li>"media"</li>
+      </ul>
+      <h3><a name="LightStates"></a>Light States</h3>
+      <dl>
+        <dt># LightStates</dt>
+        <dt>LightStates()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"becoming active"</li>
+        <li>"primary active"</li>
+        <li>"secondary active"</li>
+        <li>"becoming inactive"</li>
+        <li>"primary inactive"</li>
+        <li>"secondary inactive"</li>
+      </ul>
+      <h3><a name="MediaTypes"></a>Media</h3>
+      <dl>
+        <dt># MediaTypes</dt>
+        <dt>MediaTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"water"</li>
+        <li>"lava"</li>
+        <li>"goo"</li>
+        <li>"sewage"</li>
+        <li>"jjaro"</li>
+      </ul>
+      <h3><a name="MonsterActions"></a>Monster Actions</h3>
+      <dl>
+        <dt># MonsterActions</dt>
+        <dt>MonsterActions()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"stationary"</li>
+          <li>"waiting to attack again"</li>
+          <li>"moving"</li>
+          <li>"attacking close"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"attacking far"</li>
+          <li>"being hit"</li>
+          <li>"dying hard"</li>
+          <li>"dying soft"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"dying flaming"</li>
+          <li>"teleporting"</li>
+          <li>"teleporting in"</li>
+          <li>"teleporting out"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="MonsterClasses"></a>Monster Classes</h3>
+      <dl>
+        <dt># MonsterClasses</dt>
+        <dt>MonsterClasses()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"player"</li>
+          <li>"bob"</li>
+          <li>"madd"</li>
+          <li>"possessed drone"</li>
+          <li>"defender"</li>
+          <li>"fighter"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"trooper"</li>
+          <li>"hunter"</li>
+          <li>"enforcer"</li>
+          <li>"juggernaut"</li>
+          <li>"drone"</li>
+          <li>"compiler"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"cyborg"</li>
+          <li>"explodabob"</li>
+          <li>"tick"</li>
+          <li>"yeti"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="MonsterModes"></a>Monster Modes</h3>
+      <dl>
+        <dt># MonsterModes</dt>
+        <dt>MonsterModes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"locked"</li>
+        <li>"losing lock"</li>
+        <li>"lost lock"</li>
+        <li>"unlocked"</li>
+        <li>"running"</li>
+      </ul>
+      <h3><a name="MonsterTypes"></a>Monsters</h3>
+      <dl>
+        <dt># MonsterTypes</dt>
+        <dt>MonsterTypes()</dt>
+        <dt>MonsterTypes[monster_type]</dt>
+        <dd>
+          <dl>
+	  <dt>.alien <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">moves slower on slower levels, etc.</p>
+            </dd>
+      <dt>.attacks_immediately <span class="version">20120128</span></dt>
+            <dd>
+              <p class="description">monster will try an attack immediately</p>
+            </dd>
+	  <dt>.berserker <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">below 1/4 vitality, this monster goes berserk</p>
+            </dd>
+	  <dt>.can_die_in_flames <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">uses humanoid dying shape</p>
+            </dd>
+	  <dt>.can_teleport_under_media <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.cannot_attack <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">monster has no weapons and cannot attack (runs constantly to safety)</p>
+            </dd>
+      <dt>.cannot_be_dropped <span class="version">20120128</span></dt>
+            <dd>
+              <p class="description">monster cannot be skipped during placement</p>
+            </dd>
+	  <dt>.cannot_fire_backward <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">monster can’t turn more than 135 degrees</p>
+            </dd>
+	  <dt>.chooses_weapons_randomly <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
       <dt>.class</dt>
-<dd><p class="description">class of monster type</p></dd>
-	  <dt>.collection<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">collection of monster type</p></dd>
-	  <dt>.clut_index<span class="access"> (read-only)</span> <span class="version">20210408</span>
-</dt>
-<dd><p class="description">color table of monster type</p></dd>
+            <dd>
+              <p class="description">class of monster type</p>
+            </dd>
+	  <dt>.collection<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">collection of monster type</p>
+            </dd>
+	  <dt>.clut_index<span class="access"> (read-only)</span> <span class="version">20210408</span></dt>
+            <dd>
+              <p class="description">color table of monster type</p>
+            </dd>
       <dt>
     .enemies[monster_class]
   </dt>
-<dd><p class="description">whether monster class is an enemy</p></dd>
-	  <dt>.enlarged <span class="version">20220115</span>
-</dt>
-<dd><p class="description">monster is 1.25 times normal height</p></dd>
-	  <dt>.fires_symmetrically <span class="version">20220115</span>
-</dt>
-<dd><p class="description">fires at +/- dy, simultaneously</p></dd>
-	  <dt>.flies <span class="version">20220115</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.floats <span class="version">20220115</span>
-</dt>
-<dd><p class="description">exclusive from flies; forces the monster to take delta-h gradually</p></dd>
+            <dd>
+              <p class="description">whether monster class is an enemy</p>
+            </dd>
+	  <dt>.enlarged <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">monster is 1.25 times normal height</p>
+            </dd>
+	  <dt>.fires_symmetrically <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">fires at +/- dy, simultaneously</p>
+            </dd>
+	  <dt>.flies <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.floats <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">exclusive from flies; forces the monster to take delta-h gradually</p>
+            </dd>
       <dt>
     .friends[monster_class]
   </dt>
-<dd><p class="description">whether monster class is a friend</p></dd>
-	  <dt>.has_delayed_hard_death <span class="version">20220115</span>
-</dt>
-<dd><p class="description">always dies soft, then switches to hard</p></dd>
-	  <dt>.has_nuclear_hard_death <span class="version">20220115</span>
-</dt>
-<dd><p class="description">player’s screen whites out and slowly recovers</p></dd>
-      <dt>.impact_effect<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of effect generated when monster gets hit by a bleeding projectile</p></dd>
-      <dt>.height<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">height of monster</p></dd>
+            <dd>
+              <p class="description">whether monster class is a friend</p>
+            </dd>
+	  <dt>.has_delayed_hard_death <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">always dies soft, then switches to hard</p>
+            </dd>
+	  <dt>.has_nuclear_hard_death <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">player’s screen whites out and slowly recovers</p>
+            </dd>
+      <dt>.impact_effect<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">type of effect generated when monster gets hit by a bleeding projectile</p>
+            </dd>
+      <dt>.height<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">height of monster</p>
+            </dd>
 	  <dt>
     .immunities[damage_type]
   </dt>
-<dd><p class="description">whether monster type is immune to damage type</p></dd>
-	  <dt>.impact_effect<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description"></p></dd>
-      <dt>.initial_count <span class="version">20111201</span>
-</dt>
-<dd><p class="description">how many monsters of this type are placed in the level during initial placement</p></dd>
-	  <dt>.invisible <span class="version">20220115</span>
-</dt>
-<dd><p class="description">this monster uses _xfer_invisibility</p></dd>
+            <dd>
+              <p class="description">whether monster type is immune to damage type</p>
+            </dd>
+	  <dt>.impact_effect<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+      <dt>.initial_count <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">how many monsters of this type are placed in the level during initial placement</p>
+            </dd>
+	  <dt>.invisible <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">this monster uses _xfer_invisibility</p>
+            </dd>
       <dt>.item</dt>
-<dd><p class="description">type of item the monster drops when it dies</p></dd>
-	  <dt>.kamikaze <span class="version">20220115</span>
-</dt>
-<dd><p class="description">monster does shrapnel damage and will suicide if close enough to target</p></dd>
-      <dt>.major <span class="version">20120128</span>
-</dt>
-<dd><p class="description">monster is major</p></dd>
-      <dt>.maximum_count <span class="version">20111201</span>
-</dt>
-<dd><p class="description">maximum number of this type of monster in the level</p></dd>
-      <dt>.melee_impact_effect<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">type of effect generated when monster gets hit by a melee projectile</p></dd>
-      <dt>.minimum_count <span class="version">20111201</span>
-</dt>
-<dd><p class="description">minimum number of this type of monster in the level</p></dd>
-      <dt>.minor <span class="version">20120128</span>
-</dt>
-<dd><p class="description">monster is minor</p></dd>
-	  <dt>.not_afraid_of_goo <span class="version">20220115</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.not_afraid_of_lava <span class="version">20220115</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.not_afraid_of_sewage <span class="version">20220115</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.not_afraid_of_water <span class="version">20220115</span>
-</dt>
-<dd><p class="description"></p></dd>
-	  <dt>.omniscient <span class="version">20220115</span>
-</dt>
-<dd><p class="description">ignores line-of-sight during find_closest_appropriate_target()</p></dd>
-      <dt>.radius<span class="access"> (read-only)</span>
-</dt>
-<dd><p class="description">radius of monster</p></dd>
-      <dt>.random_chance <span class="version">20111201</span>
-</dt>
-<dd><p class="description">chance from 0 to 1.0 this monster will appear in a respawn period</p></dd>
-      <dt>.random_location <span class="version">20111201</span>
-</dt>
-<dd><p class="description">whether monsters of this type spawn in random locations</p></dd>
-	  <dt>.subtly_invisible <span class="version">20220115</span>
-</dt>
-<dd><p class="description">this monster uses _xfer_subtle_invisibility</p></dd>
-	  <dt>.tiny <span class="version">20220115</span>
-</dt>
-<dd><p class="description">0.25-size normal height</p></dd>
-      <dt>.total_available <span class="version">20111201</span>
-</dt>
-<dd>
-<p class="description">total number of monsters of this type that can be spawned in this level</p>
-<p class="note">-1 means infinite monsters are available </p>
-<p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before monster placement is done </p>
-</dd>
-	  <dt>.uses_sniper_ledges <span class="version">20220115</span>
-</dt>
-<dd><p class="description">sit on ledges and hurl shit at the player (ranged attack monsters only</p></dd>
-	  <dt>.vitality<span class="access"> (read-only)</span> <span class="version">20220115</span>
-</dt>
-<dd><p class="description">monster’s initial vitality</p></dd>
+            <dd>
+              <p class="description">type of item the monster drops when it dies</p>
+            </dd>
+	  <dt>.kamikaze <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">monster does shrapnel damage and will suicide if close enough to target</p>
+            </dd>
+      <dt>.major <span class="version">20120128</span></dt>
+            <dd>
+              <p class="description">monster is major</p>
+            </dd>
+      <dt>.maximum_count <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">maximum number of this type of monster in the level</p>
+            </dd>
+      <dt>.melee_impact_effect<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">type of effect generated when monster gets hit by a melee projectile</p>
+            </dd>
+      <dt>.minimum_count <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">minimum number of this type of monster in the level</p>
+            </dd>
+      <dt>.minor <span class="version">20120128</span></dt>
+            <dd>
+              <p class="description">monster is minor</p>
+            </dd>
+	  <dt>.not_afraid_of_goo <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.not_afraid_of_lava <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.not_afraid_of_sewage <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.not_afraid_of_water <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">
+              </p>
+            </dd>
+	  <dt>.omniscient <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">ignores line-of-sight during find_closest_appropriate_target()</p>
+            </dd>
+      <dt>.radius<span class="access"> (read-only)</span></dt>
+            <dd>
+              <p class="description">radius of monster</p>
+            </dd>
+      <dt>.random_chance <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">chance from 0 to 1.0 this monster will appear in a respawn period</p>
+            </dd>
+      <dt>.random_location <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">whether monsters of this type spawn in random locations</p>
+            </dd>
+	  <dt>.subtly_invisible <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">this monster uses _xfer_subtle_invisibility</p>
+            </dd>
+	  <dt>.tiny <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">0.25-size normal height</p>
+            </dd>
+      <dt>.total_available <span class="version">20111201</span></dt>
+            <dd>
+              <p class="description">total number of monsters of this type that can be spawned in this level</p>
+              <p class="note">-1 means infinite monsters are available </p>
+              <p class="note">setting this to anything but -1 will only be effective if changed immediately when the script runs, before monster placement is done </p>
+            </dd>
+	  <dt>.uses_sniper_ledges <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">sit on ledges and hurl shit at the player (ranged attack monsters only</p>
+            </dd>
+	  <dt>.vitality<span class="access"> (read-only)</span> <span class="version">20220115</span></dt>
+            <dd>
+              <p class="description">monster’s initial vitality</p>
+            </dd>
       <dt>
     .weaknesses[damage type]
   </dt>
-<dd><p class="description">whether monster type has a weakness to damage type</p></dd>
-      <dt>.waits_with_clear_shot <span class="version">20120128</span>
-</dt>
-<dd><p class="description">monster will sit and fire if he has a clear shot</p></dd>
+            <dd>
+              <p class="description">whether monster type has a weakness to damage type</p>
+            </dd>
+      <dt>.waits_with_clear_shot <span class="version">20120128</span></dt>
+            <dd>
+              <p class="description">monster will sit and fire if he has a clear shot</p>
+            </dd>
       
 		
 		
@@ -3133,620 +3900,661 @@ If you do this, you should customize them all at the beginning of the script. Ch
 		
 		
       
-    </dl></dd>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"player"</li>
-<li>"minor tick"</li>
-<li>"major tick"</li>
-<li>"kamikaze tick"</li>
-<li>"minor compiler"</li>
-<li>"major compiler"</li>
-<li>"minor invisible compiler"</li>
-<li>"major invisible compiler"</li>
-<li>"minor fighter"</li>
-<li>"major fighter"</li>
-<li>"minor projectile fighter"</li>
-<li>"major projectile fighter"</li>
-<li>"green bob"</li>
-<li>"blue bob"</li>
-<li>"security bob"</li>
-<li>"explodabob"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"minor drone"</li>
-<li>"major drone"</li>
-<li>"big minor drone"</li>
-<li>"big major drone"</li>
-<li>"possessed drone"</li>
-<li>"minor cyborg"</li>
-<li>"major cyborg"</li>
-<li>"minor flame cyborg"</li>
-<li>"major flame cyborg"</li>
-<li>"minor enforcer"</li>
-<li>"major enforcer"</li>
-<li>"minor hunter"</li>
-<li>"major hunter"</li>
-<li>"minor trooper"</li>
-<li>"major trooper"</li>
-<li>"mother of all cyborgs"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"mother of all hunters"</li>
-<li>"sewage yeti"</li>
-<li>"water yeti"</li>
-<li>"lava yeti"</li>
-<li>"minor defender"</li>
-<li>"major defender"</li>
-<li>"minor juggernaut"</li>
-<li>"major juggernaut"</li>
-<li>"tiny pfhor"</li>
-<li>"tiny bob"</li>
-<li>"tiny yeti"</li>
-<li>"green vacbob"</li>
-<li>"blue vacbob"</li>
-<li>"security vacbob"</li>
-<li>"explodavacbob"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="OverlayColors"></a>Overlay Colors</h3>
-<dl>
-<dt># OverlayColors</dt>
-<dt>OverlayColors()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"green"</li>
-<li>"white"</li>
-<li>"red"</li>
-<li>"dark green"</li>
-<li>"cyan"</li>
-<li>"yellow"</li>
-<li>"dark red"</li>
-<li>"blue"</li>
-</ul>
-<h3>
-<a name="PlatformTypes"></a>Platform Types</h3>
-<dl>
-<dt># PlatformTypes</dt>
-<dt>PlatformTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"spht door"</li>
-<li>"spht split door"</li>
-<li>"locked spht door"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"spht platform"</li>
-<li>"noisy spht platform"</li>
-<li>"heavy spht door"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"pfhor door"</li>
-<li>"heavy spht platform"</li>
-<li>"pfhor platform"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="PlayerColors"></a>Player and Team Colors</h3>
-<dl>
-<dt># PlayerColors</dt>
-<dt>PlayerColors()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"slate"</li>
-<li>"red"</li>
-<li>"violet"</li>
-<li>"yellow"</li>
-<li>"white"</li>
-<li>"orange"</li>
-<li>"blue"</li>
-<li>"green"</li>
-</ul>
-<h3>
-<a name="PolygonTypes"></a>Polygons</h3>
-<dl>
-<dt># PolygonTypes</dt>
-<dt>PolygonTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"normal"</li>
-<li>"item impassable"</li>
-<li>"monster impassable"</li>
-<li>"hill"</li>
-<li>"base"</li>
-<li>"platform"</li>
-<li>"light on trigger"</li>
-<li>"platform on trigger"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"light off trigger"</li>
-<li>"platform off trigger"</li>
-<li>"teleporter"</li>
-<li>"zone border"</li>
-<li>"goal"</li>
-<li>"visible monster trigger"</li>
-<li>"invisible monster trigger"</li>
-<li>"dual monster trigger"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"item trigger"</li>
-<li>"must be explored"</li>
-<li>"automatic exit"</li>
-<li>"minor ouch"</li>
-<li>"major ouch"</li>
-<li>"glue"</li>
-<li>"glue trigger"</li>
-<li>"superglue"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="ProjectileTypes"></a>Projectiles</h3>
-<dl>
-<dt># ProjectileTypes</dt>
-<dt>ProjectileTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"missile"</li>
-<li>"grenade"</li>
-<li>"pistol bullet"</li>
-<li>"rifle bullet"</li>
-<li>"shotgun bullet"</li>
-<li>"staff"</li>
-<li>"staff bolt"</li>
-<li>"flamethrower burst"</li>
-<li>"compiler bolt minor"</li>
-<li>"compiler bolt major"</li>
-<li>"alien weapon"</li>
-<li>"fusion bolt minor"</li>
-<li>"fusion bolt major"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"hunter"</li>
-<li>"fist"</li>
-<li>"armageddon sphere"</li>
-<li>"armageddon electricity"</li>
-<li>"juggernaut rocket"</li>
-<li>"trooper bullet"</li>
-<li>"trooper grenade"</li>
-<li>"minor defender"</li>
-<li>"major defender"</li>
-<li>"juggernaut missile"</li>
-<li>"minor energy drain"</li>
-<li>"major energy drain"</li>
-<li>"oxygen drain"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"minor hummer"</li>
-<li>"major hummer"</li>
-<li>"durandal hummer"</li>
-<li>"minor cyborg ball"</li>
-<li>"major cyborg ball"</li>
-<li>"ball"</li>
-<li>"minor fusion dispersal"</li>
-<li>"major fusion dispersal"</li>
-<li>"overloaded fusion dispersal"</li>
-<li>"yeti"</li>
-<li>"sewage yeti"</li>
-<li>"lava yeti"</li>
-<li>"smg bullet"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="SceneryTypes"></a>Scenery</h3>
-<dl>
-<dt># SceneryTypes</dt>
-<dt>SceneryTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"light dirt"</li>
-<li>"dark dirt"</li>
-<li>"lava bones"</li>
-<li>"lava bone"</li>
-<li>"ribs"</li>
-<li>"skull"</li>
-<li>"hanging light 1"</li>
-<li>"hanging light 2"</li>
-<li>"small cylinder"</li>
-<li>"large cylinder"</li>
-<li>"block 1"</li>
-<li>"block 2"</li>
-<li>"block 3"</li>
-<li>"pistol clip"</li>
-<li>"water short light"</li>
-<li>"water long light"</li>
-<li>"siren"</li>
-<li>"rocks"</li>
-<li>"blood drops"</li>
-<li>"water thing"</li>
-<li>"gun"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"bob remains"</li>
-<li>"puddles"</li>
-<li>"big puddles"</li>
-<li>"security monitor"</li>
-<li>"water alien supply can"</li>
-<li>"machine"</li>
-<li>"staff"</li>
-<li>"sewage short light"</li>
-<li>"sewage long light"</li>
-<li>"junk"</li>
-<li>"antenna"</li>
-<li>"big antenna"</li>
-<li>"sewage alien supply can"</li>
-<li>"sewage bones"</li>
-<li>"sewage big bones"</li>
-<li>"pfhor pieces"</li>
-<li>"bob pieces"</li>
-<li>"bob blood"</li>
-<li>"alien short light"</li>
-<li>"alien long light"</li>
-<li>"alien ceiling rod light"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"bulbous yellow alien object"</li>
-<li>"square gray organic object"</li>
-<li>"pfhor skeleton"</li>
-<li>"pfhor mask"</li>
-<li>"green stuff"</li>
-<li>"hunter shield"</li>
-<li>"alien bones"</li>
-<li>"alien sludge"</li>
-<li>"jjaro short light"</li>
-<li>"jjaro long light"</li>
-<li>"weird rod"</li>
-<li>"pfhor ship"</li>
-<li>"sun"</li>
-<li>"large glass container"</li>
-<li>"nub 1"</li>
-<li>"nub 2"</li>
-<li>"lh'owon"</li>
-<li>"floor whip antenna"</li>
-<li>"ceiling whip antenna"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="ScoringModes"></a>Scoring Modes</h3>
-<dl>
-<dt># ScoringModes</dt>
-<dt>ScoringModes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"most points"</li>
-<li>"most time"</li>
-<li>"least points"</li>
-<li>"least time"</li>
-</ul>
-<h3>
-<a name="SideTypes"></a>Side Types</h3>
-<dl>
-<dt># SideTypes</dt>
-<dt>SideTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"full"</li>
-<li>"high"</li>
-<li>"low"</li>
-<li>"split"</li>
-</ul>
-<h3>
-<a name="Sounds"></a>Sounds</h3>
-<dl>
-<dt># Sounds</dt>
-<dt>Sounds()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"startup"</li>
-<li>"teleport in"</li>
-<li>"teleport out"</li>
-<li>"crushed"</li>
-<li>"nuclear hard death"</li>
-<li>"absorbed"</li>
-<li>"breathing"</li>
-<li>"oxygen warning"</li>
-<li>"suffocation"</li>
-<li>"energy refuel"</li>
-<li>"oxygen refuel"</li>
-<li>"cant toggle switch"</li>
-<li>"switch on"</li>
-<li>"switch off"</li>
-<li>"puzzle switch"</li>
-<li>"chip insertion"</li>
-<li>"pattern buffer"</li>
-<li>"destroy control panel"</li>
-<li>"adjust volume"</li>
-<li>"got powerup"</li>
-<li>"get item"</li>
-<li>"bullet ricochet"</li>
-<li>"metallic ricochet"</li>
-<li>"empty gun"</li>
-<li>"spht door opening"</li>
-<li>"spht door closing"</li>
-<li>"spht door obstructed"</li>
-<li>"spht platform starting"</li>
-<li>"spht platform stopping"</li>
-<li>"loon"</li>
-<li>"smg firing"</li>
-<li>"smg reloading"</li>
-<li>"heavy spht platform starting"</li>
-<li>"heavy spht platform stopping"</li>
-<li>"fist hitting"</li>
-<li>"pistol firing"</li>
-<li>"pistol reloading"</li>
-<li>"assault rifle firing"</li>
-<li>"grenade launcher firing"</li>
-<li>"grenade expolding"</li>
-<li>"grenade flyby"</li>
-<li>"fusion firing"</li>
-<li>"fusion exploding"</li>
-<li>"fusion flyby"</li>
-<li>"fusion charging"</li>
-<li>"rocket exploding"</li>
-<li>"rocket flyby"</li>
-<li>"rocket firing"</li>
-<li>"flamethrower"</li>
-<li>"body falling"</li>
-<li>"body exploding"</li>
-<li>"bullet hit flesh"</li>
-<li>"fighter activate"</li>
-<li>"fighter wail"</li>
-<li>"fighter scream"</li>
-<li>"fighter chatter"</li>
-<li>"fighter attack"</li>
-<li>"fighter projectile hit"</li>
-<li>"fighter projectile flyby"</li>
-<li>"spht attack"</li>
-<li>"spht death"</li>
-<li>"spht hit"</li>
-<li>"spht projectile flyby"</li>
-<li>"spht projectile hit"</li>
-<li>"cyborg moving"</li>
-<li>"cyborg attack"</li>
-<li>"cyborg hit"</li>
-<li>"cyborg death"</li>
-<li>"cyborg projectile bounce"</li>
-<li>"cyborg projectile hit"</li>
-<li>"cyborg projectile flyby"</li>
-<li>"drone activate"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"drone start attack"</li>
-<li>"drone attack"</li>
-<li>"drone dying"</li>
-<li>"drone death"</li>
-<li>"drone projectile hit"</li>
-<li>"drone projectile flyby"</li>
-<li>"bob wail"</li>
-<li>"bob scream"</li>
-<li>"bob hit"</li>
-<li>"bob chatter"</li>
-<li>"assimilated bob chatter"</li>
-<li>"bob trash talk"</li>
-<li>"bob apology"</li>
-<li>"bob activation"</li>
-<li>"bob clear"</li>
-<li>"bob angry"</li>
-<li>"bob secure"</li>
-<li>"bob kill the player"</li>
-<li>"water"</li>
-<li>"sewage"</li>
-<li>"lava"</li>
-<li>"goo"</li>
-<li>"underwater"</li>
-<li>"wind"</li>
-<li>"waterfall"</li>
-<li>"siren"</li>
-<li>"fan"</li>
-<li>"spht door"</li>
-<li>"spht platform"</li>
-<li>"alien harmonics"</li>
-<li>"heavy spht platform"</li>
-<li>"light machinery"</li>
-<li>"heavy machinery"</li>
-<li>"transformer"</li>
-<li>"sparking transformer"</li>
-<li>"water drip"</li>
-<li>"walking in water"</li>
-<li>"exiting water"</li>
-<li>"entering water"</li>
-<li>"small water splash"</li>
-<li>"medium water splash"</li>
-<li>"large water splash"</li>
-<li>"walking in lava"</li>
-<li>"entering lava"</li>
-<li>"exiting lava"</li>
-<li>"small lava splash"</li>
-<li>"medium lava splash"</li>
-<li>"large lava splash"</li>
-<li>"walking in sewage"</li>
-<li>"exiting sewage"</li>
-<li>"entering sewage"</li>
-<li>"small sewage splash"</li>
-<li>"medium sewage splash"</li>
-<li>"large sewage splash"</li>
-<li>"walking in goo"</li>
-<li>"exiting goo"</li>
-<li>"entering goo"</li>
-<li>"small goo splash"</li>
-<li>"medium goo splash"</li>
-<li>"large goo splash"</li>
-<li>"major fusion firing"</li>
-<li>"major fusion charged"</li>
-<li>"assault rifle reloading"</li>
-<li>"assault rifle shell casings"</li>
-<li>"shotgun firing"</li>
-<li>"shotgun reloading"</li>
-<li>"ball bounce"</li>
-<li>"you are it"</li>
-<li>"got ball"</li>
-<li>"computer login"</li>
-<li>"computer logout"</li>
-<li>"computer page"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"heavy spht door"</li>
-<li>"heavy spht door opening"</li>
-<li>"heavy spht door closing"</li>
-<li>"heavy spht door open"</li>
-<li>"heavy spht door closed"</li>
-<li>"heavy spht door obstructed"</li>
-<li>"hunter activate"</li>
-<li>"hunter attack"</li>
-<li>"hunter dying"</li>
-<li>"hunter landing"</li>
-<li>"hunter exploding"</li>
-<li>"hunter projectile hit"</li>
-<li>"hunter projectile flyby"</li>
-<li>"enforcer activate"</li>
-<li>"enforcer attack"</li>
-<li>"enforcer projectile hit"</li>
-<li>"enforcer projectile flyby"</li>
-<li>"flickta melee attack"</li>
-<li>"flickta melee hit"</li>
-<li>"flickta projectile attack"</li>
-<li>"flickta projectile sewage hit"</li>
-<li>"flickta projectile sewage flyby"</li>
-<li>"flickta projectile lava hit"</li>
-<li>"flickta projectile lava flyby"</li>
-<li>"flickta dying"</li>
-<li>"machine binder"</li>
-<li>"machine bookpress"</li>
-<li>"machine puncher"</li>
-<li>"electric hum"</li>
-<li>"alarm"</li>
-<li>"night wind"</li>
-<li>"surface explosion"</li>
-<li>"underground explosion"</li>
-<li>"sphtkr attack"</li>
-<li>"sphtkr projectile hit"</li>
-<li>"sphtkr projectile flyby"</li>
-<li>"sphtkr hit"</li>
-<li>"sphtkr exploding"</li>
-<li>"tick chatter"</li>
-<li>"tick falling"</li>
-<li>"tick flapping"</li>
-<li>"tick exploding"</li>
-<li>"ceiling lamp exploding"</li>
-<li>"pfhor platform starting"</li>
-<li>"pfhor platform stopping"</li>
-<li>"pfhor platform"</li>
-<li>"pfhor door opening"</li>
-<li>"pfhor door closing"</li>
-<li>"pfhor door obstructed"</li>
-<li>"pfhor door"</li>
-<li>"pfhor switch off"</li>
-<li>"pfhor switch on"</li>
-<li>"juggernaut firing"</li>
-<li>"juggernaut warning"</li>
-<li>"juggernaut exploding"</li>
-<li>"juggernaut start attack"</li>
-<li>"enforcer exploding"</li>
-<li>"alien noise 1"</li>
-<li>"alien noise 2"</li>
-<li>"vacbob wail"</li>
-<li>"vacbob scream"</li>
-<li>"vacbob hit"</li>
-<li>"vacbob chatter"</li>
-<li>"assimilated vacbob chatter"</li>
-<li>"vacbob trash talk"</li>
-<li>"vacbob apology"</li>
-<li>"vacbob activation"</li>
-<li>"vacbob clear"</li>
-<li>"vacbob angry"</li>
-<li>"vacbob secure"</li>
-<li>"vacbob kill the player"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="TextureTypes"></a>Texture Types</h3>
-<dl>
-<dt># TextureTypes</dt>
-<dt>TextureTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<ul class="mnemonics">
-<li>"wall"</li>
-<li>"landscape"</li>
-<li>"sprite"</li>
-<li>"weapon in hand"</li>
-<li>"interface"</li>
-</ul>
-<h3>
-<a name="TransferModes"></a>Transfer Modes</h3>
-<dl>
-<dt># TransferModes</dt>
-<dt>TransferModes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"normal"</li>
-<li>"pulsate"</li>
-<li>"wobble"</li>
-<li>"fast wobble"</li>
-<li>"static"</li>
-<li>"landscape"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"horizontal slide"</li>
-<li>"fast horizontal slide"</li>
-<li>"vertical slide"</li>
-<li>"fast vertical slide"</li>
-<li>"wander"</li>
-<li>"fast wander"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"reverse horizontal slide" <span class="version">20231125</span>
-</li>
-<li>"reverse fast horizontal slide" <span class="version">20231125</span>
-</li>
-<li>"reverse vertical slide" <span class="version">20231125</span>
-</li>
-<li>"reverse fast vertical slide" <span class="version">20231125</span>
-</li>
-<li>"2x" <span class="version">20231125</span>
-</li>
-<li>"4x" <span class="version">20231125</span>
-</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-<h3>
-<a name="WeaponTypes"></a>Weapons</h3>
-<dl>
-<dt># WeaponTypes</dt>
-<dt>WeaponTypes()</dt>
-</dl>
-<h4>Mnemonics</h4>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"fist"</li>
-<li>"pistol"</li>
-<li>"fusion pistol"</li>
-<li>"assault rifle"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"missile launcher"</li>
-<li>"flamethrower"</li>
-<li>"alien weapon"</li>
-<li>"shotgun"</li>
-</ul></div>
-<div class="mnemonics-column"><ul class="mnemonics">
-<li>"ball"</li>
-<li>"smg"</li>
-</ul></div>
-<div class="end-mnemonics"></div>
-</div>
-<h1>
-<a name="example_icon"></a>Example Icon</h1>
+    </dl>
+        </dd>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"player"</li>
+          <li>"minor tick"</li>
+          <li>"major tick"</li>
+          <li>"kamikaze tick"</li>
+          <li>"minor compiler"</li>
+          <li>"major compiler"</li>
+          <li>"minor invisible compiler"</li>
+          <li>"major invisible compiler"</li>
+          <li>"minor fighter"</li>
+          <li>"major fighter"</li>
+          <li>"minor projectile fighter"</li>
+          <li>"major projectile fighter"</li>
+          <li>"green bob"</li>
+          <li>"blue bob"</li>
+          <li>"security bob"</li>
+          <li>"explodabob"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"minor drone"</li>
+          <li>"major drone"</li>
+          <li>"big minor drone"</li>
+          <li>"big major drone"</li>
+          <li>"possessed drone"</li>
+          <li>"minor cyborg"</li>
+          <li>"major cyborg"</li>
+          <li>"minor flame cyborg"</li>
+          <li>"major flame cyborg"</li>
+          <li>"minor enforcer"</li>
+          <li>"major enforcer"</li>
+          <li>"minor hunter"</li>
+          <li>"major hunter"</li>
+          <li>"minor trooper"</li>
+          <li>"major trooper"</li>
+          <li>"mother of all cyborgs"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"mother of all hunters"</li>
+          <li>"sewage yeti"</li>
+          <li>"water yeti"</li>
+          <li>"lava yeti"</li>
+          <li>"minor defender"</li>
+          <li>"major defender"</li>
+          <li>"minor juggernaut"</li>
+          <li>"major juggernaut"</li>
+          <li>"tiny pfhor"</li>
+          <li>"tiny bob"</li>
+          <li>"tiny yeti"</li>
+          <li>"green vacbob"</li>
+          <li>"blue vacbob"</li>
+          <li>"security vacbob"</li>
+          <li>"explodavacbob"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="MusicFadeTypes"></a>Music Fade Types</h3>
+      <dl>
+        <dt># MusicFadeTypes</dt>
+        <dt>MusicFadeTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"none"</li>
+        <li>"linear"</li>
+        <li>"sinusoidal"</li>
+      </ul>
+      <h3><a name="OverlayColors"></a>Overlay Colors</h3>
+      <dl>
+        <dt># OverlayColors</dt>
+        <dt>OverlayColors()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"green"</li>
+        <li>"white"</li>
+        <li>"red"</li>
+        <li>"dark green"</li>
+        <li>"cyan"</li>
+        <li>"yellow"</li>
+        <li>"dark red"</li>
+        <li>"blue"</li>
+      </ul>
+      <h3><a name="PlatformTypes"></a>Platform Types</h3>
+      <dl>
+        <dt># PlatformTypes</dt>
+        <dt>PlatformTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"spht door"</li>
+          <li>"spht split door"</li>
+          <li>"locked spht door"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"spht platform"</li>
+          <li>"noisy spht platform"</li>
+          <li>"heavy spht door"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"pfhor door"</li>
+          <li>"heavy spht platform"</li>
+          <li>"pfhor platform"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="PlayerColors"></a>Player and Team Colors</h3>
+      <dl>
+        <dt># PlayerColors</dt>
+        <dt>PlayerColors()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"slate"</li>
+        <li>"red"</li>
+        <li>"violet"</li>
+        <li>"yellow"</li>
+        <li>"white"</li>
+        <li>"orange"</li>
+        <li>"blue"</li>
+        <li>"green"</li>
+      </ul>
+      <h3><a name="PolygonTypes"></a>Polygons</h3>
+      <dl>
+        <dt># PolygonTypes</dt>
+        <dt>PolygonTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"normal"</li>
+          <li>"item impassable"</li>
+          <li>"monster impassable"</li>
+          <li>"hill"</li>
+          <li>"base"</li>
+          <li>"platform"</li>
+          <li>"light on trigger"</li>
+          <li>"platform on trigger"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"light off trigger"</li>
+          <li>"platform off trigger"</li>
+          <li>"teleporter"</li>
+          <li>"zone border"</li>
+          <li>"goal"</li>
+          <li>"visible monster trigger"</li>
+          <li>"invisible monster trigger"</li>
+          <li>"dual monster trigger"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"item trigger"</li>
+          <li>"must be explored"</li>
+          <li>"automatic exit"</li>
+          <li>"minor ouch"</li>
+          <li>"major ouch"</li>
+          <li>"glue"</li>
+          <li>"glue trigger"</li>
+          <li>"superglue"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="ProjectileTypes"></a>Projectiles</h3>
+      <dl>
+        <dt># ProjectileTypes</dt>
+        <dt>ProjectileTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"missile"</li>
+          <li>"grenade"</li>
+          <li>"pistol bullet"</li>
+          <li>"rifle bullet"</li>
+          <li>"shotgun bullet"</li>
+          <li>"staff"</li>
+          <li>"staff bolt"</li>
+          <li>"flamethrower burst"</li>
+          <li>"compiler bolt minor"</li>
+          <li>"compiler bolt major"</li>
+          <li>"alien weapon"</li>
+          <li>"fusion bolt minor"</li>
+          <li>"fusion bolt major"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"hunter"</li>
+          <li>"fist"</li>
+          <li>"armageddon sphere"</li>
+          <li>"armageddon electricity"</li>
+          <li>"juggernaut rocket"</li>
+          <li>"trooper bullet"</li>
+          <li>"trooper grenade"</li>
+          <li>"minor defender"</li>
+          <li>"major defender"</li>
+          <li>"juggernaut missile"</li>
+          <li>"minor energy drain"</li>
+          <li>"major energy drain"</li>
+          <li>"oxygen drain"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"minor hummer"</li>
+          <li>"major hummer"</li>
+          <li>"durandal hummer"</li>
+          <li>"minor cyborg ball"</li>
+          <li>"major cyborg ball"</li>
+          <li>"ball"</li>
+          <li>"minor fusion dispersal"</li>
+          <li>"major fusion dispersal"</li>
+          <li>"overloaded fusion dispersal"</li>
+          <li>"yeti"</li>
+          <li>"sewage yeti"</li>
+          <li>"lava yeti"</li>
+          <li>"smg bullet"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="SceneryTypes"></a>Scenery</h3>
+      <dl>
+        <dt># SceneryTypes</dt>
+        <dt>SceneryTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"light dirt"</li>
+          <li>"dark dirt"</li>
+          <li>"lava bones"</li>
+          <li>"lava bone"</li>
+          <li>"ribs"</li>
+          <li>"skull"</li>
+          <li>"hanging light 1"</li>
+          <li>"hanging light 2"</li>
+          <li>"small cylinder"</li>
+          <li>"large cylinder"</li>
+          <li>"block 1"</li>
+          <li>"block 2"</li>
+          <li>"block 3"</li>
+          <li>"pistol clip"</li>
+          <li>"water short light"</li>
+          <li>"water long light"</li>
+          <li>"siren"</li>
+          <li>"rocks"</li>
+          <li>"blood drops"</li>
+          <li>"water thing"</li>
+          <li>"gun"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"bob remains"</li>
+          <li>"puddles"</li>
+          <li>"big puddles"</li>
+          <li>"security monitor"</li>
+          <li>"water alien supply can"</li>
+          <li>"machine"</li>
+          <li>"staff"</li>
+          <li>"sewage short light"</li>
+          <li>"sewage long light"</li>
+          <li>"junk"</li>
+          <li>"antenna"</li>
+          <li>"big antenna"</li>
+          <li>"sewage alien supply can"</li>
+          <li>"sewage bones"</li>
+          <li>"sewage big bones"</li>
+          <li>"pfhor pieces"</li>
+          <li>"bob pieces"</li>
+          <li>"bob blood"</li>
+          <li>"alien short light"</li>
+          <li>"alien long light"</li>
+          <li>"alien ceiling rod light"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"bulbous yellow alien object"</li>
+          <li>"square gray organic object"</li>
+          <li>"pfhor skeleton"</li>
+          <li>"pfhor mask"</li>
+          <li>"green stuff"</li>
+          <li>"hunter shield"</li>
+          <li>"alien bones"</li>
+          <li>"alien sludge"</li>
+          <li>"jjaro short light"</li>
+          <li>"jjaro long light"</li>
+          <li>"weird rod"</li>
+          <li>"pfhor ship"</li>
+          <li>"sun"</li>
+          <li>"large glass container"</li>
+          <li>"nub 1"</li>
+          <li>"nub 2"</li>
+          <li>"lh'owon"</li>
+          <li>"floor whip antenna"</li>
+          <li>"ceiling whip antenna"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="ScoringModes"></a>Scoring Modes</h3>
+      <dl>
+        <dt># ScoringModes</dt>
+        <dt>ScoringModes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"most points"</li>
+        <li>"most time"</li>
+        <li>"least points"</li>
+        <li>"least time"</li>
+      </ul>
+      <h3><a name="SideTypes"></a>Side Types</h3>
+      <dl>
+        <dt># SideTypes</dt>
+        <dt>SideTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"full"</li>
+        <li>"high"</li>
+        <li>"low"</li>
+        <li>"split"</li>
+      </ul>
+      <h3><a name="Sounds"></a>Sounds</h3>
+      <dl>
+        <dt># Sounds</dt>
+        <dt>Sounds()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"startup"</li>
+          <li>"teleport in"</li>
+          <li>"teleport out"</li>
+          <li>"crushed"</li>
+          <li>"nuclear hard death"</li>
+          <li>"absorbed"</li>
+          <li>"breathing"</li>
+          <li>"oxygen warning"</li>
+          <li>"suffocation"</li>
+          <li>"energy refuel"</li>
+          <li>"oxygen refuel"</li>
+          <li>"cant toggle switch"</li>
+          <li>"switch on"</li>
+          <li>"switch off"</li>
+          <li>"puzzle switch"</li>
+          <li>"chip insertion"</li>
+          <li>"pattern buffer"</li>
+          <li>"destroy control panel"</li>
+          <li>"adjust volume"</li>
+          <li>"got powerup"</li>
+          <li>"get item"</li>
+          <li>"bullet ricochet"</li>
+          <li>"metallic ricochet"</li>
+          <li>"empty gun"</li>
+          <li>"spht door opening"</li>
+          <li>"spht door closing"</li>
+          <li>"spht door obstructed"</li>
+          <li>"spht platform starting"</li>
+          <li>"spht platform stopping"</li>
+          <li>"loon"</li>
+          <li>"smg firing"</li>
+          <li>"smg reloading"</li>
+          <li>"heavy spht platform starting"</li>
+          <li>"heavy spht platform stopping"</li>
+          <li>"fist hitting"</li>
+          <li>"pistol firing"</li>
+          <li>"pistol reloading"</li>
+          <li>"assault rifle firing"</li>
+          <li>"grenade launcher firing"</li>
+          <li>"grenade expolding"</li>
+          <li>"grenade flyby"</li>
+          <li>"fusion firing"</li>
+          <li>"fusion exploding"</li>
+          <li>"fusion flyby"</li>
+          <li>"fusion charging"</li>
+          <li>"rocket exploding"</li>
+          <li>"rocket flyby"</li>
+          <li>"rocket firing"</li>
+          <li>"flamethrower"</li>
+          <li>"body falling"</li>
+          <li>"body exploding"</li>
+          <li>"bullet hit flesh"</li>
+          <li>"fighter activate"</li>
+          <li>"fighter wail"</li>
+          <li>"fighter scream"</li>
+          <li>"fighter chatter"</li>
+          <li>"fighter attack"</li>
+          <li>"fighter projectile hit"</li>
+          <li>"fighter projectile flyby"</li>
+          <li>"spht attack"</li>
+          <li>"spht death"</li>
+          <li>"spht hit"</li>
+          <li>"spht projectile flyby"</li>
+          <li>"spht projectile hit"</li>
+          <li>"cyborg moving"</li>
+          <li>"cyborg attack"</li>
+          <li>"cyborg hit"</li>
+          <li>"cyborg death"</li>
+          <li>"cyborg projectile bounce"</li>
+          <li>"cyborg projectile hit"</li>
+          <li>"cyborg projectile flyby"</li>
+          <li>"drone activate"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"drone start attack"</li>
+          <li>"drone attack"</li>
+          <li>"drone dying"</li>
+          <li>"drone death"</li>
+          <li>"drone projectile hit"</li>
+          <li>"drone projectile flyby"</li>
+          <li>"bob wail"</li>
+          <li>"bob scream"</li>
+          <li>"bob hit"</li>
+          <li>"bob chatter"</li>
+          <li>"assimilated bob chatter"</li>
+          <li>"bob trash talk"</li>
+          <li>"bob apology"</li>
+          <li>"bob activation"</li>
+          <li>"bob clear"</li>
+          <li>"bob angry"</li>
+          <li>"bob secure"</li>
+          <li>"bob kill the player"</li>
+          <li>"water"</li>
+          <li>"sewage"</li>
+          <li>"lava"</li>
+          <li>"goo"</li>
+          <li>"underwater"</li>
+          <li>"wind"</li>
+          <li>"waterfall"</li>
+          <li>"siren"</li>
+          <li>"fan"</li>
+          <li>"spht door"</li>
+          <li>"spht platform"</li>
+          <li>"alien harmonics"</li>
+          <li>"heavy spht platform"</li>
+          <li>"light machinery"</li>
+          <li>"heavy machinery"</li>
+          <li>"transformer"</li>
+          <li>"sparking transformer"</li>
+          <li>"water drip"</li>
+          <li>"walking in water"</li>
+          <li>"exiting water"</li>
+          <li>"entering water"</li>
+          <li>"small water splash"</li>
+          <li>"medium water splash"</li>
+          <li>"large water splash"</li>
+          <li>"walking in lava"</li>
+          <li>"entering lava"</li>
+          <li>"exiting lava"</li>
+          <li>"small lava splash"</li>
+          <li>"medium lava splash"</li>
+          <li>"large lava splash"</li>
+          <li>"walking in sewage"</li>
+          <li>"exiting sewage"</li>
+          <li>"entering sewage"</li>
+          <li>"small sewage splash"</li>
+          <li>"medium sewage splash"</li>
+          <li>"large sewage splash"</li>
+          <li>"walking in goo"</li>
+          <li>"exiting goo"</li>
+          <li>"entering goo"</li>
+          <li>"small goo splash"</li>
+          <li>"medium goo splash"</li>
+          <li>"large goo splash"</li>
+          <li>"major fusion firing"</li>
+          <li>"major fusion charged"</li>
+          <li>"assault rifle reloading"</li>
+          <li>"assault rifle shell casings"</li>
+          <li>"shotgun firing"</li>
+          <li>"shotgun reloading"</li>
+          <li>"ball bounce"</li>
+          <li>"you are it"</li>
+          <li>"got ball"</li>
+          <li>"computer login"</li>
+          <li>"computer logout"</li>
+          <li>"computer page"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"heavy spht door"</li>
+          <li>"heavy spht door opening"</li>
+          <li>"heavy spht door closing"</li>
+          <li>"heavy spht door open"</li>
+          <li>"heavy spht door closed"</li>
+          <li>"heavy spht door obstructed"</li>
+          <li>"hunter activate"</li>
+          <li>"hunter attack"</li>
+          <li>"hunter dying"</li>
+          <li>"hunter landing"</li>
+          <li>"hunter exploding"</li>
+          <li>"hunter projectile hit"</li>
+          <li>"hunter projectile flyby"</li>
+          <li>"enforcer activate"</li>
+          <li>"enforcer attack"</li>
+          <li>"enforcer projectile hit"</li>
+          <li>"enforcer projectile flyby"</li>
+          <li>"flickta melee attack"</li>
+          <li>"flickta melee hit"</li>
+          <li>"flickta projectile attack"</li>
+          <li>"flickta projectile sewage hit"</li>
+          <li>"flickta projectile sewage flyby"</li>
+          <li>"flickta projectile lava hit"</li>
+          <li>"flickta projectile lava flyby"</li>
+          <li>"flickta dying"</li>
+          <li>"machine binder"</li>
+          <li>"machine bookpress"</li>
+          <li>"machine puncher"</li>
+          <li>"electric hum"</li>
+          <li>"alarm"</li>
+          <li>"night wind"</li>
+          <li>"surface explosion"</li>
+          <li>"underground explosion"</li>
+          <li>"sphtkr attack"</li>
+          <li>"sphtkr projectile hit"</li>
+          <li>"sphtkr projectile flyby"</li>
+          <li>"sphtkr hit"</li>
+          <li>"sphtkr exploding"</li>
+          <li>"tick chatter"</li>
+          <li>"tick falling"</li>
+          <li>"tick flapping"</li>
+          <li>"tick exploding"</li>
+          <li>"ceiling lamp exploding"</li>
+          <li>"pfhor platform starting"</li>
+          <li>"pfhor platform stopping"</li>
+          <li>"pfhor platform"</li>
+          <li>"pfhor door opening"</li>
+          <li>"pfhor door closing"</li>
+          <li>"pfhor door obstructed"</li>
+          <li>"pfhor door"</li>
+          <li>"pfhor switch off"</li>
+          <li>"pfhor switch on"</li>
+          <li>"juggernaut firing"</li>
+          <li>"juggernaut warning"</li>
+          <li>"juggernaut exploding"</li>
+          <li>"juggernaut start attack"</li>
+          <li>"enforcer exploding"</li>
+          <li>"alien noise 1"</li>
+          <li>"alien noise 2"</li>
+          <li>"vacbob wail"</li>
+          <li>"vacbob scream"</li>
+          <li>"vacbob hit"</li>
+          <li>"vacbob chatter"</li>
+          <li>"assimilated vacbob chatter"</li>
+          <li>"vacbob trash talk"</li>
+          <li>"vacbob apology"</li>
+          <li>"vacbob activation"</li>
+          <li>"vacbob clear"</li>
+          <li>"vacbob angry"</li>
+          <li>"vacbob secure"</li>
+          <li>"vacbob kill the player"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="TextureTypes"></a>Texture Types</h3>
+      <dl>
+        <dt># TextureTypes</dt>
+        <dt>TextureTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <ul class="mnemonics">
+        <li>"wall"</li>
+        <li>"landscape"</li>
+        <li>"sprite"</li>
+        <li>"weapon in hand"</li>
+        <li>"interface"</li>
+      </ul>
+      <h3><a name="TransferModes"></a>Transfer Modes</h3>
+      <dl>
+        <dt># TransferModes</dt>
+        <dt>TransferModes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"normal"</li>
+          <li>"pulsate"</li>
+          <li>"wobble"</li>
+          <li>"fast wobble"</li>
+          <li>"static"</li>
+          <li>"landscape"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"horizontal slide"</li>
+          <li>"fast horizontal slide"</li>
+          <li>"vertical slide"</li>
+          <li>"fast vertical slide"</li>
+          <li>"wander"</li>
+          <li>"fast wander"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"reverse horizontal slide" <span class="version">20231125</span></li>
+          <li>"reverse fast horizontal slide" <span class="version">20231125</span></li>
+          <li>"reverse vertical slide" <span class="version">20231125</span></li>
+          <li>"reverse fast vertical slide" <span class="version">20231125</span></li>
+          <li>"2x" <span class="version">20231125</span></li>
+          <li>"4x" <span class="version">20231125</span></li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+      <h3><a name="WeaponTypes"></a>Weapons</h3>
+      <dl>
+        <dt># WeaponTypes</dt>
+        <dt>WeaponTypes()</dt>
+      </dl>
+      <h4>Mnemonics</h4>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"fist"</li>
+          <li>"pistol"</li>
+          <li>"fusion pistol"</li>
+          <li>"assault rifle"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"missile launcher"</li>
+          <li>"flamethrower"</li>
+          <li>"alien weapon"</li>
+          <li>"shotgun"</li>
+        </ul>
+      </div>
+      <div class="mnemonics-column">
+        <ul class="mnemonics">
+          <li>"ball"</li>
+          <li>"smg"</li>
+        </ul>
+      </div>
+      <div class="end-mnemonics"></div>
+    </div>
+    <h1><a name="example_icon"></a>Example Icon</h1>
       <pre>
 --[[
 This is  an example  of an  icon  in  the format  used by  Aleph One’s  overlay

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -21,10 +21,12 @@
 
 	  <!ELEMENT subtable ((alias*),(description?),(length?),(index?),(call?),(function|subtable|variable|note)*)>
 	  <!ATTLIST subtable name CDATA #REQUIRED>
+	  <!ATTLIST subtable order CDATA #IMPLIED>
 	  <!ATTLIST subtable classname ID #REQUIRED>
 
 	  <!ELEMENT subtable-accessor ((alias?),(description?),(function|subtable|variable)*)>
 	  <!ATTLIST subtable-accessor name CDATA #REQUIRED>
+	  <!ATTLIST subtable-accessor order CDATA #IMPLIED>
 	  <!ATTLIST subtable-accessor classname ID #REQUIRED>
 	  <!ATTLIST subtable-accessor index CDATA #REQUIRED>
 
@@ -36,10 +38,12 @@
 	  <!ELEMENT function ((description?),(argument*),(return*),(note*))>
 	  <!ATTLIST function name CDATA #REQUIRED>
 	  <!ATTLIST function access (local-player|all) 'all'>
+	  <!ATTLIST function order CDATA #IMPLIED>
 	  <!ATTLIST function return (single|variant) 'single'>
 
 	  <!ELEMENT function-variable ((description?),(argument),(type))>
 	  <!ATTLIST function-variable name CDATA #REQUIRED>
+	  <!ATTLIST function-variable order CDATA #IMPLIED>
 	  <!ATTLIST function-variable classname CDATA #IMPLIED>
 
 	  <!ELEMENT argument (description?,type)>
@@ -50,15 +54,18 @@
 
 	  <!ELEMENT variable ((alias*), (description?),(type),(note*))>
 	  <!ATTLIST variable name CDATA #REQUIRED>
+	  <!ATTLIST variable order CDATA #IMPLIED>
 	  <!ATTLIST variable access (read-only|read-write|local-player|write-only) "read-write">
 	  <!ATTLIST variable version CDATA #IMPLIED>
 
 	  <!ELEMENT accessor ((description?),(length?),(index?),(call?),(function)*)>
 	  <!ATTLIST accessor name ID #REQUIRED>
+	  <!ATTLIST accessor order CDATA #IMPLIED>
 	  <!ATTLIST accessor contains IDREF #REQUIRED>
 
 	  <!ELEMENT enum-accessor ((description?),(length?),(index?),(call?))>
 	  <!ATTLIST enum-accessor name ID #REQUIRED>
+	  <!ATTLIST enum-accessor order CDATA #IMPLIED>
 	  <!ATTLIST enum-accessor contains IDREF #REQUIRED>
 	  <!ATTLIST enum-accessor nice-name CDATA #IMPLIED>
 	  
@@ -1148,6 +1155,8 @@ end
     <table name="music">
 	  <function name="play" version="20231125">
 		<description>plays the music</description>
+		<argument name="segment" required="false"><type>music_segment</type></argument>
+		<note>for tracks containing multiple segments, an optional starting segment can be provided</note>
 		<note>if the music was stopped, restarts it</note>
 	  </function>
 	  <function name="stop" version="20231125">
@@ -1158,9 +1167,22 @@ end
 		<argument name="volume"><type>number</type></argument>
 		<argument name="duration" required="false"><type>seconds</type></argument>
 		<argument name="stop_after_fade" required="false"><type>boolean</type></argument>
+		<argument name="fade_type" required="false"><type>music_fade_type</type></argument>
 		<note>it will fade in until volume is reached. volume is decimal [0 - 1]</note>
 		<note>duration unit is seconds and is 1 if not specified</note>
 		<note>stop_after_fade is disabled by default, if set to true if the volume reaches 0 while fading the music will automatically stop</note>
+		<note>fade_type is the fading function, see MusicFadeTypes for values, default is linear</note>
+	  </function>
+	  <function name="add_track" version="git">
+		<description>adds an audio track used to create music segments</description>
+		<argument name="track" required="true"><type>string</type></argument>
+		<return><type>number</type></return>
+		<note>returns a unique identifier for the track, usable to create segments</note>
+	  </function>
+	  <function name="request_sequence_transition" version="git">
+		<description>requests a transition from the currently playing sequence to the specified one</description>
+		<argument name="sequence" required="true"><type>music_sequence</type></argument>
+		<note>the transition will happen at the end of the currently playing segment and as long as a segment transition is configured between it and one from the requested sequence</note>
 	  </function>
 	  <variable name="volume" version="20231125">
 		<description>the volume of the music</description>
@@ -1171,6 +1193,39 @@ end
 		<description>returns true if the music is still playing</description>
 		<type>boolean</type>
 	  </variable>
+	  <subtable name="sequences" classname="music_sequences" version="git">
+		  <function name="new">
+			<description>creates a new empty sequence for the music channel and returns it</description>
+			<return><type>music_sequence</type></return>
+			<note>sequences can be seen as a set of segments configured to play in a specific order composing a track</note>
+			<note>sequences must be created and configured before the music channel starts playing otherwise they  will not be applied unless the music is stopped and restarted</note>
+		  </function>
+		  <subtable name="segments" classname="music_segments">
+		    <function name="new" order="1">
+				<description>creates a new music segment with the specified track, adds it to the sequence and returns it</description>
+				<argument name="track_identifier" required="true"><type>number</type></argument>
+				<return><type>music_segment</type></return>
+				<note>track_identifier is the unique identifier returned by the music add_track function</note>
+				<note>this function can be called multiple times with the same track identifier if multiple segments from the same track file are required</note>
+				<note>the order in which segments are created has no influence on the order in which they are played, see the add_transition function for that</note>
+		    </function>
+		    <function name="add_transition" order="2">
+				<description>specifies the next segment to play once the current one has finished and configures the transition</description>
+				<argument name="segment" required="true"><type>music_segment</type></argument>
+				<argument name="fade_out_type" required="false"><type>music_fade_type</type></argument>
+				<argument name="fade_out_duration" required="false"><type>seconds</type></argument>
+				<argument name="fade_in_type" required="false"><type>music_fade_type</type></argument>
+				<argument name="fade_in_duration" required="false"><type>seconds</type></argument>
+				<argument name="cross_fade" required="false"><type>boolean</type></argument>
+				<note>see MusicFadeTypes for the available fading functions, the default is none which means a seamless transition</note>
+				<note>the fades duration unit is seconds and is 0 if not specified</note>
+				<note>cross_fade is a boolean flag set to false if not specified</note>
+				<note>segment transitions across different sequences must also be configured to allow sequence transitions</note>
+				<note>the entire segment ordering system is handled through this function, if a full track must loop, the last segment of a sequence must transition to the first one of the same sequence</note>
+				<note>transition configuration must be completed before the music channel starts playing otherwise it will not be applied unless the music is stopped and restarted</note>
+		    </function>
+		</subtable>
+    </subtable>
     </table>
     <table name="platform">
 	  <variable name="activates_adjacent_platforms_at_each_level" version="20210408">
@@ -2404,10 +2459,11 @@ end
       </call>
 	  <function name="new" version="20231125">
 		<description>returns a new music channel</description>
-		<argument name="track"><type>string</type></argument>
+		<argument name="track" required="false"><type>string</type></argument>
 		<argument name="volume" required="false"><type>number</type></argument>
 		<argument name="loop" required="false"><type>boolean</type></argument>
 		<return><type>music</type></return>
+		<note>the track file parameter should be omitted for segmented music and add_track should be used instead</note>
 		<note>volume is decimal [0 - 1] and is 1 if not specified</note>
 		<note>loop is enabled by default</note>
 	  </function>
@@ -2417,6 +2473,8 @@ end
       <function name="fade">
 		<description>fades out the currently playing track and clears the playlist</description>
 		<argument name="duration"><type>seconds</type></argument>
+		<argument name="fade_type" required="false"><type>music_fade_type</type></argument>
+		<note>fade_type is the fading function, see MusicFadeTypes for values, default is linear</note>
       </function>
       <function name="play">
 		<description>appends all of the specified tracks to the end of the playlist</description>
@@ -3438,6 +3496,13 @@ end
 		<mnemonic name="split"/>
       </mnemonics>
     </enum>
+	<enum name="music_fade_type">
+      <mnemonics>
+	    <mnemonic name="none"/>
+		<mnemonic name="linear"/>
+		<mnemonic name="sinusoidal"/>
+      </mnemonics>
+    </enum>
     <enum name="sound">
       <mnemonics>
 		<mnemonic name="startup"/>
@@ -3732,6 +3797,7 @@ end
     <enum-accessor name="SceneryTypes" contains="scenery_type" nice-name="Scenery"/>
     <enum-accessor name="ScoringModes" contains="scoring_mode" nice-name="Scoring Modes"/>
     <enum-accessor name="SideTypes" contains="side_type" nice-name="Side Types"/>
+	<enum-accessor name="MusicFadeTypes" contains="music_fade_type" nice-name="Music Fade Types"/>
     <enum-accessor name="Sounds" contains="sound" nice-name="Sounds"/>
     <enum-accessor name="TextureTypes" contains="texture_type" nice-name="Texture Types"/>
     <enum-accessor name="TransferModes" contains="transfer_mode" nice-name="Transfer Modes"/>

--- a/docs/Lua.xsl
+++ b/docs/Lua.xsl
@@ -158,7 +158,7 @@
 		<details><summary><a href="#triggers">Triggers</a></summary>
 		<ol>
 		  <xsl:for-each select="function">
-			<xsl:sort select="@name"/>
+			<xsl:sort select="@order" data-type="number"/><xsl:sort select="@name"/>
 			<li><a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute><xsl:value-of select="@name"/></a></li>
 		  </xsl:for-each>
 		</ol>
@@ -168,7 +168,7 @@
 		<details><summary><a href="#tables">Tables</a></summary>
 	<ol>
 	  <xsl:for-each select="accessor">
-	    <xsl:sort select="@name"/>
+	    <xsl:sort select="@order" data-type="number"/><xsl:sort select="@name"/>
 	    <li><a><xsl:attribute name="href">#<xsl:value-of select="@name"/></xsl:attribute><xsl:value-of select="@name"/></a></li>
 	  </xsl:for-each>
 	</ol>
@@ -197,7 +197,7 @@
     <dd>
   <dl>
     <xsl:apply-templates select="function">
-	  <xsl:sort select="@name"/>
+	  <xsl:sort select="@order" data-type="number"/><xsl:sort select="@name"/>
 	</xsl:apply-templates>
   </dl>
     </dd>
@@ -210,7 +210,7 @@
   <div><xsl:attribute name="class">tables</xsl:attribute>
   <xsl:for-each select="description"><p><xsl:copy-of select="node()"/></p></xsl:for-each>
   <xsl:apply-templates select="accessor">
-    <xsl:sort select="@name"/>
+    <xsl:sort select="@order" data-type="number"/><xsl:sort select="@name"/>
   </xsl:apply-templates>
   </div>
 </xsl:template>
@@ -220,7 +220,7 @@
   <div class="tables">
     <xsl:for-each select="description"><p><xsl:copy-of select="node()"/></p></xsl:for-each>
     <xsl:apply-templates select="../tables/enum-accessor">
-      <xsl:sort select="@name"/>
+      <xsl:sort select="@order" data-type="number"/><xsl:sort select="@name"/>
     </xsl:apply-templates>
   </div>
 </xsl:template>
@@ -360,7 +360,7 @@
 	<p class="description"><xsl:copy-of select="description/node()"/></p>
       </xsl:when>
     </xsl:choose>
-    <dl><xsl:apply-templates select="function|function-variable|variable|subtable|subtable-accessor"><xsl:sort select="@name"/></xsl:apply-templates>
+    <dl><xsl:apply-templates select="function|function-variable|variable|subtable|subtable-accessor"><xsl:sort select="@order" data-type="number"/><xsl:sort select="@name"/></xsl:apply-templates>
   </dl></dd>
 </xsl:template>
 
@@ -492,7 +492,7 @@
     </xsl:choose>
     <xsl:choose>
       <xsl:when test="function|subtable|subtable-accessor|variable">
-	<dl><xsl:apply-templates select="function|subtable|subtable-accessor|variable"><xsl:sort select="@name"/></xsl:apply-templates></dl>
+	<dl><xsl:apply-templates select="function|subtable|subtable-accessor|variable"><xsl:sort select="@order" data-type="number"/><xsl:sort select="@name"/></xsl:apply-templates></dl>
       </xsl:when>
     </xsl:choose>
   </dd>


### PR DESCRIPTION
This PR basically adds 2 subtables to the Music lua table, Sequence & Segment. It also adds a new MusicFadeType enumeration to provide different fading functions even if for now only 2 are available (or 3 if we count the seamless transition)

Here is a music plugin using the new multiple lua plugins feature to demonstrate a simple case with the new api in use and how it behaves in game. Which will probably be easier to review than the PR to see how it works.

In it, only one music channel is used with 4 sequences:
- one sequence for the "normal track" composed of a single segment (default or triggered when the last time the player created a projectile was some time ago)
- one sequence for the "fight track" composed of 2 segments (triggered when the player creates projectiles)
- one sequence for the "hard fight track" of a single segment (triggered when the player creates projectiles and with hp < 75)
- one sequence for the "dead track" composed of a single segment that doesn't loop (triggered when the player hp <= 0)

All segment transitions are seamless transitions except the ones that lead to the dead sequence which use crossfades transition.
[SegmentedMusic.zip](https://github.com/user-attachments/files/25152283/SegmentedMusic.zip)

I also updated the xslt because I wanted the "new" functions for the subtables to be placed first in the documentation and sorting by name as it does now, was preventing that.
