### PR TITLE
Add a preference controlling interface scale

### DIFF
--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -1034,6 +1034,10 @@ static const char *bobbing_view_labels[] = {
 	"None", "Default", "Weapon Only", NULL
 };
 
+static const char* ui_scale_labels[] = {
+"Normal", "Double", "Largest", NULL
+};
+
 static const char* hud_scale_labels[] = {
 "Normal", "Double", "Largest", NULL
 };
@@ -1279,6 +1283,12 @@ static void graphics_dialog(void *arg)
 	table->dual_add(fullscreen_w->label("Windowed Mode"), d);
 	table->dual_add(fullscreen_w, d);
 
+	w_select_popup *ui_scale_w = new w_select_popup();
+	ui_scale_w->set_labels(build_stringvector_from_cstring_array(ui_scale_labels));
+	ui_scale_w->set_selection(graphics_preferences->screen_mode.ui_scale_level);
+	table->dual_add(ui_scale_w->label("Interface Size"), d);
+	table->dual_add(ui_scale_w, d);
+
 	w_toggle *high_dpi_w = NULL;
 	high_dpi_w = new w_toggle(graphics_preferences->screen_mode.high_dpi);
 #if (defined(__APPLE__) && defined(__MACH__))
@@ -1495,7 +1505,14 @@ static void graphics_dialog(void *arg)
 			
 			changed = true;
 		}
-	    
+
+		short ui_scale = static_cast<short>(ui_scale_w->get_selection());
+		if (ui_scale != graphics_preferences->screen_mode.ui_scale_level)
+		{
+			graphics_preferences->screen_mode.ui_scale_level = ui_scale;
+			changed = true;
+    }
+
 	    short hud_scale = static_cast<short>(hud_scale_w->get_selection());
 	    if (hud_scale != graphics_preferences->screen_mode.hud_scale_level)
 	    {
@@ -3622,6 +3639,7 @@ InfoTree graphics_preferences_tree()
 	root.put_attr("scmode_auto_resolution", graphics_preferences->screen_mode.auto_resolution);
 	root.put_attr("scmode_high_dpi", graphics_preferences->screen_mode.high_dpi);
 	root.put_attr("scmode_hud", graphics_preferences->screen_mode.hud);
+	root.put_attr("scmode_ui_scale", graphics_preferences->screen_mode.ui_scale_level);
 	root.put_attr("scmode_hud_scale", graphics_preferences->screen_mode.hud_scale_level);
 	root.put_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.put_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);
@@ -4131,6 +4149,7 @@ static void default_graphics_preferences(graphics_preferences_data *preferences)
 	preferences->screen_mode.auto_resolution = true;
 	preferences->screen_mode.high_dpi = true;
 	preferences->screen_mode.hud = true;
+	preferences->screen_mode.ui_scale_level = 0;
 	preferences->screen_mode.hud_scale_level = 0;
 	preferences->screen_mode.term_scale_level = 2;
 	preferences->screen_mode.translucent_map = false;
@@ -4600,6 +4619,7 @@ void parse_graphics_preferences(InfoTree root, std::string version)
 	root.read_attr("scmode_auto_resolution", graphics_preferences->screen_mode.auto_resolution);
 	root.read_attr("scmode_high_dpi", graphics_preferences->screen_mode.high_dpi);
 	root.read_attr("scmode_hud", graphics_preferences->screen_mode.hud);
+	root.read_attr("scmode_ui_scale", graphics_preferences->screen_mode.ui_scale_level);
 	root.read_attr("scmode_hud_scale", graphics_preferences->screen_mode.hud_scale_level);
 	root.read_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.read_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);

--- a/Source_Files/Misc/sdl_dialogs.cpp
+++ b/Source_Files/Misc/sdl_dialogs.cpp
@@ -1791,6 +1791,9 @@ void dialog::update(SDL_Rect r) const
 		OGL_Blitter blitter;
 		SDL_Rect src = { 0, 0, rect.w, rect.h };
 		blitter.Load(*dialog_surface, src);
+		if (graphics_preferences->screen_mode.ui_scale_level == 1) {
+			blitter.nearFilter = GL_NEAREST;
+		}
 		blitter.Draw(rect);
 
 		MainScreenSwap();

--- a/Source_Files/RenderMain/OGL_FBO.cpp
+++ b/Source_Files/RenderMain/OGL_FBO.cpp
@@ -27,6 +27,7 @@
 
 #include "OGL_Setup.h"
 #include "OGL_Render.h"
+#include "OGL_Textures.h"
 
 std::vector<FBO *> FBO::active_chain;
 
@@ -42,6 +43,8 @@ FBO::FBO(GLuint w, GLuint h, bool srgb) : _h(h), _w(w), _srgb(srgb) {
 	glGenTextures(1, &texID);
 	glBindTexture(GL_TEXTURE_RECTANGLE_ARB, texID);
 	glTexImage2D(GL_TEXTURE_RECTANGLE_ARB, 0, srgb ? GL_SRGB : GL_RGB8, _w, _h, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+	glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, TxtrTypeInfoList[OGL_Txtr_HUD].NearFilter);
+	glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, TxtrTypeInfoList[OGL_Txtr_HUD].FarFilter);
 	glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_RECTANGLE_ARB, texID, 0);
 	assert(glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT) == GL_FRAMEBUFFER_COMPLETE_EXT);
 	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);

--- a/Source_Files/shell.h
+++ b/Source_Files/shell.h
@@ -84,6 +84,7 @@ struct screen_mode_data
 	bool auto_resolution;
 	bool high_dpi;
 	bool hud;
+	short ui_scale_level;
 	short hud_scale_level;
 	short term_scale_level;
 	bool fix_h_not_v;


### PR DESCRIPTION
This PR adds a new preference "Interface Scale" analogous to the terminal and hud size prefs. Options are "Normal"  which corresponds to current behavior, "Double" which scales the interface 2x if the screen is large enough and applies nearest neighbor for perfect pixels, and "Largest" which behaves like the scaling does in full screen mode. The new preference might require updating the default preferences for the scenarios, not sure yet.