### PR TITLE
add interface scale preference

### DIFF
--- a/Source_Files/Misc/preferences.cpp
+++ b/Source_Files/Misc/preferences.cpp
@@ -1034,6 +1034,10 @@ static const char *bobbing_view_labels[] = {
 	"None", "Default", "Weapon Only", NULL
 };
 
+static const char* ui_scale_labels[] = {
+"Normal", "Double", "Largest", NULL
+};
+
 static const char* hud_scale_labels[] = {
 "Normal", "Double", "Largest", NULL
 };
@@ -1279,6 +1283,12 @@ static void graphics_dialog(void *arg)
 	table->dual_add(fullscreen_w->label("Windowed Mode"), d);
 	table->dual_add(fullscreen_w, d);
 
+	w_select_popup *ui_scale_w = new w_select_popup();
+	ui_scale_w->set_labels(build_stringvector_from_cstring_array(ui_scale_labels));
+	ui_scale_w->set_selection(graphics_preferences->screen_mode.ui_scale_level);
+	table->dual_add(ui_scale_w->label("Interface Size"), d);
+	table->dual_add(ui_scale_w, d);
+
 	w_toggle *high_dpi_w = NULL;
 	high_dpi_w = new w_toggle(graphics_preferences->screen_mode.high_dpi);
 #if (defined(__APPLE__) && defined(__MACH__))
@@ -1495,7 +1505,14 @@ static void graphics_dialog(void *arg)
 			
 			changed = true;
 		}
-	    
+
+		short ui_scale = static_cast<short>(ui_scale_w->get_selection());
+		if (ui_scale != graphics_preferences->screen_mode.ui_scale_level)
+		{
+			graphics_preferences->screen_mode.ui_scale_level = ui_scale;
+			changed = true;
+    }
+
 	    short hud_scale = static_cast<short>(hud_scale_w->get_selection());
 	    if (hud_scale != graphics_preferences->screen_mode.hud_scale_level)
 	    {
@@ -3625,6 +3642,7 @@ InfoTree graphics_preferences_tree()
 	root.put_attr("scmode_auto_resolution", graphics_preferences->screen_mode.auto_resolution);
 	root.put_attr("scmode_high_dpi", graphics_preferences->screen_mode.high_dpi);
 	root.put_attr("scmode_hud", graphics_preferences->screen_mode.hud);
+	root.put_attr("scmode_ui_scale", graphics_preferences->screen_mode.ui_scale_level);
 	root.put_attr("scmode_hud_scale", graphics_preferences->screen_mode.hud_scale_level);
 	root.put_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.put_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);
@@ -4134,6 +4152,7 @@ static void default_graphics_preferences(graphics_preferences_data *preferences)
 	preferences->screen_mode.auto_resolution = true;
 	preferences->screen_mode.high_dpi = true;
 	preferences->screen_mode.hud = true;
+	preferences->screen_mode.ui_scale_level = 0;
 	preferences->screen_mode.hud_scale_level = 0;
 	preferences->screen_mode.term_scale_level = 2;
 	preferences->screen_mode.translucent_map = false;
@@ -4603,6 +4622,7 @@ void parse_graphics_preferences(InfoTree root, std::string version)
 	root.read_attr("scmode_auto_resolution", graphics_preferences->screen_mode.auto_resolution);
 	root.read_attr("scmode_high_dpi", graphics_preferences->screen_mode.high_dpi);
 	root.read_attr("scmode_hud", graphics_preferences->screen_mode.hud);
+	root.read_attr("scmode_ui_scale", graphics_preferences->screen_mode.ui_scale_level);
 	root.read_attr("scmode_hud_scale", graphics_preferences->screen_mode.hud_scale_level);
 	root.read_attr("scmode_term_scale", graphics_preferences->screen_mode.term_scale_level);
 	root.read_attr("scmode_translucent_map", graphics_preferences->screen_mode.translucent_map);

--- a/Source_Files/Misc/sdl_dialogs.cpp
+++ b/Source_Files/Misc/sdl_dialogs.cpp
@@ -1791,6 +1791,9 @@ void dialog::update(SDL_Rect r) const
 		OGL_Blitter blitter;
 		SDL_Rect src = { 0, 0, rect.w, rect.h };
 		blitter.Load(*dialog_surface, src);
+		if (graphics_preferences->screen_mode.ui_scale_level == 1) {
+			blitter.nearFilter = GL_NEAREST;
+		}
 		blitter.Draw(rect);
 
 		MainScreenSwap();

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -115,7 +115,6 @@ bool using_default_gamma = true;
 
 static bool PrevFullscreen = false;
 static bool in_game = false;	// Flag: menu (fixed 640x480) or in-game (variable size) display
-// static int prev_ui_scale = -1;
 
 static int failed_multisamples = 0;		// remember when GL multisample setting didn't succeed
 static bool passed_shader = false;      // remember when we passed Shader tests
@@ -802,7 +801,6 @@ static bool need_mode_change(int window_width, int window_height,
 	if (!screen_mode.fullscreen) {
 		int w, h;
 		SDL_GetWindowSize(main_screen, &w, &h);
-		// if (w != window_width || h != window_height || screen_mode.ui_scale_level != prev_ui_scale) {
 		if (w != window_width || h != window_height) {
 			SDL_SetWindowSize(main_screen, window_width, window_height);
 			SDL_SetWindowPosition(main_screen, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
@@ -1143,8 +1141,6 @@ static void change_screen_mode(int width, int height, int depth, bool nogl, bool
 	}
 #endif
 
-	// prev_ui_scale = screen_mode.ui_scale_level;
-	
 	if (in_game && (screen_mode.hud && (prev_width != main_surface->w || prev_height != main_surface->h)) || force_resize_hud)
 	{
 		L_Call_HUDResize();

--- a/Source_Files/RenderOther/screen.cpp
+++ b/Source_Files/RenderOther/screen.cpp
@@ -518,7 +518,7 @@ void Screen::bound_screen_to_rect(SDL_Rect &r, bool in_game)
 		float vscale = MIN(pixw / static_cast<float>(virw), pixh / static_cast<float>(virh));
 		
 		if (!in_game && screen_mode.ui_scale_level == 1) {
-			vscale = MAX(floorf(vscale), 2.0f);
+			vscale = MIN(floorf(vscale), 2.0f);
 		}
 		
 		int vpw = static_cast<int>(r.w * vscale + 0.5f);
@@ -571,7 +571,7 @@ void Screen::window_to_screen(int &x, int &y)
 
 		if (screen_mode.ui_scale_level == 1)
 		{
-			float scale = MAX(MIN(
+			float scale = MIN(MIN(
 					floorf(winh / static_cast<float>(virh)),
 					floorf(winw / static_cast<float>(virw))
 				), 2.0f);

--- a/Source_Files/shell.h
+++ b/Source_Files/shell.h
@@ -84,6 +84,7 @@ struct screen_mode_data
 	bool auto_resolution;
 	bool high_dpi;
 	bool hud;
+	short ui_scale_level;
 	short hud_scale_level;
 	short term_scale_level;
 	bool fix_h_not_v;


### PR DESCRIPTION
This PR adds a new preference "Interface Size" analogous to the terminal and hud size prefs. Options are "Normal" which corresponds to current behavior, "Double" which scales the interface 2x if the screen is large enough and applies nearest neighbor for perfect pixels, and "Largest" which behaves like the scaling does in full screen mode. The new preference might require updating the default preferences for the scenarios, not sure yet.